### PR TITLE
Update linktitle for Aspose.PDF for Rust documentation to include "vi…

### DIFF
--- a/en/rust-cpp/_index.md
+++ b/en/rust-cpp/_index.md
@@ -1,6 +1,6 @@
 ---
 title: Documentation
-linktitle: Aspose.PDF for Rust
+linktitle: Aspose.PDF for Rust via C++
 second_title: Aspose.PDF for Rust via C++
 type: docs
 weight: 70


### PR DESCRIPTION
…a C++"