### PR TITLE
Translate reportingservices to Chinese

### DIFF
--- a/zh/reportingservices/_index.md
+++ b/zh/reportingservices/_index.md
@@ -5,9 +5,9 @@ second_title: Aspose.PDF for Reporting Services
 type: docs
 weight: 120
 url: /zh/reportingservices/
-description: 了解 Aspose.PDF for Reporting Services。直接从 SQL Server Reporting Services (SSRS) 生成 PDF 报告，提供高级自定义功能。
+description: 发现 Aspose.PDF for Reporting Services。使用高级自定义功能，直接从 SQL Server Reporting Services (SSRS) 生成 PDF 报表。
 is_root: true
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
@@ -16,21 +16,21 @@ lastmod: "2026-06-19"
 
 ## 欢迎使用 Aspose.PDF for Reporting Services
 
-Microsoft SQL Server Reporting Services 满足了许多组织的需求：构建商务智能和报告解决方案的需求。直到现在，开发人员必须将报告嵌入到其应用程序中，或者组织必须购买昂贵且有时存在问题的第三方报告解决方案。现在，Microsoft SQL Server Reporting Services 提供了一个完整的企业级报告分发解决方案，使企业能够更好、更快地做出决策。
+Microsoft SQL Server Reporting Services 满足了许多组织的需求：构建商业智能和报告解决方案的需求。直到目前，开发人员必须将报告嵌入到他们的应用程序中，或者组织必须购买昂贵且有时会出现问题的第三方报告解决方案。现在，Microsoft SQL Server Reporting Services 提供了一套完整的企业级报告分发解决方案，使企业能够更好更快地做出决策。
 
 {{% /alert %}}
 
 ## 主题
 
 - [产品概述](/pdf/zh/reportingservices/product-overview/)
-- [支持的文件格式](/pdf/zh/reportingservices/supported-file-formats/)
+- [受支持的文件格式](/pdf/zh/reportingservices/supported-file-formats/)
 - [功能](/pdf/zh/reportingservices/features/)
 - [示例报告库](/pdf/zh/reportingservices/sample-reports-gallery/)
-- [安装 Aspose.Pdf for Reporting Services](/pdf/zh/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [授权 Aspose.Pdf for Reporting Services](/pdf/zh/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [配置 Aspose.Pdf for Reporting Services](/pdf/zh/reportingservices/configure-aspose-pdf-for-reporting-services/)
-- [展开报告项属性](/pdf/zh/reportingservices/expand-report-items-properties/)
-- [评估 Aspose.Pdf for Reporting Services](/pdf/zh/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
+- [安装 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [授权 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [配置 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [展开报表项属性](/pdf/zh/reportingservices/expand-report-items-properties/)
+- [评估 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
 
 ## Aspose.PDF for Reporting Services 资源
 
@@ -39,10 +39,9 @@ Microsoft SQL Server Reporting Services 满足了许多组织的需求：构建�
 - [Aspose.PDF for Reporting Services 功能](/pdf/zh/reportingservices/features/)
 - [Aspose.PDF for Reporting Services 发行说明](https://releases.aspose.com/pdf/reportingservices/release-notes/)
 - [下载 Aspose.PDF for Reporting Services](https://releases.aspose.com/pdf/reportingservices/)
-- [示例报告画廊 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/sample-reports-gallery/)
-- [安装 Aspose.Pdf for Reporting Services](/pdf/zh/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [授权 Aspose.Pdf for Reporting Services](/pdf/zh/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [配置 Aspose.Pdf for Reporting Services](/pdf/zh/reportingservices/configure-aspose-pdf-for-reporting-services/)
-- [展开报告项属性](/pdf/zh/reportingservices/expand-report-items-properties/)
-- [评估 Aspose.Pdf for Reporting Services](/pdf/zh/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
-
+- [示例报告库 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/sample-reports-gallery/)
+- [安装 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [授权 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [配置 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [展开报表项属性](/pdf/zh/reportingservices/expand-report-items-properties/)
+- [评估 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/evaluate-aspose-pdf-for-reporting-services/)

--- a/zh/reportingservices/_index.md
+++ b/zh/reportingservices/_index.md
@@ -1,47 +1,47 @@
 ---
 title: 文档
-linktitle:  Aspose.PDF for Reporting Services
+linktitle:  用于报告服务的 Aspose.PDF
 second_title: Aspose.PDF for Reporting Services
 type: docs
 weight: 120
-url: /zh/reportingservices/
-description: 发现 Aspose.PDF for Reporting Services。使用高级自定义功能，直接从 SQL Server Reporting Services (SSRS) 生成 PDF 报表。
+url: /reportingservices/
+description: 了解用于报告服务的 Aspose.PDF。通过高级自定义，直接从 SQL Server Reporting Services (SSRS) 生成 PDF 报告。
 is_root: true
-lastmod: "2026-07-29"
+lastmod: "2024-05-05"
 ---
 
 {{% alert color="primary" %}}
 
-![Aspose.PDF for Reporting Services 标志](home_5.png)
+![Aspose.PDF for Reporting Services 徽标](home_5.png)
 
-## 欢迎使用 Aspose.PDF for Reporting Services
+## 欢迎使用 Aspose.PDF 报告服务
 
-Microsoft SQL Server Reporting Services 满足了许多组织的需求：构建商业智能和报告解决方案的需求。直到目前，开发人员必须将报告嵌入到他们的应用程序中，或者组织必须购买昂贵且有时会出现问题的第三方报告解决方案。现在，Microsoft SQL Server Reporting Services 提供了一套完整的企业级报告分发解决方案，使企业能够更好更快地做出决策。
+Microsoft SQL Server Reporting Services 满足了许多组织的需求：构建商业智能和报告解决方案的需求。到目前为止，开发人员需要将报告嵌入到他们的应用程序中，或者组织需要购买昂贵且有时有问题的第三方报告解决方案。现在，Microsoft SQL Server Reporting Services 提供了在整个企业内分发报告的完整解决方案；使企业能够更好更快地做出决策。
 
 {{% /alert %}}
 
 ## 主题
 
 - [产品概述](/pdf/zh/reportingservices/product-overview/)
-- [受支持的文件格式](/pdf/zh/reportingservices/supported-file-formats/)
-- [功能](/pdf/zh/reportingservices/features/)
-- [示例报告库](/pdf/zh/reportingservices/sample-reports-gallery/)
+- [支持的文件格式](/pdf/zh/reportingservices/supported-file-formats/)
+- [特征](/pdf/zh/reportingservices/features/)
+- [样本报告库](/pdf/zh/reportingservices/sample-reports-gallery/)
 - [安装 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [授权 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [配置 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/configure-aspose-pdf-for-reporting-services/)
-- [展开报表项属性](/pdf/zh/reportingservices/expand-report-items-properties/)
-- [评估 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
+- [报告服务 Aspose.PDF 许可证](/pdf/zh/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [为 Reporting Services 配置 Aspose.PDF](/pdf/zh/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [展开报告项目属性](/pdf/zh/reportingservices/expand-report-items-properties/)
+- [评估 Aspose.PDF 的报告服务](/pdf/zh/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
 
-## Aspose.PDF for Reporting Services 资源
+## 用于报告服务资源的 Aspose.PDF
 
 - [Aspose.PDF for Reporting Services 产品概述](/pdf/zh/reportingservices/product-overview/)
 - [Aspose.PDF for Reporting Services 支持的文件格式](/pdf/zh/reportingservices/supported-file-formats/)
 - [Aspose.PDF for Reporting Services 功能](/pdf/zh/reportingservices/features/)
 - [Aspose.PDF for Reporting Services 发行说明](https://releases.aspose.com/pdf/reportingservices/release-notes/)
-- [下载 Aspose.PDF for Reporting Services](https://releases.aspose.com/pdf/reportingservices/)
-- [示例报告库 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/sample-reports-gallery/)
+- [下载用于报告服务的 Aspose.PDF](https://releases.aspose.com/pdf/reportingservices/)
+- [用于报告服务的示例报告库 Aspose.PDF](/pdf/zh/reportingservices/sample-reports-gallery/)
 - [安装 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [授权 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [配置 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/configure-aspose-pdf-for-reporting-services/)
-- [展开报表项属性](/pdf/zh/reportingservices/expand-report-items-properties/)
-- [评估 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
+- [报告服务 Aspose.PDF 许可证](/pdf/zh/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [为 Reporting Services 配置 Aspose.PDF](/pdf/zh/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [展开报告项目属性](/pdf/zh/reportingservices/expand-report-items-properties/)
+- [评估 Aspose.PDF 的报告服务](/pdf/zh/reportingservices/evaluate-aspose-pdf-for-reporting-services/)

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
@@ -4,12 +4,12 @@ linktitle: 配置
 
 type: docs
 weight: 80
-url: /zh/reportingservices/configure-aspose-pdf-for-reporting-services/
-description: 了解如何配置 Aspose.PDF for Reporting Services，以高效地自定义 SSRS 报告的 PDF 输出设置。
-lastmod: "2026-07-29"
+url: /reportingservices/configure-aspose-pdf-for-reporting-services/
+description: 了解如何配置 Aspose.PDF for Reporting Services 以高效地自定义 SSRS 报告的 PDF 输出设置。
+lastmod: "2021-06-05"
 ---
 
 ## 本节包括以下主题：
 
-- [设置参数](/pdf/zh/reportingservices/setting-parameters/)
-- [支持的参数](/pdf/zh/reportingservices/supported-parameters/)
+- [设置参数](/pdf/reportingservices/setting-parameters/)
+- [支持的参数](/pdf/reportingservices/supported-parameters/)

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
@@ -5,12 +5,11 @@ linktitle: 配置
 type: docs
 weight: 80
 url: /zh/reportingservices/configure-aspose-pdf-for-reporting-services/
-description: 了解如何配置 Aspose.PDF for Reporting Services，以高效地自定义 SSRS 报表的 PDF 输出设置。
-lastmod: "2026-06-19"
+description: 了解如何配置 Aspose.PDF for Reporting Services，以高效地自定义 SSRS 报告的 PDF 输出设置。
+lastmod: "2026-07-29"
 ---
 
 ## 本节包括以下主题：
 
 - [设置参数](/pdf/zh/reportingservices/setting-parameters/)
 - [支持的参数](/pdf/zh/reportingservices/supported-parameters/)
-

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
@@ -1,27 +1,26 @@
 ---
-title: Setting Parameters
-linktitle: Setting Parameters
+title: 设置参数
+linktitle: 设置参数
 type: docs
 weight: 10
-url: /zh/reportingservices/setting-parameters/
-description: 了解如何在 Aspose.PDF for Reporting Services 中设置 PDF 渲染参数，以便精确控制输出结果。
-lastmod: "2026-07-29"
+url: /reportingservices/setting-parameters/
+description: 了解如何在 Aspose.PDF for Reporting Services 中设置 PDF 渲染参数。实现对输出的精确控制。
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-您可以指定某些配置参数，这些参数会影响 Aspose.PDF for Reporting Services 生成文档的方式。本节介绍该过程。
+您可以指定某些配置参数，这些参数会影响 Aspose.PDF for Reporting Services 生成文档的方式。本节描述了这个过程。
 
 {{% /alert %}}
 
-要配置 Aspose.PDF for Reporting Services，您需要编辑 `C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config` 文件。该文件是 XML 文件，渲染器配置位于与 Aspose.PDF 渲染器对应的 ```<Extension>``` 元素内。
+要为 Reporting Services 配置 Aspose.Pdf，您需要编辑 `C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config` 文件。这是一个 XML 文件，渲染器配置位于与 Aspose.PDF 渲染器对应的 `<Extension>` 元素内。
 
-**Example**
+## 例子
 
-{{< highlight csharp >}}
-
+```xml
 <Render>
-...
+…
 <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
 <!--Insert configuration elements for exporting to PDF here. The following is an example
 For PageOrientation -->
@@ -30,19 +29,18 @@ For PageOrientation -->
     </Configuration>
 </Extension>
 </Render>
-
-{{< /highlight >}}
+```
 
 {{% alert color="primary" %}}
 
-如果您只想为某个特定报表文件设置参数，而不是为服务器上的每个报表都设置参数，则可以在 Report Builder 中为该报表添加报表参数。下面以添加前面展示的 `IsLandscape` 参数为例说明操作步骤。
+如果您想为特定报表文件设置参数，而不是为服务器上的每个报表设置参数，您可以按照以下步骤在报表生成器中为特定报表添加报表参数（例如，我们将添加前面显示的“IsLandscape”参数）：
 
-1. 在 Report Designer 中打开报表，右键单击 `Report Data` 窗格中的 `Parameters` 文件夹，然后选择 `Add Parameter...`。或者，您也可以展开 `New` 列表并选择 `Parameter...`。
- 
-![todo:image_alt_text](setting-parameters_1.png)
+1. 在报表设计器中打开报表，右键单击“报表数据”窗格中的“参数”文件夹，然后选择“添加参数...”（或者，下拉“新建”列表并选择“参数...”）。
 
-1. 在 `Report Parameter Properties` 对话框中，创建名为 `IsLandscape` 的参数，将数据类型设置为 Boolean，并在 `Default Values` 选项卡中添加值 True。
+![Parameters set up. Step 1](setting-parameters_1.png)
 
-![todo:image_alt_text](setting-parameters_2.png)
+1. 在“报告参数属性”对话框中，创建名为“IsLandscape”的参数，数据类型为布尔值，并在“默认值”选项卡中添加值 True。
+
+![Parameters set up. Step 2](setting-parameters_2.png)
 
 {{% /alert %}}

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
@@ -1,22 +1,22 @@
 ---
-title: 设置参数
-linktitle: 设置参数
+title: Setting Parameters
+linktitle: Setting Parameters
 type: docs
 weight: 10
-url: /zh/reportingservices/setting-parameters/
-description: 了解如何在 Aspose.PDF for Reporting Services 中设置 PDF 渲染的参数，实现对输出的精确控制。
-lastmod: "2026-06-19"
+url: /reportingservices/setting-parameters/
+description: Find out how to set parameters for PDF rendering in Aspose.PDF for Reporting Services. Achieve precise control over output.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-您可以指定某些配置参数，这些参数会影响 Aspose.Pdf for Reporting Services 生成文档的方式。本节将描述此过程。
+You can specify certain configuration parameters that affect how Aspose.PDF for Reporting Services generates documents. This section describes this process.
 
 {{% /alert %}}
 
-要配置 Aspose.Pdf for Reporting Services，您需要编辑 C:\\Program Files\\Microsoft SQL Server\\<Instance>\\Reporting Services\\ReportServer\\rsreportserver.config 文件。该文件是 XML 文件，渲染器配置位于其中的 ```<Extension>``` 对应于 Aspose.PDF 渲染器的元素。
+To configure Aspose.PDF for Reporting Services, you need to edit the C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config file. This is an XML file and the renderer configuration is inside the ```<Extension>``` element corresponding to the Aspose.PDF renderer.
 
-**示例**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -35,15 +35,14 @@ For PageOrientation -->
 
 {{% alert color="primary" %}}
 
-如果您想为特定的报表文件设置参数，而不是为服务器上的每个报表设置参数，您可以在 Report Builder 中为该特定报表添加报表参数，按照以下步骤操作（例如，我们将添加前面显示的 ‘IsLandscape’ 参数）：
+If you want to set parameters for specific report file but not for every report on the server, you can add a report parameter for the specific report in the Report Builder as the following steps (for example, we’ll add an 'IsLandscape' parameter shown earlier):
 
-1. 在 Report Designer 中打开报表，右键单击 ‘Report Data’ 窗格中的 ‘Parameters’ 文件夹，然后选择 ‘Add Parameter…’（或者，您也可以下拉 ‘New’ 列表并选择 ‘Parameter…’）。
+1. Open the report in the Report Designer, right-click on the 'Parameters' folder in the 'Report Data' pane, and select 'Add Parameter…' (or, alternately, pull down the 'New' list and select 'Parameter…').
  
 ![todo:image_alt_text](setting-parameters_1.png)
 
-1. 在 ‘Report Parameter Properties’ 对话框中，创建名为 ‘IsLandscape’ 的参数，数据类型设置为 Boolean，并在 ‘Default Values’ 选项卡中添加值 True。
+1. In the 'Report Parameter Properties' dialog, create the parameter named 'IsLandscape', with the data type of Boolean, and add the value True in the 'Default Values' tab.
 
 ![todo:image_alt_text](setting-parameters_2.png)
 
 {{% /alert %}}
-

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
@@ -3,25 +3,23 @@ title: 支持的参数
 linktitle: 支持的参数
 type: docs
 weight: 20
-url: /zh/reportingservices/supported-parameters/
-description: 在 Aspose.PDF for Reporting Services 中探索受支持的参数，以轻松控制和自定义 PDF 渲染。
-lastmod: "2026-07-29"
+url: /reportingservices/supported-parameters/
+description: 探索 Aspose.PDF for Reporting Services 中支持的参数，以轻松控制和自定义 PDF 渲染。
+lastmod: "2021-06-05"
 ---
 
-参数化报表是一种接受用于报表处理的输入值的报表。通过参数化报表，您可以根据报表运行时设置的值来更改报表的输出。Aspose.PDF for Reporting Services 支持两种参数：报告服务器参数和报表参数。报告服务器参数适用于报告服务器上的所有报表。如果您希望某些参数仅适用于特定报表，则应使用报表参数。
+参数化报表是接受报表处理中使用的输入值的报表。使用参数化报告，您可以根据报告运行时设置的值改变报告的输出。 Aspose.PDF for Reporting Services 支持两种参数：报表服务器参数和报表参数。报表服务器参数用于报表服务器上的所有报表。如果你想让一些参数适合特定的报表，你应该使用报表参数。
 
-当前，Aspose.Pdf 渲染器支持广泛的参数，例如：
+目前，Aspose.Pdf渲染器支持多种参数，例如：
 
-**本节包含以下主题：**
+**本节包括以下主题：**
 
-- [页面方向](/pdf/zh/reportingservices/page-orientation/)
-- [HTML 格式化](/pdf/zh/reportingservices/html-formatting/)
-- [安全设置](/pdf/zh/reportingservices/security-setting/)
-- [是否嵌入字体](/pdf/zh/reportingservices/isfontembedded/)
-- [页面大小](/pdf/zh/reportingservices/pagesize/)
-- [页面边距大小](/pdf/zh/reportingservices/page-margin-size/)
-- [XMP 元数据](/pdf/zh/reportingservices/xmp-metadata/)
-- [调试信息](/pdf/zh/reportingservices/debug-information/)
-- [PDF_A 合规性](/pdf/zh/reportingservices/pdf_a-conformance/)
-
-
+- [页面方向](/pdf/reportingservices/page-orientation/)
+- [HTML 格式](/pdf/reportingservices/html-formatting/)
+- [安全设置](/pdf/reportingservices/security-setting/)
+- [IsFontEmbedded](/pdf/reportingservices/isfontembedded/)
+- [页面大小](/pdf/reportingservices/pagesize/)
+- [页边距大小](/pdf/reportingservices/page-margin-size/)
+- [XMP Metadata](/pdf/reportingservices/xmp-metadata/)
+- [调试信息](/pdf/reportingservices/debug-information/)
+- [PDF_A 一致性](/pdf/reportingservices/pdf_a-conformance/)

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
@@ -1,18 +1,18 @@
 ---
-title: 受支持的参数
-linktitle: 受支持的参数
+title: 支持的参数
+linktitle: 支持的参数
 type: docs
 weight: 20
 url: /zh/reportingservices/supported-parameters/
 description: 在 Aspose.PDF for Reporting Services 中探索受支持的参数，以轻松控制和自定义 PDF 渲染。
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-参数化报告是指接受输入值用于报告处理的报告。使用参数化报告，您可以根据报告运行时设置的值来改变报告的输出。Aspose.PDF for Reporting Services 支持两种参数：报告服务器参数和报告参数。报告服务器参数用于报告服务器上的所有报告。如果您希望使某些参数仅适用于特定报告，应使用报告参数。
+参数化报表是一种接受用于报表处理的输入值的报表。通过参数化报表，您可以根据报表运行时设置的值来更改报表的输出。Aspose.PDF for Reporting Services 支持两种参数：报告服务器参数和报表参数。报告服务器参数适用于报告服务器上的所有报表。如果您希望某些参数仅适用于特定报表，则应使用报表参数。
 
-目前，Aspose.PDF 渲染器支持广泛的参数，例如：
+当前，Aspose.Pdf 渲染器支持广泛的参数，例如：
 
-**本节包括以下主题：**
+**本节包含以下主题：**
 
 - [页面方向](/pdf/zh/reportingservices/page-orientation/)
 - [HTML 格式化](/pdf/zh/reportingservices/html-formatting/)
@@ -23,6 +23,5 @@ lastmod: "2026-06-19"
 - [XMP 元数据](/pdf/zh/reportingservices/xmp-metadata/)
 - [调试信息](/pdf/zh/reportingservices/debug-information/)
 - [PDF_A 合规性](/pdf/zh/reportingservices/pdf_a-conformance/)
-
 
 

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
@@ -3,34 +3,36 @@ title: 调试信息
 linktitle: 调试信息
 type: docs
 weight: 90
-url: /zh/reportingservices/debug-information/
-description: 访问并分析 Aspose.PDF for Reporting Services 中 PDF 渲染的调试信息，以有效排查问题。
-lastmod: "2026-07-29"
+url: /reportingservices/debug-information/
+description: 访问和分析 Aspose.PDF for Reporting Services 中 PDF 渲染的调试信息，以有效地解决问题。
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-渲染或渲染结果出现问题是不可避免的。由于保密或隐私等原因，我们无法获取用户报告中使用的数据源，因而无法复现报告中的错误。为促进客户与开发者之间的交流更加便捷顺畅，我们添加了此参数。如果在使用 Aspose.PDF for Reporting Services 渲染报告时遇到问题，请设置此报告参数，您将得到以 XML 格式呈现的渲染文档。随后，请在产品论坛中将该 XML 文件发布给我们。
+渲染或者渲染结果出现问题是在所难免的。由于保密或隐私等原因，我们无法获取用户报告中使用的数据源，因此无法重现报告中的错误。为了让客户和开发者之间的沟通更加轻松、顺畅，我们添加了这个参数。如果您在使用 Aspose.PDF for Reporting Services 渲染报表时遇到问题，请设置此报表参数，然后您将获得 XML 格式的渲染文档。之后，请在产品论坛中为我们发布 XML 文件。
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**参数名称**: SavingXmlFormat  
-**日期类型**: 布尔  
-**支持的值**: True, False (默认)  
 
-**示例**
-{{< highlight csharp >}}
+```txt
+Parameter Name: SavingXmlFormat
+Date Type: Boolean  
+Values supported**: True, False (default)
+```
 
+## 例子
+
+```xml
 <Render>
 ...
 <Extension Name="APPDF" Type=" Aspose.PDF.ReportingServices.Renderer,Aspose.PDF.ReportingServices">
 <Configuration>
-<SavingXmlFormat > 真 </SavingXmlFormat>
+<SavingXmlFormat > True </SavingXmlFormat>
 </Configuration>
 </Extension>
 </Render>
-
-{{< /highlight >}}
+```
 
 {{% /alert %}}

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
@@ -4,20 +4,20 @@ linktitle: 调试信息
 type: docs
 weight: 90
 url: /zh/reportingservices/debug-information/
-description: 在 Aspose.PDF for Reporting Services 中访问和分析 PDF 渲染的调试信息，以有效排查问题。
-lastmod: "2026-06-19"
+description: 访问并分析 Aspose.PDF for Reporting Services 中 PDF 渲染的调试信息，以有效排查问题。
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-渲染或渲染结果出现问题是不可避免的。由于保密或隐私等原因，我们无法获取用户报告中使用的数据源，因而无法复现报告中的错误。为使客户与开发人员的沟通更加便捷顺畅，我们添加了此参数。如果在使用 Aspose.PDF for Reporting Services 渲染报告时遇到问题，请设置此报告参数，随后您将获得以 XML 格式的渲染文档。之后，请将该 XML 文件在产品论坛中发布给我们。
+渲染或渲染结果出现问题是不可避免的。由于保密或隐私等原因，我们无法获取用户报告中使用的数据源，因而无法复现报告中的错误。为促进客户与开发者之间的交流更加便捷顺畅，我们添加了此参数。如果在使用 Aspose.PDF for Reporting Services 渲染报告时遇到问题，请设置此报告参数，您将得到以 XML 格式呈现的渲染文档。随后，请在产品论坛中将该 XML 文件发布给我们。
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**参数名**: SavingXmlFormat  
-**日期类型**: Boolean  
-**支持的值**: True, False (default)  
+**参数名称**: SavingXmlFormat  
+**日期类型**: 布尔  
+**支持的值**: True, False (默认)  
 
 **示例**
 {{< highlight csharp >}}
@@ -26,7 +26,7 @@ lastmod: "2026-06-19"
 ...
 <Extension Name="APPDF" Type=" Aspose.PDF.ReportingServices.Renderer,Aspose.PDF.ReportingServices">
 <Configuration>
-<SavingXmlFormat > True </SavingXmlFormat>
+<SavingXmlFormat > 真 </SavingXmlFormat>
 </Configuration>
 </Extension>
 </Render>
@@ -34,4 +34,3 @@ lastmod: "2026-06-19"
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
@@ -1,35 +1,35 @@
 ---
-title: HTML 格式化
-linktitle: HTML 格式化
+title: HTML Formatting
+linktitle: HTML Formatting
 type: docs
 weight: 20
-url: /zh/reportingservices/html-formatting/
-description: 使用 Aspose.PDF for Reporting Services 在 PDF 报告中启用 HTML 格式化。轻松添加样式和结构。
-lastmod: "2026-06-19"
+url: /reportingservices/html-formatting/
+description: Enable HTML formatting in PDF reports using Aspose.PDF for Reporting Services. Add styles and structure with ease.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-有时您可能希望导出带有格式的文本框文本。遗憾的是，Reporting Services 不支持此功能。不过，您仍然可以使用 Aspose.PDF for Reporting Services 实现它。只需启用一种特殊模式，使所有文本框中的文本都被视为 HTML，并放置必要的 HTML 标记以在输出文档中格式化文本。例如，要在同一个文本框中拥有普通、粗体和斜体文本，请输入以下文本框值：
+Sometimes you might wish to export text in textboxes with formatting. Unfortunately, Reporting Services does not support this. However, you still can implement it using Aspose.PDF for Reporting Services. Just enable a special mode in which all text in textboxes is treated as HTML and put the necessary HTML tags to format the text in the output document. For example, to have normal, bold and italic text in the same textbox, enter the following textbox value:
 
-这段文字的一部分是 ```<b>bold</b>``` 以及其他文本是 ```<i>italic</i>```.
+Some of this text is ```<b>bold</b>``` and other text is ```<i>italic</i>```.
 
-导出后，文本看起来会像这段文字的一部分是 **bold**，另一部分是 *italic*。
+When exported, the text will look like as some of this text is **bold** and other text is *italic*.
 
-请注意，此方法有一些限制
+Please note that this approach has some limitations
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-- 在设计时（在 Report Builder、Reporting Services web portal 等）中，格式不可见。相反，您会看到以标签形式的纯文本 HTML 文本。
-- Aspose.PDF for Reporting Services 渲染扩展能够识别并正确格式化文本框中的 HTML 代码。Reporting Services 的默认 PDF 渲染器会将此标记导出为纯文本。
+- The formatting isn’t visible in design time (in the Report Builder, Reporting Services web portal etc.). Instead, you will see the HTML text in form of plain text with tags.
+- Aspose.PDF for Reporting Services rendering extension recognizes and properly formats HTML code in textboxes. The default PDF renderer of Reporting Services will export this markup as plain text.
 
-**参数名称**: IsHtmlTagSupported  
-**数据类型**: Boolean  
-**支持的值**: True, False (default)   
+**Parameter Name**: IsHtmlTagSupported  
+**Date Type**: Boolean  
+**Values supported**: True, False (default)   
 
-**示例**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -44,10 +44,9 @@ lastmod: "2026-06-19"
 
 {{< /highlight >}}
 
-如果您想在 Report Designer 中添加此参数，请使用 ‘Boolean’ 数据类型。
+If you want to add this parameter in the Report Designer, use the 'Boolean' data type.
 
  
-当前 Aspose.Pdf for Reporting Services 支持所有 HTML 标签的一个子集。您可以在 Aspose.PDF 中找到更多信息。 [文档](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
+Currently Aspose.PDF for Reporting Services supports a subset of all the HTML tags. You may find more information in the Aspose.PDF [Documentation](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
 
 {{% /alert %}}
-

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
@@ -1,39 +1,40 @@
 ---
-title: HTML Formatting
-linktitle: HTML Formatting
+title: HTML 格式
+linktitle: HTML 格式
 type: docs
 weight: 20
 url: /reportingservices/html-formatting/
-description: Enable HTML formatting in PDF reports using Aspose.PDF for Reporting Services. Add styles and structure with ease.
+description: 使用 Aspose.PDF for Reporting Services 在 PDF 报告中启用 HTML 格式。轻松添加样式和结构。
 lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Sometimes you might wish to export text in textboxes with formatting. Unfortunately, Reporting Services does not support this. However, you still can implement it using Aspose.PDF for Reporting Services. Just enable a special mode in which all text in textboxes is treated as HTML and put the necessary HTML tags to format the text in the output document. For example, to have normal, bold and italic text in the same textbox, enter the following textbox value:
+有时您可能希望导出带有格式的文本框中的文本。不幸的是，Reporting Services 不支持此功能。但是，您仍然可以使用 Aspose.PDF for Reporting Services 来实现它。只需启用一种特殊模式，在该模式中，文本框中的所有文本都被视为 HTML，并放置必要的 HTML 标签来格式化输出文档中的文本。例如，要在同一文本框中包含正常、粗体和斜体文本，请输入以下文本框值：
 
-Some of this text is ```<b>bold</b>``` and other text is ```<i>italic</i>```.
+其中一些文本是`<b>bold</b>`，其他文本是`<i>italic</i>`。
 
-When exported, the text will look like as some of this text is **bold** and other text is *italic*.
+导出时，文本将如下所示：其中一些文本为**粗体**，其他文本为*斜体*。
 
-Please note that this approach has some limitations
+请注意，这种方法有一些限制
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-- The formatting isn’t visible in design time (in the Report Builder, Reporting Services web portal etc.). Instead, you will see the HTML text in form of plain text with tags.
-- Aspose.PDF for Reporting Services rendering extension recognizes and properly formats HTML code in textboxes. The default PDF renderer of Reporting Services will export this markup as plain text.
+- 格式在设计时不可见（在报表生成器、Reporting Services Web 门户等中）。相反，您将看到带有标签的纯文本形式的 HTML 文本。
+- Aspose.PDF for Reporting Services 渲染扩展可识别文本框中的 HTML 代码并正确设置其格式。 Reporting Services 的默认 PDF 渲染器会将此标记导出为纯文本。
 
-**Parameter Name**: IsHtmlTagSupported  
-**Date Type**: Boolean  
-**Values supported**: True, False (default)   
+```text
+Parameter Name: IsHtmlTagSupported  
+Date Type: Boolean  
+Values supported: True, False (default)   
+```
 
-**Example**
+## 例子
 
-{{< highlight csharp >}}
-
- <Render>
+```xml
+<Render>
 ...
     <Extension Name="APPDF" Type=" Aspose.PDF.ReportingServices.Renderer,Aspose.PDF.ReportingServices ">
     <Configuration>
@@ -41,12 +42,10 @@ Please note that this approach has some limitations
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
+如果要在报表设计器中添加此参数，请使用`Boolean` 数据类型。
 
-If you want to add this parameter in the Report Designer, use the 'Boolean' data type.
-
- 
-Currently Aspose.PDF for Reporting Services supports a subset of all the HTML tags. You may find more information in the Aspose.PDF [Documentation](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
+目前 Aspose.Pdf for Reporting Services 支持所有 HTML 标签的子集。您可以在 Aspose.PDF [文档](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom) 中找到更多信息。
 
 {{% /alert %}}

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
@@ -4,19 +4,19 @@ linktitle: IsFontEmbedded
 type: docs
 weight: 50
 url: /zh/reportingservices/isfontembedded/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-RS designer 不支持嵌入文本的字体；使用 Aspose.PDF for Reporting Services，您可以轻松将字体信息嵌入到 PDF 文档中。
+RS 设计器不支持文本的嵌入字体；使用 Aspose.PDF for Reporting Services，您可以轻松地将字体信息嵌入到 PDF 文档中。
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 **参数名称**: IsFontEmbedded  
 **数据类型**: Boolean  
-**支持的值**: True, False (default)  
+**支持的值**: True, False (默认)  
 
 **示例**
 {{< highlight csharp >}}
@@ -25,7 +25,7 @@ RS designer 不支持嵌入文本的字体；使用 Aspose.PDF for Reporting Ser
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsFontEmbedded>True</IsFontEmbedded>
+    <IsFontEmbedded>真</IsFontEmbedded>
     </Configuration>
     </Extension>
 </Render>
@@ -33,4 +33,3 @@ RS designer 不支持嵌入文本的字体；使用 Aspose.PDF for Reporting Ser
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
@@ -1,35 +1,33 @@
 ---
-title: IsFontEmbedded
-linktitle: IsFontEmbedded
+title: 是否嵌入字体
+linktitle: 是否嵌入字体
 type: docs
 weight: 50
-url: /zh/reportingservices/isfontembedded/
-lastmod: "2026-07-29"
+url: /reportingservices/isfontembedded/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-RS 设计器不支持文本的嵌入字体；使用 Aspose.PDF for Reporting Services，您可以轻松地将字体信息嵌入到 PDF 文档中。
+RS Designer 不支持文本的嵌入字体；使用 Aspose.PDF for Reporting Services，您可以轻松地将字体信息嵌入到 PDF 文档中。
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**参数名称**: IsFontEmbedded  
-**数据类型**: Boolean  
-**支持的值**: True, False (默认)  
+```txt
+Parameter Name: IsFontEmbedded  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**示例**
-{{< highlight csharp >}}
+## 例子
 
+```xml
 <Render>
-…
+...
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsFontEmbedded>真</IsFontEmbedded>
+    <IsFontEmbedded>True</IsFontEmbedded>
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
@@ -5,12 +5,12 @@ type: docs
 weight: 70
 url: /zh/reportingservices/page-margin-size/
 description: 使用 Aspose.PDF for Reporting Services 调整 PDF 报告中的页面边距大小，以提高可读性和布局。
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Reporting Services 报表设计器不支持设置页面边距大小。Aspose.Pdf for Reporting Services 提供四个参数来设置相应的页面边距大小，它们是：
+Reporting Services 报表设计器不支持设置页面边距大小。Aspose.PDF for Reporting Services 提供四个参数来设置相应的页面边距大小，它们是：
 
 {{% /alert %}}
 
@@ -18,22 +18,22 @@ Reporting Services 报表设计器不支持设置页面边距大小。Aspose.Pdf
 1)  
 **参数名称**: PageMarginLeft  
 **日期类型**: Float  
-**支持的值**: 任何正数或零
+**支持的值**:  任意正数或零
 
 2)  
 **参数名称**: PageMarginRight  
 **日期类型**: Float  
-**支持的值**: 任何正数或零
+**支持的值**:  任意正数或零
 
 3)  
 **参数名称**: PageMarginTop  
 **日期类型**: Float  
-**支持的值**: 任何正数或零
+**支持的值**:  任意正数或零
 
 4)  
 **参数名称**: PageMarginBottom  
 **日期类型**: Float  
-**支持的值**: 任何正数或零
+**支持的值**:  任意正数或零
 
 **示例**
 
@@ -54,4 +54,3 @@ Reporting Services 报表设计器不支持设置页面边距大小。Aspose.Pdf
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
@@ -1,44 +1,46 @@
 ---
-title: 页面边距大小
-linktitle: 页面边距大小
+title: 页边距大小
+linktitle: 页边距大小
 type: docs
 weight: 70
-url: /zh/reportingservices/page-margin-size/
-description: 使用 Aspose.PDF for Reporting Services 调整 PDF 报告中的页面边距大小，以提高可读性和布局。
-lastmod: "2026-07-29"
+url: /reportingservices/page-margin-size/
+description: 使用 Aspose.PDF for Reporting Services 调整 PDF 报告中的页边距大小，以提高可读性和布局。
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Reporting Services 报表设计器不支持设置页面边距大小。Aspose.PDF for Reporting Services 提供四个参数来设置相应的页面边距大小，它们是：
+Reporting Services 报表设计器不支持设置页边距大小。 Aspose.PDF for Reporting Services提供了四个参数来设置相应的页边距大小，它们是：
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-1)  
-**参数名称**: PageMarginLeft  
-**日期类型**: Float  
-**支持的值**:  任意正数或零
+```text
+Parameter Name: PageMarginLeft  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-2)  
-**参数名称**: PageMarginRight  
-**日期类型**: Float  
-**支持的值**:  任意正数或零
+```text
+Parameter Name: PageMarginRight  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-3)  
-**参数名称**: PageMarginTop  
-**日期类型**: Float  
-**支持的值**:  任意正数或零
+```text
+Parameter Name: PageMarginTop  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-4)  
-**参数名称**: PageMarginBottom  
-**日期类型**: Float  
-**支持的值**:  任意正数或零
+```text
+Parameter Name: PageMarginBottom  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-**示例**
+## 例子
 
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type=" Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices ">
@@ -50,7 +52,4 @@ Reporting Services 报表设计器不支持设置页面边距大小。Aspose.PDF
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
@@ -1,37 +1,36 @@
 ---
-title: 页面方向
+title: Page Orientation
 linktitle: 页面方向
 type: docs
 weight: 10
-url: /zh/reportingservices/page-orientation/
-description: 在 Aspose.PDF for Reporting Services 中配置 PDF 报告的页面方向。自定义布局以获得更好的呈现。
-lastmod: "2026-07-29"
+url: /reportingservices/page-orientation/
+description: 在 Aspose.PDF for Reporting Services 中配置 PDF 报告的页面方向。自定义布局以获得更好的呈现效果。
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-报告定义语言不允许显式指定报告中页面的方向。使用 Aspose.PDF for Reporting Services，您可以轻松指示导出器生成横向页面方向的 PDF 文档。默认方向为纵向。
+报告定义语言不允许明确指定报告中页面的方向。使用 Aspose.PDF for Reporting Services，您可以轻松指示导出器生成横向页面方向的 PDF 文档。默认方向是纵向。
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+The default orientation is portrait.
+Parameter Name: IsLandscape
+Date Type: Boolean
+Values supported: True, False (default)
+```
 
-默认方向为纵向。
-**参数名称**: IsLandscape
-**数据类型**: Boolean
-**支持的值**: True, False (默认)
+## 例子
 
-**示例**
-{{< highlight csharp >}}
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsLandscape>真</IsLandscape>
+    <IsLandscape>True</IsLandscape>
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
-
-{{% /alert %}}

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
@@ -4,13 +4,13 @@ linktitle: 页面方向
 type: docs
 weight: 10
 url: /zh/reportingservices/page-orientation/
-description: 在 Aspose.PDF for Reporting Services 中配置 PDF 报表的页面方向。自定义布局以获得更好的呈现效果。
-lastmod: "2026-06-19"
+description: 在 Aspose.PDF for Reporting Services 中配置 PDF 报告的页面方向。自定义布局以获得更好的呈现。
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-报表定义语言不允许在报表中显式指定页面方向。使用 Aspose.PDF for Reporting Services，您可以轻松指示导出器生成横向页面方向的 PDF 文档。默认方向为纵向。
+报告定义语言不允许显式指定报告中页面的方向。使用 Aspose.PDF for Reporting Services，您可以轻松指示导出器生成横向页面方向的 PDF 文档。默认方向为纵向。
 
 {{% /alert %}}
 
@@ -19,7 +19,7 @@ lastmod: "2026-06-19"
 默认方向为纵向。
 **参数名称**: IsLandscape
 **数据类型**: Boolean
-**支持的值**: True, False (default)
+**支持的值**: True, False (默认)
 
 **示例**
 {{< highlight csharp >}}
@@ -27,7 +27,7 @@ lastmod: "2026-06-19"
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsLandscape>True</IsLandscape>
+    <IsLandscape>真</IsLandscape>
     </Configuration>
     </Extension>
 </Render>
@@ -35,4 +35,3 @@ lastmod: "2026-06-19"
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
@@ -3,27 +3,26 @@ title: 页面大小
 linktitle: 页面大小
 type: docs
 weight: 60
-url: /zh/reportingservices/pagesize/
-description: 在 Aspose.PDF for Reporting Services 中自定义 PDF 报告的页面大小，以满足特定文档需求。
-lastmod: "2026-07-29"
+url: /reportingservices/pagesize/
+description: 在 Aspose.PDF for Reporting Services 中自定义 PDF 报告的页面大小，以满足特定的文档要求。
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Reporting Services 报表设计器不支持常见的页面尺寸，如 A4、B5、Letter 等。使用 Aspose.PDF for Reporting Services，您可以按照以下示例实现。
+Reporting Services 报表设计器不支持常见的页面尺寸，例如 A4、B5、Letter 等。使用 Aspose.PDF for Reporting Services，您可以按照以下示例获取它。
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+Parameter Name: PageSize  
+Date Type: String  
+Values supported: A0, A1, A2, A3, A4, A5, A6, B5, Letter, Legal, Ledger, P11x17  
+```
 
-**参数名称**: 页面大小  
-**日期类型**: 字符串  
-**支持的值**: A0, A1, A2, A3, A4, A5, A6, B5, Letter, Legal, Ledger, P11x17  
+## 例子
 
-**示例**
-
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
@@ -32,7 +31,4 @@ Reporting Services 报表设计器不支持常见的页面尺寸，如 A4、B5�
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
@@ -1,23 +1,23 @@
 ---
-title: PageSize
-linktitle: PageSize
+title: 页面大小
+linktitle: 页面大小
 type: docs
 weight: 60
 url: /zh/reportingservices/pagesize/
-description: 定制 Aspose.PDF for Reporting Services 中 PDF 报告的页面尺寸，以满足特定文档需求。
-lastmod: "2026-06-19"
+description: 在 Aspose.PDF for Reporting Services 中自定义 PDF 报告的页面大小，以满足特定文档需求。
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Reporting Services 报表设计器不支持常见的页面尺寸，如 A4、B5、Letter 等。使用 Aspose.Pdf for Reporting Services，您可以通过以下示例实现。
+Reporting Services 报表设计器不支持常见的页面尺寸，如 A4、B5、Letter 等。使用 Aspose.PDF for Reporting Services，您可以按照以下示例实现。
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**参数名称**: PageSize  
-**日期类型**: String  
+**参数名称**: 页面大小  
+**日期类型**: 字符串  
 **支持的值**: A0, A1, A2, A3, A4, A5, A6, B5, Letter, Legal, Ledger, P11x17  
 
 **示例**
@@ -36,4 +36,3 @@ Reporting Services 报表设计器不支持常见的页面尺寸，如 A4、B5�
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
@@ -5,12 +5,12 @@ type: docs
 weight: 100
 url: /zh/reportingservices/pdf_a-conformance/
 description: 在 Aspose.PDF for Reporting Services 中启用 PDF/A 合规性。轻松创建符合归档要求的文档。
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-您可以在 Aspose.PDF 文档中获取 PDF/A（可归档 PDF）合规性的介绍。
+您可以在 Aspose.PDF 文档中了解 PDF/A（可归档 PDF）合规性的介绍。
 
 如果您想创建 PDF/A 文档，请添加以下报表参数。
 
@@ -20,7 +20,7 @@ lastmod: "2026-06-19"
 {{% alert color="primary" %}}
 
 **参数名称**: PdfConformance  
-**数据类型**: String  
+**数据类型**: 字符串  
 **支持的值**: PdfA1A, PdfA1B, PdfA2A, PdfA2B, PdfA2U, PdfA3A, PdfA3B, PdfA3U, PdfA4, PdfA4E, PdfA4F  
 
 **示例**
@@ -37,4 +37,3 @@ lastmod: "2026-06-19"
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
@@ -1,31 +1,30 @@
 ---
-title: PDF_A 合规性
-linktitle: PDF_A 合规性
+title: PDF_A 一致性
+linktitle: PDF_A 一致性
 type: docs
 weight: 100
-url: /zh/reportingservices/pdf_a-conformance/
-description: 在 Aspose.PDF for Reporting Services 中启用 PDF/A 合规性。轻松创建符合归档要求的文档。
-lastmod: "2026-07-29"
+url: /reportingservices/pdf_a-conformance/
+description: 在 Aspose.PDF for Reporting Services 中启用 PDF/A 一致性。轻松创建符合存档要求的文档。
+lastmod: "2025-05-22"
 ---
 
 {{% alert color="primary" %}}
 
-您可以在 Aspose.PDF 文档中了解 PDF/A（可归档 PDF）合规性的介绍。
+您可以在 Aspose.PDF 文档中了解 PDF/A（可存档 PDF）一致性的介绍。
 
-如果您想创建 PDF/A 文档，请添加以下报表参数。
+如果要创建 PDF/A 文档，请添加以下报告参数。
 
 {{% /alert %}}
 
+```text
+Parameter Name: PdfConformance  
+Date Type: String  
+Values supported: PdfA1A, PdfA1B, PdfA2A, PdfA2B, PdfA2U, PdfA3A, PdfA3B, PdfA3U, PdfA4, PdfA4E, PdfA4F  
+```
 
-{{% alert color="primary" %}}
+## 例子
 
-**参数名称**: PdfConformance  
-**数据类型**: 字符串  
-**支持的值**: PdfA1A, PdfA1B, PdfA2A, PdfA2B, PdfA2U, PdfA3A, PdfA3B, PdfA3U, PdfA4, PdfA4E, PdfA4F  
-
-**示例**
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
@@ -34,6 +33,4 @@ lastmod: "2026-07-29"
     </Configuration>
     </Extension>
 </Render>
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
@@ -4,46 +4,46 @@ linktitle: 安全设置
 type: docs
 weight: 30
 url: /zh/reportingservices/security-setting/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-安全一直是各个领域中最重要的问题，无论是网络保护还是 PDF 文档的保护。文档出于许多可能的原因需要被加密：文档的编写者可能希望保持文档内容的安全，并且不希望其他人对其进行更改，等等。
+安全始终是所有领域中最重要的问题，无论是网络保护还是 PDF 文档的保护。文档之所以被加密，可能有多种原因：文档作者可能希望保持文档内容的安全，并且不希望他人进行更改，等等。
 
-Aspose.Pdf for Reporting Services 在这些安全方面下了很大功夫，向开发人员提供了可用于保护 PDF 文档的功能。因此，它包含了许多参数，允许开发人员对 PDF 文档应用不同的安全措施。
+Aspose.PDF for Reporting Services 通过向开发者提供这些可用于保护 PDF 文档的功能，对此类安全方面给予了充分关注。因此，它包含了许多参数，允许开发者对 PDF 文档实施不同的安全措施。
 
-其中一种措施是在加密过程中对 PDF 文档进行密码保护。您还可以限制或允许内容修改、复制内容、文档打印或启用/禁用表单填写。这些功能目前默认的 SQL Reporting Services PDF Exporter 并不支持，但您可以使用 Aspose.Pdf for Reporting Services 实现这些功能。只需向报表或报表服务器配置文件添加相应的安全参数，即可创建具有受限权限的安全 PDF 文档。
+其中一项措施是在加密过程中对 PDF 文档进行密码保护。您还可以限制或允许内容修改、复制内容、文档打印或启用/禁用表单填写。当前默认的 SQL Reporting Services PDF 导出器不支持这些功能，但您可以使用 Aspose.PDF for Reporting Services 实现这些功能。只需在报告或报告服务器配置文件中添加相应的安全参数，即可创建具有受限权限的安全 PDF 文档。
 
-当前，Aspose.Pdf for Reporting Services 渲染器支持以下安全属性：
+当前，Aspose.PDF for Reporting Services 渲染器支持以下安全属性：
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**参数名称**: 用户密码  
-**日期类型**: 字符串  
-**支持的值**: 任意纯文本
+**参数名称**: User Password  
+**日期类型**: String  
+**支持的值**: Any plain text
 
-**参数名称**: 主密码  
-**日期类型**: 字符串  
-**支持的值**: 任意纯文本 
+**参数名称**: Master Password  
+**日期类型**: String  
+**支持的值**: Any plain text 
 
 **参数名称**: IsCopyingAllowed  
-**数据类型**: 布尔  
-**支持的值**: True, False (default)  
+**数据类型**: Boolean  
+**支持的值**: True, False (默认)  
 
 **参数名称**: IsPrintingAllowed  
-**数据类型**: 布尔  
-**支持的值**: True, False (default)  
+**数据类型**: Boolean  
+**支持的值**: True, False (默认)  
 
 **参数名称**: IsContentsModifyingAllowed  
-**数据类型**: 布尔  
-**支持的值**: True, False (default)  
+**数据类型**: Boolean  
+**支持的值**: True, False (默认)  
 
 **参数名称**: IsFormFillingAllowed  
-**数据类型**: 布尔  
-**支持的值**: True, False (default)  
+**数据类型**: Boolean  
+**支持的值**: True, False (默认)  
 
 **示例**
 
@@ -54,8 +54,8 @@ Aspose.Pdf for Reporting Services 在这些安全方面下了很大功夫，向�
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
     <UserPassword>aspose</UserPassword>
-    <IsCopyingAllowed>False</IsCopyingAllowed>
-    <IsPrintingAllowed>False</IsPrintingAllowed>
+    <IsCopyingAllowed>假</IsCopyingAllowed>
+    <IsPrintingAllowed>假</IsPrintingAllowed>
     </Configuration>
     </Extension>
 </Render>
@@ -63,4 +63,3 @@ Aspose.Pdf for Reporting Services 在这些安全方面下了很大功夫，向�
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
@@ -3,63 +3,70 @@ title: 安全设置
 linktitle: 安全设置
 type: docs
 weight: 30
-url: /zh/reportingservices/security-setting/
-lastmod: "2026-07-29"
+url: /reportingservices/security-setting/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-安全始终是所有领域中最重要的问题，无论是网络保护还是 PDF 文档的保护。文档之所以被加密，可能有多种原因：文档作者可能希望保持文档内容的安全，并且不希望他人进行更改，等等。
+安全一直是各个领域最重要的问题，无论是网络还是 PDF 文档的保护。确保文档安全的原因有很多：文档的作者可能希望保证文档内容的安全并且不希望允许其他人更改它，等等。
 
-Aspose.PDF for Reporting Services 通过向开发者提供这些可用于保护 PDF 文档的功能，对此类安全方面给予了充分关注。因此，它包含了许多参数，允许开发者对 PDF 文档实施不同的安全措施。
+Aspose.PDF for Reporting Services 非常重视此类安全方面的问题，为开发人员提供了这些功能，这些功能可帮助他们保护 PDF 文档。因此，它包含许多参数，允许开发人员对 PDF 文档应用不同的安全措施。
 
-其中一项措施是在加密过程中对 PDF 文档进行密码保护。您还可以限制或允许内容修改、复制内容、文档打印或启用/禁用表单填写。当前默认的 SQL Reporting Services PDF 导出器不支持这些功能，但您可以使用 Aspose.PDF for Reporting Services 实现这些功能。只需在报告或报告服务器配置文件中添加相应的安全参数，即可创建具有受限权限的安全 PDF 文档。
+其中一项措施是在加密过程中使用密码保护 PDF 文档。您还可以限制或允许内容修改、复制内容、文档打印或允许/禁用表单填写。默认的 SQL Reporting Services PDF 导出器目前不支持这些功能，但您可以使用 Aspose.PDF for Reporting Services 来实现这些功能。只需将相应的安全参数添加到报表或报表服务器配置文件中，您就可以使用有限的权限创建安全的 PDF 文档。
 
-当前，Aspose.PDF for Reporting Services 渲染器支持以下安全属性：
+目前，Aspose.PDF for Reporting Services 渲染器支持以下安全属性：
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+Parameter Name: User Password  
+Date Type: String  
+Values supported: Any plain text
+```
 
-**参数名称**: User Password  
-**日期类型**: String  
-**支持的值**: Any plain text
+```text
+Parameter Name: Master Password  
+Date Type: String  
+Values supported: Any plain text 
+```
 
-**参数名称**: Master Password  
-**日期类型**: String  
-**支持的值**: Any plain text 
+```text
+Parameter Name: IsCopyingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default) 
+```
 
-**参数名称**: IsCopyingAllowed  
-**数据类型**: Boolean  
-**支持的值**: True, False (默认)  
+```text
+Parameter Name: IsPrintingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**参数名称**: IsPrintingAllowed  
-**数据类型**: Boolean  
-**支持的值**: True, False (默认)  
+```text
+Parameter Name: IsContentsModifyingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default) 
+```
 
-**参数名称**: IsContentsModifyingAllowed  
-**数据类型**: Boolean  
-**支持的值**: True, False (默认)  
+```text
+Parameter Name: IsFormFillingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**参数名称**: IsFormFillingAllowed  
-**数据类型**: Boolean  
-**支持的值**: True, False (默认)  
+## 例子
 
-**示例**
-
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
     <UserPassword>aspose</UserPassword>
-    <IsCopyingAllowed>假</IsCopyingAllowed>
-    <IsPrintingAllowed>假</IsPrintingAllowed>
+    <IsCopyingAllowed>False</IsCopyingAllowed>
+    <IsPrintingAllowed>False</IsPrintingAllowed>
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
-
-{{% /alert %}}

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
@@ -4,28 +4,28 @@ linktitle: XMP 元数据
 type: docs
 weight: 80
 url: /zh/reportingservices/xmp-metadata/
-description: 学习使用 Aspose.PDF for Reporting Services 在 PDF 报告中管理 XMP 元数据。提升文档元数据处理。
-lastmod: "2026-06-19"
+description: 学习使用 Aspose.PDF for Reporting Services 在 PDF 报告中管理 XMP 元数据。增强文档元数据处理。
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Reporting Services 报表设计器不支持在文档中嵌入 XMP 元数据。Aspose.Pdf for Reporting Services 提供四个参数来设置相应的 XMP 元数据，它们是：
+Reporting Services 报表设计器不支持在文档中嵌入 XMP 元数据。Aspose.PDF for Reporting Services 提供了四个参数来设置相应的 XMP 元数据，它们是：
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 **参数名称**: CreationDate  
 **日期类型**: 字符串  
-**支持的值**: 日期，使用其中一种日期格式
+**支持的值**: 日期，符合其中一种日期格式
 
 **参数名称**: ModifyDate  
 **日期类型**: 字符串  
-**支持的值**: 日期，使用其中一种日期格式 
+**支持的值**: 日期，符合其中一种日期格式 
 
 **参数名称**: MetaDataDate  
 **日期类型**: 字符串  
-**支持的值**: 日期，使用其中一种日期格式 
+**支持的值**: 日期，符合其中一种日期格式 
 
 **参数名称**: CreatorTool  
 **日期类型**: 字符串  
@@ -40,8 +40,8 @@ Reporting Services 报表设计器不支持在文档中嵌入 XMP 元数据。As
     <Configuration>
     <CreationDate>2017-12-10</CreationDate>
     <ModifyDate>2018-1-12</ModifyDate>
-    <MetaDataDate>2018-3-7</MetaDataDate>
-    <CreatorTool>Aspose.Pdf for Reporting Services</CreatorTool>
+    <MetaDataDate>2018年3月7日</MetaDataDate>
+    <CreatorTool>Aspose.PDF for Reporting Services</CreatorTool>
     </Configuration>
     </Extension>
 </Render>
@@ -49,5 +49,4 @@ Reporting Services 报表设计器不支持在文档中嵌入 XMP 元数据。As
 {{< /highlight >}}
 
 {{% /alert %}}
-
 

--- a/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
+++ b/zh/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
@@ -1,52 +1,57 @@
 ---
-title: XMP 元数据
-linktitle: XMP 元数据
+title: XMP元数据
+linktitle: XMP元数据
 type: docs
 weight: 80
-url: /zh/reportingservices/xmp-metadata/
-description: 学习使用 Aspose.PDF for Reporting Services 在 PDF 报告中管理 XMP 元数据。增强文档元数据处理。
-lastmod: "2026-07-29"
+url: /reportingservices/xmp-metadata/
+description: 了解使用 Aspose.PDF for Reporting Services 管理 PDF 报告中的 XMP 元数据。增强文档元数据处理。
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Reporting Services 报表设计器不支持在文档中嵌入 XMP 元数据。Aspose.PDF for Reporting Services 提供了四个参数来设置相应的 XMP 元数据，它们是：
+Reporting Services 报表设计器不支持在文档中嵌入 XMP 元数据。 Aspose.PDF for Reporting Services提供了四个参数来设置相应的XMP元数据，它们是：
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**参数名称**: CreationDate  
-**日期类型**: 字符串  
-**支持的值**: 日期，符合其中一种日期格式
+```text
+**Parameter Name: CreationDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats
+```
 
-**参数名称**: ModifyDate  
-**日期类型**: 字符串  
-**支持的值**: 日期，符合其中一种日期格式 
+```text
+**Parameter Name: ModifyDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats 
+```
 
-**参数名称**: MetaDataDate  
-**日期类型**: 字符串  
-**支持的值**: 日期，符合其中一种日期格式 
+```text
+**Parameter Name: MetaDataDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats 
+```
 
-**参数名称**: CreatorTool  
-**日期类型**: 字符串  
-**支持的值**: 任意纯文本  
+```text
+**Parameter Name: CreatorTool  
+**Date Type: String  
+**Values supported: Any plain text  
+```
 
-**示例**
-{{< highlight csharp >}}
+## 例子
 
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer, Aspose.Pdf.ReportingServices">
     <Configuration>
     <CreationDate>2017-12-10</CreationDate>
     <ModifyDate>2018-1-12</ModifyDate>
-    <MetaDataDate>2018年3月7日</MetaDataDate>
+    <MetaDataDate>2018-3-7</MetaDataDate>
     <CreatorTool>Aspose.PDF for Reporting Services</CreatorTool>
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
-
-{{% /alert %}}
 

--- a/zh/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
+++ b/zh/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
@@ -4,23 +4,22 @@ linktitle: 评估 Aspose.Pdf
 type: docs
 weight: 110
 url: /zh/reportingservices/evaluate-aspose-pdf-for-reporting-services/
-description: 免费试用 Aspose.PDF for Reporting Services。了解如何在做出购买决定之前评估其功能。
-lastmod: "2026-06-19"
+description: 免费试用 Aspose.PDF for Reporting Services。了解如何在做出购买决策之前评估其功能。
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-此页面说明了 Aspose.PDF for Reporting Services 的授权版和评估版之间的差异
+此页面说明了 Aspose.PDF for Reporting Services 的许可版与评估版之间的区别
 
 {{% /alert %}}
 
-您可以轻松下载 [Aspose.PDF for Reporting Services](https://downloads.aspose.com/pdf/reportingservices) 用于评估。评估下载与购买下载相同。当您将许可证文件放置在包含 Aspose.PDF.ReportingServices.dll 的文件夹中，或在本地模式下使用 Report Viewer 组件时通过几行代码初始化许可证，评估版即可变为正式版。Aspose.PDF for Reporting Services 的评估版（未指定许可证）提供完整的产品功能，但在将 .RDL 文件渲染为 PDF 格式时，会在文档顶部插入评估水印。您可以访问以下页面获取进一步的说明 [如何为 Aspose.PDF for Reporting Services 授权](/pdf/zh/reportingservices/license-aspose-pdf-for-reporting-services/)
+您可以轻松下载 [Aspose.PDF for Reporting Services](https://downloads.aspose.com/pdf/reportingservices) 用于评估。评估下载与购买下载相同。当您将许可证文件放置在包含 Aspose.PDF.ReportingServices.dll 的文件夹中，或在本地模式下使用 Report Viewer 组件时通过几行代码初始化许可证，评估版即转为已授权。Aspose.PDF for Reporting Services 的评估版（未指定许可证）提供完整的产品功能，但在将 .RDL 文件渲染为 PDF 格式时会在文档顶部插入评估水印。您可以访问以下页面获取进一步的说明。 [如何为 Aspose.PDF for Reporting Services 授权](/pdf/zh/reportingservices/license-aspose-pdf-for-reporting-services/)
 
 ![todo:image_alt_text](evaluate-aspose-pdf-for-reporting-services_1.png)
 
 {{% alert color="primary" %}}
 
-如果您想在没有评估版限制的情况下测试 Aspose.PDF for Reporting Services，您也可以请求 30 天的临时许可证。请参阅 [如何获取临时许可证？](<https://about.aspose.com/>)
+如果您想在不受评估版限制的情况下测试 Aspose.PDF for Reporting Services，亦可申请 30 天的临时许可证。请参阅 [如何获取临时许可证？](<https://about.aspose.com/>)
 
 {{% /alert %}}
-

--- a/zh/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
+++ b/zh/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
@@ -3,23 +3,23 @@ title: 评估 Aspose.Pdf
 linktitle: 评估 Aspose.Pdf
 type: docs
 weight: 110
-url: /zh/reportingservices/evaluate-aspose-pdf-for-reporting-services/
-description: 免费试用 Aspose.PDF for Reporting Services。了解如何在做出购买决策之前评估其功能。
-lastmod: "2026-07-29"
+url: /reportingservices/evaluate-aspose-pdf-for-reporting-services/
+description: 免费试用 Aspose.PDF for Reporting Services。了解如何在做出购买决定之前评估其功能。
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-此页面说明了 Aspose.PDF for Reporting Services 的许可版与评估版之间的区别
+本页说明了 Aspose.PDF for Reporting Services 的许可版和评估版之间的区别
 
 {{% /alert %}}
 
-您可以轻松下载 [Aspose.PDF for Reporting Services](https://downloads.aspose.com/pdf/reportingservices) 用于评估。评估下载与购买下载相同。当您将许可证文件放置在包含 Aspose.PDF.ReportingServices.dll 的文件夹中，或在本地模式下使用 Report Viewer 组件时通过几行代码初始化许可证，评估版即转为已授权。Aspose.PDF for Reporting Services 的评估版（未指定许可证）提供完整的产品功能，但在将 .RDL 文件渲染为 PDF 格式时会在文档顶部插入评估水印。您可以访问以下页面获取进一步的说明。 [如何为 Aspose.PDF for Reporting Services 授权](/pdf/zh/reportingservices/license-aspose-pdf-for-reporting-services/)
+您可以轻松下载 [用于报告服务的 Aspose.PDF](https://downloads.aspose.com/pdf/reportingservices) 进行评估。评估下载与购买的下载相同。当您将许可证文件放置在包含 Aspose.PDF.ReportingServices.dll 的文件夹中或在本地模式下使用带有报表查看器的组件时初始化许可证的几行代码时，评估版就会获得许可。 Aspose.PDF for Reporting Services 的评估版（未指定许可证）提供完整的产品功能，但在将 .RDL 文件渲染为 PDF 格式时，它会在文档顶部插入评估水印。您可以访问以下页面以获取更多说明 [如何为报告服务授予 Aspose.PDF 许可](/pdf/zh/reportingservices/license-aspose-pdf-for-reporting-services/)
 
-![todo:image_alt_text](evaluate-aspose-pdf-for-reporting-services_1.png)
+![评估](evaluate-aspose-pdf-for-reporting-services_1.png)
 
 {{% alert color="primary" %}}
 
-如果您想在不受评估版限制的情况下测试 Aspose.PDF for Reporting Services，亦可申请 30 天的临时许可证。请参阅 [如何获取临时许可证？](<https://about.aspose.com/>)
+如果您想在不受评估版本限制的情况下测试 Aspose.PDF for Reporting Services，您还可以请求 30 天的临时许可证。请参考 [如何获得临时许可证？](<https://about.aspose.com/>)
 
 {{% /alert %}}

--- a/zh/reportingservices/expand-report-items-properties/_index.md
+++ b/zh/reportingservices/expand-report-items-properties/_index.md
@@ -1,15 +1,14 @@
 ---
-title: 展开报告项属性
-linktitle: 展开报告项属性
+title: 展开报表项属性
+linktitle: 展开报表项属性
 type: docs
 weight: 90
 url: /zh/reportingservices/expand-report-items-properties/
-description: 使用 Aspose.PDF 增强 SSRS 报告。了解如何展开报告项属性以实现详细的 PDF 定制。
-lastmod: "2026-06-19"
+description: 使用 Aspose.PDF 增强 SSRS 报表。了解如何展开报表项属性以实现详细的 PDF 定制。
+lastmod: "2026-07-29"
 ---
 
-**本节包括以下主题：**
+**此章节包括以下主题：**
 
 - [添加自定义属性](/pdf/zh/reportingservices/adding-custom-properties/)
 - [支持自定义属性](/pdf/zh/reportingservices/custom-properties-supported/)
-

--- a/zh/reportingservices/expand-report-items-properties/_index.md
+++ b/zh/reportingservices/expand-report-items-properties/_index.md
@@ -1,14 +1,14 @@
 ---
-title: 展开报表项属性
-linktitle: 展开报表项属性
+title: 展开报告项目道具
+linktitle: 展开报告项目道具
 type: docs
 weight: 90
-url: /zh/reportingservices/expand-report-items-properties/
-description: 使用 Aspose.PDF 增强 SSRS 报表。了解如何展开报表项属性以实现详细的 PDF 定制。
-lastmod: "2026-07-29"
+url: /reportingservices/expand-report-items-properties/
+description: 使用 Aspose.PDF 增强 SSRS 报告。了解如何扩展报表项属性以进行详细的 PDF 自定义。
+lastmod: "2021-06-05"
 ---
 
-**此章节包括以下主题：**
+**本节包括以下主题：**
 
 - [添加自定义属性](/pdf/zh/reportingservices/adding-custom-properties/)
 - [支持自定义属性](/pdf/zh/reportingservices/custom-properties-supported/)

--- a/zh/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
+++ b/zh/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
@@ -5,49 +5,48 @@ type: docs
 weight: 10
 url: /zh/reportingservices/adding-custom-properties/
 description: 了解如何使用 Aspose.PDF for Reporting Services 向 PDF 报告添加自定义属性。高效地自定义您的文档。
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-您可以为某些报表项添加自定义属性，以扩展它们的用途，例如 ToC、线条箭头等。本节介绍此过程。
+您可以为某些报表项添加自定义属性，以扩展其用途，例如目录、线条箭头等。本节描述了此过程。
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-您可以为某些报表项添加自定义属性，以扩展它们的用途，例如目录、线条箭头等。本节介绍此过程。
+您可以为某些报表项添加自定义属性，以扩展其用途，例如目录、线条箭头等。本节描述了此过程。
 
 要添加自定义属性，您需要按照以下步骤编辑 RDL 文档的代码文件：
 
-1. 如以下图所示，打开您的项目，导航至解决方案资源管理器，右键单击所选的报告文件，然后选择 'View Code' 菜单项。
+1. 如下面的图所示，打开您的项目，导航到解决方案资源管理器，右键单击选中的报表文件，然后选择‘View Code’菜单项。
 
 ![todo:image_alt_text](adding-custom-properties_1.png)
 
-2. 编辑 XML 代码文件。例如，如果您想为图表报告项添加自定义属性，则需要在下面示例中添加类似红色文本的代码。
+2. 编辑 XML 代码文件。例如，如果您想为图表报表项添加自定义属性，您需要添加类似以下示例中红色文本的代码。
 
 **示例**
 
 {{< highlight csharp >}}
 
 <chart Name="chart1">
-    <Left>5.5cm</Left>
-    <Top>0.5cm</Top>
+    <Left>5.5厘米</Left>
+    <Top>0.5厘米</Top>
       ......
     <Style>
       ......
     </style>     
     <CustomProperties>
       <CustomProperty>
-        <Name>IsInList</Name>
-        <Value>True</Value>
+        <Name>是否在列表中</Name>
+        <Value>真</Value>
       </CustomProperty>
     </CustomProperties>
 </chart> 
 
 {{< /highlight >}}
 
-在此代码片段示例中，自定义属性名称是 IsInList，值为 'True'。
+在此代码片段示例中，自定义属性名称为 IsInList，值为 'True'。
 
 {{% /alert %}}
-

--- a/zh/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
+++ b/zh/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
@@ -3,50 +3,45 @@ title: 添加自定义属性
 linktitle: 添加自定义属性
 type: docs
 weight: 10
-url: /zh/reportingservices/adding-custom-properties/
-description: 了解如何使用 Aspose.PDF for Reporting Services 向 PDF 报告添加自定义属性。高效地自定义您的文档。
-lastmod: "2026-07-29"
+url: /reportingservices/adding-custom-properties/
+description: 了解如何使用 Aspose.PDF for Reporting Services 将自定义属性添加到 PDF 报告。高效定制您的文档。
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-您可以为某些报表项添加自定义属性，以扩展其用途，例如目录、线条箭头等。本节描述了此过程。
+您可以为某些报表项添加自定义属性以扩展其用途，例如目录、线条箭头等。本节描述了这个过程。
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+您可以为某些报表项添加自定义属性以扩展其用途，例如目录、线条箭头等。本节描述了这个过程。
 
-您可以为某些报表项添加自定义属性，以扩展其用途，例如目录、线条箭头等。本节描述了此过程。
+要添加自定义属性，您需要按照以下步骤编辑RDL文档的代码文件：
 
-要添加自定义属性，您需要按照以下步骤编辑 RDL 文档的代码文件：
+1. 如下图所示，打开项目，导航到解决方案资源管理器，右键单击所选的报告文件，然后选择“查看代码”菜单项。
 
-1. 如下面的图所示，打开您的项目，导航到解决方案资源管理器，右键单击选中的报表文件，然后选择‘View Code’菜单项。
+![Add Custom Properties](adding-custom-properties_1.png)
 
-![todo:image_alt_text](adding-custom-properties_1.png)
+2. 编辑 XML 代码文件。例如，如果要为图表报表项添加自定义属性，则需要添加类似于以下示例中红色文本的代码。
 
-2. 编辑 XML 代码文件。例如，如果您想为图表报表项添加自定义属性，您需要添加类似以下示例中红色文本的代码。
+## 例子
 
-**示例**
-
-{{< highlight csharp >}}
-
+```xml
 <chart Name="chart1">
-    <Left>5.5厘米</Left>
-    <Top>0.5厘米</Top>
+    <Left>5.5cm</Left>
+    <Top>0.5cm</Top>
       ......
     <Style>
       ......
     </style>     
     <CustomProperties>
       <CustomProperty>
-        <Name>是否在列表中</Name>
-        <Value>真</Value>
+        <Name>IsInList</Name>
+        <Value>True</Value>
       </CustomProperty>
     </CustomProperties>
 </chart> 
+```
 
-{{< /highlight >}}
+在此代码片段示例中，自定义属性名称为 IsInList，值为 `True`。
 
-在此代码片段示例中，自定义属性名称为 IsInList，值为 'True'。
-
-{{% /alert %}}

--- a/zh/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
+++ b/zh/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
@@ -1,16 +1,16 @@
 ---
-title: 支持的自定义属性
-linktitle: 支持的自定义属性
+title: 支持自定义属性
+linktitle: 支持自定义属性
 type: docs
 weight: 20
-url: /zh/reportingservices/custom-properties-supported/
-description: 检查 Aspose.PDF for Reporting Services 中受支持的自定义属性。最大化 PDF 输出的灵活性。
-lastmod: "2026-07-29"
+url: /reportingservices/custom-properties-supported/
+description: 检查 Aspose.PDF for Reporting Services 支持的自定义属性。最大限度地提高 PDF 输出的灵活性。
+lastmod: "2021-06-05"
 ---
 
 **本节包括以下主题：**
 
-- [目录、表格或图形列表](/pdf/zh/reportingservices/table-of-contents-list-of-tables-or-figures/)
-- [线形箭头](/pdf/zh/reportingservices/line-arrows/)
-- [脚注 尾注](/pdf/zh/reportingservices/footnote-endnote/)
-- [两端对齐 完全对齐 文本对齐](/pdf/zh/reportingservices/justify-fulljustify-text-alignment/)
+- [目录 表格或图形列表](/pdf/zh/reportingservices/table-of-contents-list-of-tables-or-figures/)
+- [线箭头](/pdf/zh/reportingservices/line-arrows/)
+- [脚注尾注](/pdf/zh/reportingservices/footnote-endnote/)
+- [Justify FullJustify 文本对齐](/pdf/zh/reportingservices/justify-fulljustify-text-alignment/)

--- a/zh/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
+++ b/zh/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
@@ -4,14 +4,13 @@ linktitle: 支持的自定义属性
 type: docs
 weight: 20
 url: /zh/reportingservices/custom-properties-supported/
-description: 检查 Aspose.PDF for Reporting Services 中支持的自定义属性。最大化 PDF 输出的灵活性。
-lastmod: "2026-06-19"
+description: 检查 Aspose.PDF for Reporting Services 中受支持的自定义属性。最大化 PDF 输出的灵活性。
+lastmod: "2026-07-29"
 ---
 
 **本节包括以下主题：**
 
-- [目录 表格或图形列表](/pdf/zh/reportingservices/table-of-contents-list-of-tables-or-figures/)
-- [线箭头](/pdf/zh/reportingservices/line-arrows/)
+- [目录、表格或图形列表](/pdf/zh/reportingservices/table-of-contents-list-of-tables-or-figures/)
+- [线形箭头](/pdf/zh/reportingservices/line-arrows/)
 - [脚注 尾注](/pdf/zh/reportingservices/footnote-endnote/)
 - [两端对齐 完全对齐 文本对齐](/pdf/zh/reportingservices/justify-fulljustify-text-alignment/)
-

--- a/zh/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
+++ b/zh/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
@@ -4,27 +4,27 @@ linktitle: 脚注 尾注
 type: docs
 weight: 30
 url: /zh/reportingservices/footnote-endnote/
-description: 使用 Aspose.PDF for Reporting Services 为您的 PDF 报告添加脚注和尾注。提供详细的文档引用。
-lastmod: "2026-06-19"
+description: 使用 Aspose.PDF for Reporting Services 将脚注和尾注添加到您的 PDF 报告中。提供详细的文档引用。
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Report Builder 无法为文本框设置脚注或尾注。使用 Aspose.Pdf for Reporting Services，您可以通过添加自定义属性轻松实现。
+Report Builder 无法为文本框设置脚注或尾注。使用 Aspose.PDF for Reporting Services，您可以通过添加自定义属性轻松实现此功能。
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 脚注
 **Custom Property** **Name**: 脚注
-**Custom Property Value**: *值* *应该* *是* *一个* *字符串*
+**Custom Property Value**: *该* *值* *应该* *是* *一个* *字符串*
 
 尾注
 **Custom Property** **Name**: 尾注
-**Custom Property Value**: *值* *应该* *是* *一个* *字符串*
+**Custom Property Value**: *该* *值* *应该* *是* *一个* *字符串*
 
 {{% alert color="primary" %}}
-在下面的示例中，报表包含一个值为 'AsposePdf4RS' 的文本框，我们想要以脚注的形式添加补充说明，文本为 "An optional PDF renderer for SSRS from Aspose Pty. Ltd."。
+在下面的示例中，报告包含一个值为 'AsposePdf4RS' 的文本框，我们想在脚注中添加补充说明，文本为 "An optional PDF renderer for SSRS from Aspose Pty. Ltd."。
 {{% /alert %}}
 
 **示例**
@@ -54,4 +54,3 @@ Report Builder 无法为文本框设置脚注或尾注。使用 Aspose.Pdf for R
 </Textbox>
 ```
 {{% /alert %}}
-

--- a/zh/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
+++ b/zh/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
@@ -1,33 +1,34 @@
 ---
-title: 脚注 尾注
-linktitle: 脚注 尾注
+title: 脚注尾注
+linktitle: 脚注尾注
 type: docs
 weight: 30
-url: /zh/reportingservices/footnote-endnote/
-description: 使用 Aspose.PDF for Reporting Services 将脚注和尾注添加到您的 PDF 报告中。提供详细的文档引用。
-lastmod: "2026-07-29"
+url: /reportingservices/footnote-endnote/
+description: 使用 Aspose.PDF for Reporting Services 将脚注和尾注添加到 PDF 报告中。提供详细的文档参考。
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Builder 无法为文本框设置脚注或尾注。使用 Aspose.PDF for Reporting Services，您可以通过添加自定义属性轻松实现此功能。
+报表生成器无法设置文本框的脚注或尾注。借助 Aspose.PDF for Reporting Services，您可以通过添加自定义属性轻松实现这一点。
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-脚注
-**Custom Property** **Name**: 脚注
-**Custom Property Value**: *该* *值* *应该* *是* *一个* *字符串*
+```text
+Footnote
+Custom Property `Name`: Footnote
+Custom Property Value: `the` `value` `should` `be` `a` `string`
+```
 
-尾注
-**Custom Property** **Name**: 尾注
-**Custom Property Value**: *该* *值* *应该* *是* *一个* *字符串*
+```text
+Endnote
+Custom Property `Name`: Endnote
+Custom Property Value: `the` `value` `should` `be` `a` `string`
+```
 
-{{% alert color="primary" %}}
-在下面的示例中，报告包含一个值为 'AsposePdf4RS' 的文本框，我们想在脚注中添加补充说明，文本为 "An optional PDF renderer for SSRS from Aspose Pty. Ltd."。
-{{% /alert %}}
+在下面的示例中，报告包含一个值为 `AsposePdf4RS` 的文本框，我们希望以脚注的形式添加补充说明，其中包含文本“Aspose Pty. Ltd. 的 SSRS 的可选 PDF 渲染器”。
 
-**示例**
+## 例子
 
 ```cs
 <Textbox Name="Textbox1">
@@ -53,4 +54,3 @@ Report Builder 无法为文本框设置脚注或尾注。使用 Aspose.PDF for R
 </Paragraphs>
 </Textbox>
 ```
-{{% /alert %}}

--- a/zh/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
+++ b/zh/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
@@ -1,16 +1,16 @@
 ---
-title: 两端对齐 完全两端对齐 文本对齐
-linktitle: 两端对齐 完全两端对齐 文本对齐
+title: 对齐 FullJustify 文本对齐
+linktitle: 对齐 FullJustify 文本对齐
 type: docs
 weight: 40
 url: /zh/reportingservices/justify-fulljustify-text-alignment/
 description: 使用 Aspose.PDF for Reporting Services 实现 PDF 报表中文本对齐的完美效果。支持两端对齐和完全两端对齐选项。
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Report builder 不支持为文本框 “Justify” 和 “FullJustify” 指定文本对齐的功能。使用 Aspose.Pdf for Reporting Services，您可以通过添加自定义属性轻松实现此功能。
+报表生成器不支持为文本框 “Justify” 与 “FullJustify” 指定文本对齐的功能。使用 Aspose.PDF for Reporting Services，您可以通过添加自定义属性轻松实现此功能。
 
 {{% /alert %}}
 
@@ -19,7 +19,7 @@ Report builder 不支持为文本框 “Justify” 和 “FullJustify” 指定�
 **自定义属性类型** : 字符串  
 **自定义属性值** : Justify, FullJustify  
 
-在报告中，代码应如下所示：
+在报告中，代码应如下所示:
 
 **示例**
 
@@ -28,11 +28,10 @@ Report builder 不支持为文本框 “Justify” 和 “FullJustify” 指定�
 <value> AsposePdf4RS </value>     
   <CustomProperties>
    <CustomProperty>
-     <Name>TextAlignment</Name>
-     <Value>Justify</Value>
+     <Name>文本对齐</Name>
+     <Value>两端对齐</Value>
    </CustomProperty>
   </CustomProperties>
 </Textbox>
 {{< /highlight >}}
 {{% /alert %}}
-

--- a/zh/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
+++ b/zh/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
@@ -1,37 +1,37 @@
 ---
-title: 对齐 FullJustify 文本对齐
-linktitle: 对齐 FullJustify 文本对齐
+title: Justify FullJustify 文本对齐
+linktitle: Justify FullJustify 文本对齐
 type: docs
 weight: 40
-url: /zh/reportingservices/justify-fulljustify-text-alignment/
-description: 使用 Aspose.PDF for Reporting Services 实现 PDF 报表中文本对齐的完美效果。支持两端对齐和完全两端对齐选项。
-lastmod: "2026-07-29"
+url: /reportingservices/justify-fulljustify-text-alignment/
+description: 使用 Aspose.PDF for Reporting Services 在 PDF 报告中实现完美的文本对齐。支持对齐和完全对齐选项。
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-报表生成器不支持为文本框 “Justify” 与 “FullJustify” 指定文本对齐的功能。使用 Aspose.PDF for Reporting Services，您可以通过添加自定义属性轻松实现此功能。
+报表生成器不支持为文本框指定文本对齐方式的功能 `Justify` 和 `FullJustify`。借助 Aspose.PDF for Reporting Services，您可以通过添加自定义属性轻松实现这一点。
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**自定义属性名称** : TextAlignment  
-**自定义属性类型** : 字符串  
-**自定义属性值** : Justify, FullJustify  
+```text
+Custom Property `Name`: TextAlignment  
+Custom Property `Type`: String  
+Custom Property `Values`: Justify, FullJustify  
+```
 
-在报告中，代码应如下所示:
+报告中的代码应如下所示：
 
-**示例**
+## 例子
 
-{{< highlight csharp >}}
+```xml
 <Textbox Name="textbox1">
 <value> AsposePdf4RS </value>     
   <CustomProperties>
    <CustomProperty>
-     <Name>文本对齐</Name>
-     <Value>两端对齐</Value>
+     <Name>TextAlignment</Name>
+     <Value>Justify</Value>
    </CustomProperty>
   </CustomProperties>
 </Textbox>
-{{< /highlight >}}
-{{% /alert %}}
+```

--- a/zh/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
+++ b/zh/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
@@ -1,44 +1,46 @@
 ---
-title: 线条箭头
-linktitle: 线条箭头
+title: 线箭头
+linktitle: 线箭头
 type: docs
 weight: 20
-url: /zh/reportingservices/line-arrows/
-description: 学习如何在 PDF 报告中使用 Aspose.PDF for Reporting Services 添加线条箭头。轻松提升报告视觉效果。
-lastmod: "2026-07-29"
+url: /reportingservices/line-arrows/
+description: 了解使用 Aspose.PDF for Reporting Services 在 PDF 报告中添加线条箭头。轻松增强报告视觉效果。
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-RDL 规范未对线元素的箭头进行规定，因此 Report Builder 不支持线的箭头设置。使用 Aspose.PDF for Reporting Services，您可以轻松实现此功能。
+RDL规范没有指定线元素的箭头，因此报表生成器不支持线的箭头设置。借助 Aspose.PDF for Reporting Services，您可以轻松做到这一点。
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+目前，Aspose.PDF 渲染器支持通过添加自定义属性在行的开头或结尾添加箭头。
 
-当前，Aspose.PDF 渲染器支持通过添加自定义属性为线的起点或终点添加箭头。
+```text
+Add Start Arrow for Line  
+Custom Property `Name`: HasArrowAtStart  
+Custom Property `Value`: True  
+```
 
-为线添加起始箭头  
-**自定义属性** **名称**: HasArrowAtStart  
-**自定义属性值**: True  
+```text
+Add End Arrow for Line  
+Custom Property `Name`: HasArrowAtEnd  
+Custom Property `Value`: True  
+```
 
-为线添加结束箭头  
-**自定义属性** **名称**: HasArrowAtEnd  
-**自定义属性值**: True  
+例如，有两行名为 `line1` 和 `line2` 在当前报表文件中，line1 有开始箭头，line2 有开始和结束箭头，为了满足这些要求，您可以添加自定义属性，如以下代码片段所示。
 
-例如，在当前报告文件中有两条线，分别名为 'line1' 和 'line2'，其中 line1 带有起始箭头，line2 带有起始和结束箭头。为满足这些要求，您可以按以下代码片段添加自定义属性。
+## 例子
 
-**示例**
-
-{{< highlight csharp >}}
+```xml
  <Line Name="line1">
     <Style>
       ......
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>起始处有箭头</Name>
-        <Value>真</Value>
+        <Name>HasArrowAtStart</Name>
+        <Value>True</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
@@ -49,15 +51,14 @@ RDL 规范未对线元素的箭头进行规定，因此 Report Builder 不支持
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>起始处有箭头</Name>
-        <Value>真</Value>
+        <Name>HasArrowAtStart</Name>
+        <Value>True</Value>
       </CustomProperty>
 <CustomProperty>
-        <Name>末尾有箭头</Name>
-        <Value>真</Value>
+        <Name>HasArrowAtEnd</Name>
+        <Value>True</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
+```
 
-{{< /highlight >}}
-{{% /alert %}}

--- a/zh/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
+++ b/zh/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
@@ -4,29 +4,29 @@ linktitle: 线条箭头
 type: docs
 weight: 20
 url: /zh/reportingservices/line-arrows/
-description: 学习如何在使用 Aspose.PDF for Reporting Services 的 PDF 报表中添加线条箭头。轻松提升报告的视觉效果。
-lastmod: "2026-06-19"
+description: 学习如何在 PDF 报告中使用 Aspose.PDF for Reporting Services 添加线条箭头。轻松提升报告视觉效果。
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-RDL 规范未对线条元素的箭头进行规定，因而 Report Builder 不支持对线条设置箭头。使用 Aspose.PDF for Reporting Services，您可以轻松实现此功能。
+RDL 规范未对线元素的箭头进行规定，因此 Report Builder 不支持线的箭头设置。使用 Aspose.PDF for Reporting Services，您可以轻松实现此功能。
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-目前，Aspose.PDF 渲染器通过添加自定义属性支持在直线的起始或结束位置添加箭头。
+当前，Aspose.PDF 渲染器支持通过添加自定义属性为线的起点或终点添加箭头。
 
-为线条添加起始箭头  
+为线添加起始箭头  
 **自定义属性** **名称**: HasArrowAtStart  
 **自定义属性值**: True  
 
-为线条添加结束箭头  
+为线添加结束箭头  
 **自定义属性** **名称**: HasArrowAtEnd  
 **自定义属性值**: True  
 
-例如，在当前报告文件中有两条线，名称分别为 'line1' 和 'line2'，其中 line1 具有起始箭头，line2 具有起始和结束箭头。为满足这些要求，您可以按以下代码片段添加自定义属性。
+例如，在当前报告文件中有两条线，分别名为 'line1' 和 'line2'，其中 line1 带有起始箭头，line2 带有起始和结束箭头。为满足这些要求，您可以按以下代码片段添加自定义属性。
 
 **示例**
 
@@ -37,8 +37,8 @@ RDL 规范未对线条元素的箭头进行规定，因而 Report Builder 不支
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>HasArrowAtStart</Name>
-        <Value>True</Value>
+        <Name>起始处有箭头</Name>
+        <Value>真</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
@@ -49,16 +49,15 @@ RDL 规范未对线条元素的箭头进行规定，因而 Report Builder 不支
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>HasArrowAtStart</Name>
-        <Value>True</Value>
+        <Name>起始处有箭头</Name>
+        <Value>真</Value>
       </CustomProperty>
 <CustomProperty>
-        <Name>HasArrowAtEnd</Name>
-        <Value>True</Value>
+        <Name>末尾有箭头</Name>
+        <Value>真</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
 
 {{< /highlight >}}
 {{% /alert %}}
-

--- a/zh/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
+++ b/zh/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
@@ -1,25 +1,24 @@
 ---
-title: Table of Contents List of Tables or Figures
-linktitle: Table of Contents List of Tables or Figures
+title: 目录 表格或图形列表
+linktitle: 目录 表格或图形列表
 type: docs
 weight: 10
 url: /reportingservices/table-of-contents-list-of-tables-or-figures/
-description: Learn how to add a Table of Contents, List of Tables, or Figures in PDF reports using Aspose.PDF for Reporting Services.
+description: 了解如何使用 Aspose.PDF for Reporting Services 在 PDF 报告中添加目录、表格列表或图表。
 lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Designer does not support adding table of contents for report documents. With Aspose.PDF for Reporting Services you can easily instruct the PDF render to produce PDF documents with Table of Contents, or List of Tables or Figures. You can do it in the following steps:
+报表设计器不支持添加报表文档的目录。使用 Aspose.PDF for Reporting Services，您可以轻松指示 PDF 渲染器生成带有目录、表格或图形列表的 PDF 文档。您可以按照以下步骤进行操作：
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/bin, where ```<Instance>``` is the directory of the Report Server. If the file does not exist, create it in the ```<Instance>```/bin directory and place the following markup inside.
+确保 Aspose.Pdf.ListSectionStyle.xml 文件存在于 ```<Instance>```/bin, where ```<Instance>``` is the directory of the Report Server. If the file does not exist, create it in the ```<Instance>```/bin 目录中，并将以下标记放入其中。
 
-## Table of Contents
+## 目录
 
-**Example**
+### 例子
 
 ```cs
 <ListSection ListType="TableOfContents">
@@ -41,9 +40,9 @@ Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/b
 </ListSection>
 ```
 
-##  List of TableS
+##  表列表
 
-**Example**
+### 例子
 
 ```cs
 <ListSection ListType="ListOfTables">
@@ -53,9 +52,9 @@ Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/b
 </ListSection>
 ```
 
-## List of Figures
+## 图列表
 
-**Example**
+### 例子
 
 ```cs
  <ListSection ListType="ListOfFigures">
@@ -66,40 +65,29 @@ Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/b
 
 ```
 
-Please refer to 'Working with TOC' section of the Aspose.Pdf online documentation.
+请参阅 Aspose.Pdf 在线文档的“使用 TOC”部分。
 
-**2-** Add report parameter 'IsListSectionSupported' and set the value to be True as shown in the 'List Section' paragraph.
-**3-** Add custom property for your report item you want to be listed in Table of Contents, List of Tables or Figures.
+**2-** 添加报告参数`IsListSectionSupported` 并将值设置为True，如`List Section` 段落中所示。
+**3-** 为您想要在目录、表格或图形列表中列出的报告项目添加自定义属性。
 
-{{% /alert %}}
+```text
+Custom Property Name: IsInList
+Property Value: Boolean
+Custom Property Value: True or False
+```
 
-{{% alert color="primary" %}}
+将当前报告项目标记为按目录或表格或图形列表中的索引列出。
 
-**Custom Property Name** :IsInList
-**Property Value** :Boolean
-**Custom Property Value** : True or False
+```text
+Custom Property Name: Title
+Custom Property Type: String
+```
 
-{{% alert color="primary" %}}
+目录、表格或图形列表中显示的项目标题。
 
-Marks the current report item as listed by index in the table of contents, or the list of tables or figures.
+```text
+Custom Property Name: ListLevel
+Custom Property Type: Integer
+```
 
-{{% /alert %}}
-
-**Custom Property Name** : Title
-**Custom Property Type** : String
-
-{{% alert color="primary" %}}
-
-The item title displayed in the table of contents, list of tables or figures.
-{{% /alert %}}
-
-**Custom Property Name** : ListLevel
-**Custom Property Type** : Integer
-
-{{% alert color="primary" %}}
-
-The level of listed items displayed in the table of contents.
-
-{{% /alert %}}
-
-{{% /alert %}}
+目录中显示的列出项目的级别。

--- a/zh/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
+++ b/zh/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
@@ -1,25 +1,25 @@
 ---
-title: 目录、表格列表或图形
-linktitle: 目录、表格列表或图形
+title: Table of Contents List of Tables or Figures
+linktitle: Table of Contents List of Tables or Figures
 type: docs
 weight: 10
-url: /zh/reportingservices/table-of-contents-list-of-tables-or-figures/
-description: 了解如何使用 Aspose.PDF for Reporting Services 在 PDF 报告中添加目录、表格列表或图形。
-lastmod: "2026-06-19"
+url: /reportingservices/table-of-contents-list-of-tables-or-figures/
+description: Learn how to add a Table of Contents, List of Tables, or Figures in PDF reports using Aspose.PDF for Reporting Services.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Designer 不支持在报告文档中添加目录。使用 Aspose.PDF for Reporting Services，您可以轻松指示 PDF 渲染器生成带有目录、表格列表或图形的 PDF 文档。您可以按照以下步骤进行操作：
+Report Designer does not support adding table of contents for report documents. With Aspose.PDF for Reporting Services you can easily instruct the PDF render to produce PDF documents with Table of Contents, or List of Tables or Figures. You can do it in the following steps:
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-确保 Aspose.Pdf.ListSectionStyle.xml 文件存在于 ```<Instance>```/bin，在哪里 ```<Instance>``` 是 Report Server 的目录。如果文件不存在，请在其中创建。 ```<Instance>```/bin 目录，并将以下标记放入其中。
+Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/bin, where ```<Instance>``` is the directory of the Report Server. If the file does not exist, create it in the ```<Instance>```/bin directory and place the following markup inside.
 
-## 目录
+## Table of Contents
 
-**示例**
+**Example**
 
 ```cs
 <ListSection ListType="TableOfContents">
@@ -41,9 +41,9 @@ Report Designer 不支持在报告文档中添加目录。使用 Aspose.PDF for 
 </ListSection>
 ```
 
-##  表格列表
+##  List of TableS
 
-**示例**
+**Example**
 
 ```cs
 <ListSection ListType="ListOfTables">
@@ -53,9 +53,9 @@ Report Designer 不支持在报告文档中添加目录。使用 Aspose.PDF for 
 </ListSection>
 ```
 
-## 图表列表
+## List of Figures
 
-**示例**
+**Example**
 
 ```cs
  <ListSection ListType="ListOfFigures">
@@ -66,41 +66,40 @@ Report Designer 不支持在报告文档中添加目录。使用 Aspose.PDF for 
 
 ```
 
-请参阅 Aspose.Pdf 在线文档中的 'Working with TOC' 部分。
+Please refer to 'Working with TOC' section of the Aspose.Pdf online documentation.
 
-**2-** 添加报告参数 'IsListSectionSupported'，并将其值设置为 True，如 'List Section' 段落所示。
-**3-** 为您想要列入目录、表格目录或图表目录的报告项添加自定义属性。
+**2-** Add report parameter 'IsListSectionSupported' and set the value to be True as shown in the 'List Section' paragraph.
+**3-** Add custom property for your report item you want to be listed in Table of Contents, List of Tables or Figures.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**自定义属性名称** :IsInList
-**属性值** :Boolean
-**自定义属性值** : True 或 False
+**Custom Property Name** :IsInList
+**Property Value** :Boolean
+**Custom Property Value** : True or False
 
 {{% alert color="primary" %}}
 
-将当前报告项标记为在目录、表格列表或图形列表中按索引列出。
+Marks the current report item as listed by index in the table of contents, or the list of tables or figures.
 
 {{% /alert %}}
 
-**自定义属性名称** : 标题
-**自定义属性类型** : 字符串
+**Custom Property Name** : Title
+**Custom Property Type** : String
 
 {{% alert color="primary" %}}
 
-在目录、表格列表或图形列表中显示的项目标题。
+The item title displayed in the table of contents, list of tables or figures.
 {{% /alert %}}
 
-**自定义属性名称** : 列表级别
-**自定义属性类型** : 整数
+**Custom Property Name** : ListLevel
+**Custom Property Type** : Integer
 
 {{% alert color="primary" %}}
 
-目录中显示的列出项的层级。
+The level of listed items displayed in the table of contents.
 
 {{% /alert %}}
 
 {{% /alert %}}
-

--- a/zh/reportingservices/features/_index.md
+++ b/zh/reportingservices/features/_index.md
@@ -4,14 +4,14 @@ linktitle: 功能
 type: docs
 weight: 30
 url: /zh/reportingservices/features/
-description: 了解 Aspose.PDF for Reporting Services 的关键功能。通过高级 PDF 渲染功能和自定义提升 SSRS 报表。
-lastmod: "2026-06-19"
+description: 了解 Aspose.PDF for Reporting Services 的关键功能。通过高级 PDF 渲染功能和自定义来增强 SSRS 报表。
+lastmod: "2026-07-29"
 ---
 
-**本节包括以下主题：**
-- [全面的 RDL 支持](/pdf/zh/reportingservices/comprehensive-rdl-support/)
-- [参数化报告支持](/pdf/zh/reportingservices/parameterized-report-support/)
-- [自定义报告项支持](/pdf/zh/reportingservices/custom-report-item-support/)
-- [轻松且轻量级部署](/pdf/zh/reportingservices/easy-and-lightweight-deployment/)
-- [世界级免费技术支持](/pdf/zh/reportingservices/world-class-free-technical-support/)
+**此部分包括以下主题：**
 
+- [全面的 RDL 支持](/pdf/zh/reportingservices/comprehensive-rdl-support/)
+- [参数化报表支持](/pdf/zh/reportingservices/parameterized-report-support/)
+- [自定义报表项支持](/pdf/zh/reportingservices/custom-report-item-support/)
+- [轻松且轻量化的部署](/pdf/zh/reportingservices/easy-and-lightweight-deployment/)
+- [世界级的免费技术支持](/pdf/zh/reportingservices/world-class-free-technical-support/)

--- a/zh/reportingservices/features/_index.md
+++ b/zh/reportingservices/features/_index.md
@@ -1,17 +1,17 @@
 ---
-title: 功能
-linktitle: 功能
+title: 特征
+linktitle: 特征
 type: docs
 weight: 30
-url: /zh/reportingservices/features/
-description: 了解 Aspose.PDF for Reporting Services 的关键功能。通过高级 PDF 渲染功能和自定义来增强 SSRS 报表。
-lastmod: "2026-07-29"
+url: /reportingservices/features/
+description: 了解 Aspose.PDF for Reporting Services 的主要功能。通过高级 PDF 渲染功能和自定义增强 SSRS 报告。
+lastmod: "2021-06-05"
 ---
 
-**此部分包括以下主题：**
+**本节包括以下主题：**
 
 - [全面的 RDL 支持](/pdf/zh/reportingservices/comprehensive-rdl-support/)
-- [参数化报表支持](/pdf/zh/reportingservices/parameterized-report-support/)
-- [自定义报表项支持](/pdf/zh/reportingservices/custom-report-item-support/)
-- [轻松且轻量化的部署](/pdf/zh/reportingservices/easy-and-lightweight-deployment/)
-- [世界级的免费技术支持](/pdf/zh/reportingservices/world-class-free-technical-support/)
+- [参数化报告支持](/pdf/zh/reportingservices/parameterized-report-support/)
+- [自定义报告项目支持](/pdf/zh/reportingservices/custom-report-item-support/)
+- [轻松、轻量级部署](/pdf/zh/reportingservices/easy-and-lightweight-deployment/)
+- [世界一流的免费技术支持](/pdf/zh/reportingservices/world-class-free-technical-support/)

--- a/zh/reportingservices/features/comprehensive-rdl-support/_index.md
+++ b/zh/reportingservices/features/comprehensive-rdl-support/_index.md
@@ -5,25 +5,25 @@ type: docs
 weight: 10
 url: /zh/reportingservices/comprehensive-rdl-support/
 description: 在 Aspose.PDF for Reporting Services 中发现全面的 RDL 支持。将复杂的 SQL Server 报表渲染为专业的 PDF。
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
 Aspose.PDF for Reporting Services 支持 RDL 规范。这意味着：
 
-* 无需重新设计或自定义现有报表。
-* 无需使用特定的报表设计器。您可以使用任何 RDL 报表设计器，报表将以您设计的方式精准导出。
+* 无需重新设计或定制现有报表。
+* 无需使用特定的报表设计器。您可以使用任何 RDL 报表设计器，报表将以您设计的方式精确导出。
 
 {{% /alert %}}
 
 ## **支持的 RDL 元素**
-Aspose.PDF for Reporting Services 支持以下 RDL 元素：
+Aspose.PDF for Reporting Services 支持以下 RDL 元素:
 
 - 章节
 - 页眉，页脚
 - 文本框
-- 图片
+- 图像
 - 图表
 - 列表
 - 表格
@@ -34,4 +34,3 @@ Aspose.PDF for Reporting Services 支持以下 RDL 元素：
 - 子报告
 - 仪表面板 (RS2008)
 - Tablix (RS2008)
-

--- a/zh/reportingservices/features/comprehensive-rdl-support/_index.md
+++ b/zh/reportingservices/features/comprehensive-rdl-support/_index.md
@@ -3,34 +3,34 @@ title: 全面的 RDL 支持
 linktitle: 全面的 RDL 支持
 type: docs
 weight: 10
-url: /zh/reportingservices/comprehensive-rdl-support/
-description: 在 Aspose.PDF for Reporting Services 中发现全面的 RDL 支持。将复杂的 SQL Server 报表渲染为专业的 PDF。
-lastmod: "2026-07-29"
+url: /reportingservices/comprehensive-rdl-support/
+description: 了解 Aspose.PDF 中针对 Reporting Services 的全面 RDL 支持。将复杂的 SQL Server 报告呈现为专业的 PDF。
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
 Aspose.PDF for Reporting Services 支持 RDL 规范。这意味着：
 
-* 无需重新设计或定制现有报表。
-* 无需使用特定的报表设计器。您可以使用任何 RDL 报表设计器，报表将以您设计的方式精确导出。
+* 无需重新设计或定制现有报告。
+* 无需使用特定的报表设计器。您可以使用任何 RDL 报表设计器，报表将完全按照您设计的方式导出。
 
 {{% /alert %}}
 
-## **支持的 RDL 元素**
-Aspose.PDF for Reporting Services 支持以下 RDL 元素:
+## 支持的 RDL 元素
+Aspose.PDF for Reporting Services 支持以下 RDL 元素：
 
-- 章节
-- 页眉，页脚
+- 部分
+- 页眉、页脚
 - 文本框
-- 图像
+- 图片
 - 图表
 - 列表
 - 表格
 - 矩阵
-- 样式
+- 风格
 - 矩形
-- 线条
+- 线路
 - 子报告
-- 仪表面板 (RS2008)
-- Tablix (RS2008)
+- 仪表板 (RS2008)
+- 塔布利克斯 (RS2008)

--- a/zh/reportingservices/features/custom-report-item-support/_index.md
+++ b/zh/reportingservices/features/custom-report-item-support/_index.md
@@ -1,21 +1,21 @@
 ---
-title: 自定义报表项支持
-linktitle: 自定义报表项支持
+title: 自定义报告项目支持
+linktitle: 自定义报告项目支持
 type: docs
 weight: 30
-url: /zh/reportingservices/custom-report-item-support/
-description: 在 Aspose.PDF for Reporting Services 中利用自定义报表项支持，轻松实现定制的高质量 PDF 输出。
-lastmod: "2026-07-29"
+url: /reportingservices/custom-report-item-support/
+description: 利用 Aspose.PDF for Reporting Services 中的自定义报表项支持。轻松实现定制的高质量 PDF 输出。
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-根据 RS2016、RS2017、RS2019、RS2022 以及 Power BI 的 RDL 规范，几乎每个报表项都可以通过添加自定义属性来扩展。目前 Aspose.PDF for Reporting Services 2016、2017、2019、2022 和 Power BI 支持以下三种属性：
+在RS2016、RS2017、RS2019、RS2022和Power BI的RDL规范中，几乎每个报表项都可以通过添加自定义属性来扩展。目前，Aspose.PDF for Reporting Services 2016、2017、2019、2022 和 Power BI 支持三个此类属性，即：
 
 - 目录、表格或图形列表。
-- 线条箭头。
+- 线箭头。
 - 脚注/尾注。
 
-了解如何在其中使用它们 [展开报告项属性](/pdf/zh/reportingservices/expand-report-items-properties/) 文章。
+了解如何在 [展开报告项目属性](/pdf/zh/reportingservices/expand-report-items-properties/) 文章。
 
 {{% /alert %}}

--- a/zh/reportingservices/features/custom-report-item-support/_index.md
+++ b/zh/reportingservices/features/custom-report-item-support/_index.md
@@ -4,13 +4,13 @@ linktitle: 自定义报表项支持
 type: docs
 weight: 30
 url: /zh/reportingservices/custom-report-item-support/
-description: 在 Aspose.PDF for Reporting Services 中利用自定义报表项支持。轻松实现量身定制的高质量 PDF 输出。
-lastmod: "2026-06-19"
+description: 在 Aspose.PDF for Reporting Services 中利用自定义报表项支持，轻松实现定制的高质量 PDF 输出。
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-在 RS2016、RS2017、RS2019、RS2022 以及 Power BI 的 RDL 规范中，几乎每个报表项都可以通过添加自定义属性进行扩展。目前 Aspose.Pdf for Reporting Services 2016、2017、2019、2022 和 Power BI 支持以下三种属性，分别是：
+根据 RS2016、RS2017、RS2019、RS2022 以及 Power BI 的 RDL 规范，几乎每个报表项都可以通过添加自定义属性来扩展。目前 Aspose.PDF for Reporting Services 2016、2017、2019、2022 和 Power BI 支持以下三种属性：
 
 - 目录、表格或图形列表。
 - 线条箭头。
@@ -19,4 +19,3 @@ lastmod: "2026-06-19"
 了解如何在其中使用它们 [展开报告项属性](/pdf/zh/reportingservices/expand-report-items-properties/) 文章。
 
 {{% /alert %}}
-

--- a/zh/reportingservices/features/easy-and-lightweight-deployment/_index.md
+++ b/zh/reportingservices/features/easy-and-lightweight-deployment/_index.md
@@ -1,21 +1,21 @@
 ---
-title: 轻松且轻量级部署
-linktitle: 轻松且轻量级部署
+title: 轻松、轻量级部署
+linktitle: 轻松、轻量级部署
 type: docs
 weight: 40
-url: /zh/reportingservices/easy-and-lightweight-deployment/
-description: 了解如何以最小的努力部署 Aspose.PDF for Reporting Services。轻量级设置确保快速实施和高效。
-lastmod: "2026-07-29"
+url: /reportingservices/easy-and-lightweight-deployment/
+description: 了解如何以最少的努力部署 Aspose.PDF for Reporting Services。轻量级设置确保快速实施和效率。
+lastmod: "2021-06-05"
 ---
 
-**Aspose.PDF for Reporting Services** 是 Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 和 Power BI Report Server 的自定义渲染扩展。Aspose.PDF for Reporting Services 提供为单个 MSI 安装程序，可在运行以下任一环境的计算机上进行安装：
+**Aspose.PDF for Reporting Services** 是 Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 和 Power BI Report Server 的自定义渲染扩展。 Aspose.PDF for Reporting Services 作为单个 MSI 安装程序提供，可以安装在运行以下其中一项的计算机上：
 
-- Microsoft SQL Server 2016 Reporting Services  
-- Microsoft SQL Server 2017 Reporting Services  
-- Microsoft SQL Server 2019 Reporting Services  
-- Microsoft SQL Server 2022 Reporting Services  
-- Microsoft Power BI Report Server
+- Microsoft SQL Server 2016 报告服务  
+- Microsoft SQL Server 2017 报告服务  
+- Microsoft SQL Server 2019 报告服务  
+- Microsoft SQL Server 2022 报告服务  
+- Microsoft Power BI 报表服务器
  
-Aspose.PDF for Reporting Services 易于部署和管理，因为它仅由一个 .NET 程序集 Aspose.Pdf.ReportingServices.dll 组成，完全使用 C# 编写，符合 CLS 并且仅包含安全的托管代码。您需要在服务器上安装 .NET Framework 4.8.1。
+Aspose.PDF for Reporting Services 易于部署和管理，因为它仅由一个 .NET 程序集 Aspose.Pdf.ReportingServices.dll 组成，完全用 C# 编写，符合 CLS，并且仅包含安全的托管代码。您需要在服务器上安装.NET Framework 4.8.1。
 
-必须将 Aspose.Pdf.ReportingServices.dll 复制到 ReportServer\\bin 目录，并且必须更新配置文件，以便 Reporting Services 能够识别新的渲染扩展。这些步骤由 Aspose.PDF for Reporting Services 安装程序执行，但您也可以按照本文档后面描述的手动执行这些操作。
+必须将 Aspose.Pdf.ReportingServices.dll 复制到 ReportServer\bin 目录，并且必须更新配置文件，以便 Reporting Services 能够识别新的呈现扩展。这些步骤由 Aspose.PDF for Reporting Services 安装程序执行，但您也可以按照本文档中的进一步描述手动执行这些步骤。

--- a/zh/reportingservices/features/easy-and-lightweight-deployment/_index.md
+++ b/zh/reportingservices/features/easy-and-lightweight-deployment/_index.md
@@ -4,19 +4,18 @@ linktitle: 轻松且轻量级部署
 type: docs
 weight: 40
 url: /zh/reportingservices/easy-and-lightweight-deployment/
-description: 了解如何以最小的工作量部署 Aspose.PDF for Reporting Services。轻量级的设置确保快速实施和高效。
-lastmod: "2026-06-19"
+description: 了解如何以最小的努力部署 Aspose.PDF for Reporting Services。轻量级设置确保快速实施和高效。
+lastmod: "2026-07-29"
 ---
 
-**Aspose.Pdf for Reporting Services** 是 Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 和 Power BI Report Server 的自定义渲染扩展。Aspose.Pdf for Reporting Services 以单个 MSI 安装程序的形式提供，可安装在运行以下任一环境的计算机上：
+**Aspose.PDF for Reporting Services** 是 Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 和 Power BI Report Server 的自定义渲染扩展。Aspose.PDF for Reporting Services 提供为单个 MSI 安装程序，可在运行以下任一环境的计算机上进行安装：
 
 - Microsoft SQL Server 2016 Reporting Services  
 - Microsoft SQL Server 2017 Reporting Services  
 - Microsoft SQL Server 2019 Reporting Services  
-- Microsoft SQL Server 2022 报告服务  
-- Microsoft Power BI 报表服务器
+- Microsoft SQL Server 2022 Reporting Services  
+- Microsoft Power BI Report Server
  
-Aspose.Pdf for Reporting Services 易于部署和管理，因为它仅由一个 .NET 程序集 Aspose.Pdf.ReportingServices.dll 组成，该程序集完全用 C# 编写，符合 CLS 标准，并且只包含安全的托管代码。服务器上必须安装 .NET Framework 4.8.1。
+Aspose.PDF for Reporting Services 易于部署和管理，因为它仅由一个 .NET 程序集 Aspose.Pdf.ReportingServices.dll 组成，完全使用 C# 编写，符合 CLS 并且仅包含安全的托管代码。您需要在服务器上安装 .NET Framework 4.8.1。
 
-必须将 Aspose.Pdf.ReportingServices.dll 复制到 ReportServer\\bin 目录，并且需要更新配置文件，以便 Reporting Services 能识别新的渲染扩展。这些步骤由 Aspose.Pdf for Reporting Services 安装程序自动完成，但您也可以按照本文档后续描述手动执行。
-
+必须将 Aspose.Pdf.ReportingServices.dll 复制到 ReportServer\\bin 目录，并且必须更新配置文件，以便 Reporting Services 能够识别新的渲染扩展。这些步骤由 Aspose.PDF for Reporting Services 安装程序执行，但您也可以按照本文档后面描述的手动执行这些操作。

--- a/zh/reportingservices/features/parameterized-report-support/_index.md
+++ b/zh/reportingservices/features/parameterized-report-support/_index.md
@@ -3,25 +3,25 @@ title: 参数化报告支持
 linktitle: 参数化报告支持
 type: docs
 weight: 20
-url: /zh/reportingservices/parameterized-report-support/
-lastmod: "2026-07-29"
+url: /reportingservices/parameterized-report-support/
+lastmod: "2021-06-05"
 ---
 
-参数化报告是一种接受用于报告处理的输入值的报告。使用参数化报告，您可以根据报告运行时设置的值来更改报告的输出。Aspose.PDF for Reporting Services 支持两种参数：报告服务器参数和报告参数。报告服务器参数用于报告服务器上的所有报告。如果您希望将某些参数仅用于特定报告，则应使用报告参数。
+参数化报表是接受报表处理中使用的输入值的报表。使用参数化报告，您可以根据报告运行时设置的值改变报告的输出。 Aspose.PDF for Reporting Services 支持两种参数：报表服务器参数和报表参数。报表服务器参数用于报表服务器上的所有报表。如果你想让一些参数适合特定的报表，你应该使用报表参数。
 
-目前，Aspose.Pdf 渲染器支持广泛的参数，例如：
+目前，Aspose.Pdf渲染器支持多种参数，例如：
 
-## **支持的参数**
-在当前版本中，Aspose.PDF 渲染支持许多参数方面，具体如下：
+## 支持的参数
+在当前版本中，Aspose.PDF render支持很多方面的参数，它们是：
 
 - 页面方向
-- HTML 格式化
+- HTML 格式
 - 安全属性
-- 页面大小
-- 页面边距大小
+- 页面尺寸
+- 页边距大小
 - 字体嵌入
-- PDF/A 合规性
-- XMP 元数据
+- PDF/A 一致性
+- XMP元数据
 - 调试信息
 
-了解更多关于参数的信息，请参阅 [配置 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/configure-aspose-pdf-for-reporting-services/) 文章。
+从以下位置了解有关参数的更多信息 [为 Reporting Services 配置 Aspose.PDF](/pdf/zh/reportingservices/configure-aspose-pdf-for-reporting-services/) 文章。

--- a/zh/reportingservices/features/parameterized-report-support/_index.md
+++ b/zh/reportingservices/features/parameterized-report-support/_index.md
@@ -4,25 +4,24 @@ linktitle: 参数化报告支持
 type: docs
 weight: 20
 url: /zh/reportingservices/parameterized-report-support/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-参数化报告是一种接受用于报告处理的输入值的报告。使用参数化报告，您可以根据报告运行时设置的值来改变报告的输出。Aspose.Pdf for Reporting Services 支持两种参数：报告服务器参数和报告参数。报告服务器参数用于报告服务器上的所有报告。如果您希望使某些参数适用于特定报告，则应使用报告参数。
+参数化报告是一种接受用于报告处理的输入值的报告。使用参数化报告，您可以根据报告运行时设置的值来更改报告的输出。Aspose.PDF for Reporting Services 支持两种参数：报告服务器参数和报告参数。报告服务器参数用于报告服务器上的所有报告。如果您希望将某些参数仅用于特定报告，则应使用报告参数。
 
-当前，Aspose.Pdf 渲染器支持广泛的参数，例如：
+目前，Aspose.Pdf 渲染器支持广泛的参数，例如：
 
 ## **支持的参数**
-在当前版本中，Aspose.PDF 渲染支持参数的许多方面，包括：
+在当前版本中，Aspose.PDF 渲染支持许多参数方面，具体如下：
 
 - 页面方向
 - HTML 格式化
 - 安全属性
-- 页面尺寸
-- 页面边距尺寸
+- 页面大小
+- 页面边距大小
 - 字体嵌入
 - PDF/A 合规性
 - XMP 元数据
 - 调试信息
 
-了解更多关于参数的信息 [配置 Aspose.PDF 用于 Reporting Services](/pdf/zh/reportingservices/configure-aspose-pdf-for-reporting-services/) 文章。
-
+了解更多关于参数的信息，请参阅 [配置 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/configure-aspose-pdf-for-reporting-services/) 文章。

--- a/zh/reportingservices/features/world-class-free-technical-support/_index.md
+++ b/zh/reportingservices/features/world-class-free-technical-support/_index.md
@@ -1,21 +1,21 @@
 ---
-title: 世界级免费技术支持
-linktitle: 世界级免费技术支持
+title: 世界一流的免费技术支持
+linktitle: 世界一流的免费技术支持
 type: docs
 weight: 50
-url: /zh/reportingservices/world-class-free-technical-support/
-description: 尽情享受 Aspose.PDF for Reporting Services 的世界级免费技术支持。随时获得专家帮助。
-lastmod: "2026-07-29"
+url: /reportingservices/world-class-free-technical-support/
+description: 享受 Aspose.PDF for Reporting Services 的世界一流的免费技术支持。在您需要时随时获取专家帮助。
+lastmod: "2021-06-05"
 ---
 
-Aspose 因其免费且无限的技术支持而闻名，该支持由技术文章、手册、论坛以及随时待命的支持团队和产品开发人员提供保障。如果发布了产品的新版本或 Hot Fix，只要您拥有有效订阅，所有新版本均可免费获取。
+Aspose 以其免费且无限制的技术支持而闻名，并由技术文章、手册、论坛以及随时准备就绪的支持和产品开发人员提供支持。如果产品有新版本或修补程序发布，并且您有有效的订阅，则所有新版本都可以免费获得。
 
-**Aspose.Support Forums** 不仅是解决技术问题的场所，还是与活跃且不断壮大的 Aspose 用户社区参与开发讨论的地方。目前在 Aspose 网站上已有超过 129,000 名用户注册。
+**Aspose.Support 论坛** 不仅可以解决技术问题，还可以与充满活力且不断发展的 Aspose 用户社区一起参与开发讨论。目前，Aspose 网站注册用户超过 129,000 名。
 
-Aspose.Blogs 是查看最新发布信息以及 Aspose 开发者观点的所在。
+Aspose.Blogs 是查找有关最新版本以及 Aspose 开发人员的意见的信息的地方。
 
-Aspose.Support Forums 中有大量活跃的讨论：
+Aspose.Support 论坛中有很多活动：
 
-![todo:image_alt_text](world-class-free-technical-support.png)
+![Free Technical Support](world-class-free-technical-support.png)
 
  

--- a/zh/reportingservices/features/world-class-free-technical-support/_index.md
+++ b/zh/reportingservices/features/world-class-free-technical-support/_index.md
@@ -4,17 +4,17 @@ linktitle: 世界级免费技术支持
 type: docs
 weight: 50
 url: /zh/reportingservices/world-class-free-technical-support/
-description: 享受针对 Aspose.PDF for Reporting Services 的世界级免费技术支持。您可以在任何需要时获得专家帮助。
-lastmod: "2026-06-19"
+description: 尽情享受 Aspose.PDF for Reporting Services 的世界级免费技术支持。随时获得专家帮助。
+lastmod: "2026-07-29"
 ---
 
-Aspose 以其免费且无限的技术支持而闻名，并有技术文章、手册、论坛以及随时待命的支持团队和产品开发者作为后盾。如果发布了新版本或热修复，只要您拥有有效订阅，所有新版本均可免费获取。
+Aspose 因其免费且无限的技术支持而闻名，该支持由技术文章、手册、论坛以及随时待命的支持团队和产品开发人员提供保障。如果发布了产品的新版本或 Hot Fix，只要您拥有有效订阅，所有新版本均可免费获取。
 
-**Aspose.Support Forums** 不仅是解决技术问题的场所，还是与充满活力且不断壮大的 Aspose 用户社区参与开发讨论的地方。目前 Aspose 网站已注册超过 129,000 名用户。
+**Aspose.Support Forums** 不仅是解决技术问题的场所，还是与活跃且不断壮大的 Aspose 用户社区参与开发讨论的地方。目前在 Aspose 网站上已有超过 129,000 名用户注册。
 
-Aspose.Blogs 是获取最新发行信息以及 Aspose 开发者观点的渠道。
+Aspose.Blogs 是查看最新发布信息以及 Aspose 开发者观点的所在。
 
-Aspose.Support Forums 中有大量活动：
+Aspose.Support Forums 中有大量活跃的讨论：
 
 ![todo:image_alt_text](world-class-free-technical-support.png)
 

--- a/zh/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
+++ b/zh/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
@@ -1,19 +1,17 @@
 ---
-title: 安装 Aspose.PDF
-linktitle: 安装 Aspose.PDF
+title: 安装Aspose.PDF
+linktitle: 安装Aspose.PDF
 type: docs
 weight: 50
-url: /zh/reportingservices/install-aspose-pdf-for-reporting-services/
-description: 了解如何安装 Aspose.PDF for Reporting Services。按照本分步指南启用 SSRS 中的 PDF 导出功能。
-lastmod: "2026-07-29"
+url: /reportingservices/install-aspose-pdf-for-reporting-services/
+description: 了解如何安装 Aspose.PDF for Reporting Services。按照此分步指南在 SSRS 中启用 PDF 导出功能。
+lastmod: "2021-06-05"
 ---
-
-{{% alert color="primary" %}}
 
 **本节包括以下主题：**
 
-- [使用 MSI Installer 安装](/pdf/zh/reportingservices/install-with-msi-installer/)
-- [手动安装](/pdf/zh/reportingservices/install-manually/)
-- [使用配置工具进行安装](/pdf/zh/reportingservices/install-with-configuring-tool/)
+- [使用 MSI 安装程序安装](/pdf/reportingservices/install-with-msi-installer/)
+- [手动安装](/pdf/reportingservices/install-manually/)
+- [使用配置工具安装](/pdf/reportingservices/install-with-configuring-tool/)
 
-{{% /alert %}}
+

--- a/zh/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
+++ b/zh/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
@@ -4,17 +4,16 @@ linktitle: 安装 Aspose.PDF
 type: docs
 weight: 50
 url: /zh/reportingservices/install-aspose-pdf-for-reporting-services/
-description: 了解如何安装 Aspose.PDF for Reporting Services。按照本分步指南在 SSRS 中启用 PDF 导出功能。
-lastmod: "2026-06-19"
+description: 了解如何安装 Aspose.PDF for Reporting Services。按照本分步指南启用 SSRS 中的 PDF 导出功能。
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
 **本节包括以下主题：**
 
-- [使用 MSI 安装程序进行安装](/pdf/zh/reportingservices/install-with-msi-installer/)
+- [使用 MSI Installer 安装](/pdf/zh/reportingservices/install-with-msi-installer/)
 - [手动安装](/pdf/zh/reportingservices/install-manually/)
 - [使用配置工具进行安装](/pdf/zh/reportingservices/install-with-configuring-tool/)
 
 {{% /alert %}}
-

--- a/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
+++ b/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
@@ -4,11 +4,10 @@ linktitle: 手动安装
 type: docs
 weight: 20
 url: /zh/reportingservices/install-manually/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-**此部分包括以下主题：**
+**本节包括以下主题：**
 
 - [安装到报告服务器](/pdf/zh/reportingservices/install-to-report-server/)
-
 

--- a/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
+++ b/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
@@ -3,11 +3,11 @@ title: 手动安装
 linktitle: 手动安装
 type: docs
 weight: 20
-url: /zh/reportingservices/install-manually/
-lastmod: "2026-07-29"
+url: /reportingservices/install-manually/
+lastmod: "2021-06-05"
 ---
 
 **本节包括以下主题：**
 
-- [安装到报告服务器](/pdf/zh/reportingservices/install-to-report-server/)
+- [安装到报表服务器](/pdf/reportingservices/install-to-report-server/)
 

--- a/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
+++ b/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
@@ -1,40 +1,40 @@
 ---
-title: 安装到报告服务器
-linktitle: 安装到报告服务器
+title: Install to Report Server
+linktitle: Install to Report Server
 type: docs
 weight: 10
-url: /zh/reportingservices/install-to-report-server/
-lastmod: "2026-06-19"
+url: /reportingservices/install-to-report-server/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-只有在手动安装 Aspose.PDF for Reporting Services（而非使用 MSI 安装程序）时，您才需要按照以下步骤进行。MSI 安装程序会自动执行所有必要的安装和注册操作。
+You only need to follow these steps if you install Aspose.PDF for Reporting Services manually, not using the MSI installer. MSI installer performs all necessary installation and registration actions automatically.
 
 {{% /alert %}}
 
-在以下步骤中，您需要复制并修改 Microsoft SQL Server Reporting Services 所在目录中的文件。zip 包中的 SSRS 2016 程序集位于 \Bin\SSRS2016 目录；SSRS 2017 程序集位于 \Bin\SSRS2017 目录；SSRS 2019 程序集位于 \Bin\SSRS2019 目录；SSRS 2022 程序集位于 \Bin\SSRS2022 目录；Power BI Report Server 程序集位于 \Bin\PowerBI 目录。 
+In the following steps, you will need to copy and modify files in the directory where Microsoft SQL Server Reporting Services is installed. The SSRS 2016 assembly is located in the \Bin\SSRS2016 directory of the zip package; the SSRS 2017 assembly is located in the \Bin\SSRS2017 directory; the SSRS 2019 assembly is located in the \Bin\SSRS2019 directory; the SSRS 2022 assembly is located in the \Bin\SSRS2022 directory; the Power BI Report Server assembly is located in the \Bin\PowerBI directory. 
 
 {{% alert color="primary" %}}
 
-**Step 1.** 定位 Report Server 安装目录。Microsoft SQL Server 的根目录通常是 C:\Program Files\Microsoft SQL Server。后续处理在 Reporting Services 2016、Reporting Services 2017 及以后版本，以及 Power BI Report Server 中略有不同：
+**Step 1.** Locate the Report Server installation directory. The root directory for Microsoft SQL Server is usually C:\Program Files\Microsoft SQL Server. Further process is slightly different for Reporting Services 2016, Reporting Services 2017 and later, and Power BI Report Server:
 
-- Report Server 2016 默认安装在 C:\\Program Files\\Microsoft SQL Server\\MSRS13.MSSQLSERVER\\Reporting Services\\ReportServer 目录。如果您使用自定义命名实例而不是默认实例，则默认路径为 C:\\Program Files\\Microsoft SQL Server\\MSRS13.[SSRSInstanceName]\\Reporting Services\\ReportServer
-- Report Server 2017 及以后版本默认安装在 C:\\Program Files\\Microsoft SQL Server Reporting Services\\SSRS\\ReportServer 目录。
-- Power BI Report Server 默认安装在 C:\\Program Files\\Microsoft Power BI Report Server\\PBIRS\\ReportServer 目录。
+- Report Server 2016 by default is installed in the C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer directory. If you are using custom named instances instead of the default one, the default path will be C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
+- Report Server 2017 and later by default is installed in the C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer directory.
+- Power BI Report Server by default is installed in the C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer directory.
 
-在以下文本中，报告服务的安装目录（上述路径之一）将被引用为 ```<Instance>```.
+In the following text the installation directory of the Reporting Services (one of the aforementioned paths) will be referenced to as ```<Instance>```.
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Step 2.** 复制相应 SSRS 版本的 Aspose.Pdf.ReportingServices.dll 到 ```<Instance>```\bin 文件夹。
+**Step 2.** Copy Aspose.Pdf.ReportingServices.dll for the corresponding SSRS version to the ```<Instance>```\bin folder.
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**第3步。** 将 Aspose.Pdf for Reporting Services 注册为渲染扩展。打开 ```<Instance>```\rsreportserver.config 文件并将以下行添加到 ```<Render>``` 元素：
+**Step 3.** Register Aspose.PDF for Reporting Services as a rendering extension. Open the ```<Instance>```\rsreportserver.config file and add the following lines into the ```<Render>``` element:
 {{% /alert %}}
 
-**示例**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -49,10 +49,10 @@ lastmod: "2026-06-19"
 {{< /highlight >}}
 
 {{% alert color="primary" %}}
-**Step 4.** 为 Reporting Services 提供 Aspose.Pdf 并授予执行权限。打开 ```<Instance>```\\rssrvpolicy.config 文件，并将以下文本作为第二至外层的最后一项添加 ```<CodeGroup>``` 元素（应该是 ```<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):```
+**Step 4.** Provide Aspose.PDF for Reporting Services with permissions to execute. Open the ```<Instance>```\rssrvpolicy.config file and add the following text as the last item in the second to outer ```<CodeGroup>``` element (which should be ```<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):```
 {{% /alert %}}
 
-**示例**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -81,20 +81,16 @@ Name="Aspose.Pdf_for_Reporting_Services" Description="This code group grants ful
 {{< /highlight >}}
 
 {{% alert color="primary" %}}
-**步骤 5.** 验证 Aspose.Pdf for Reporting Services 已成功安装。打开 Reporting Services Web 门户并检查报告的可用导出格式列表。您可以通过启动 web 浏览器并在地址栏中键入 Reporting Services Web 门户的 URL 来启动该门户（默认情况下它是 http://```<Reporting_Services_server_name>```/reports/)。 在您的 Web 门户中选择一个可用的报表，然后展开 Export 下拉列表。您应该会看到包括 Aspose.Pdf for Reporting Services 扩展提供的导出格式列表。请选择 PDF via Aspose.PDF 项目。
+**Step 5.** Verify that Aspose.PDF for Reporting Services was installed successfully. Open the Reporting Services web portal and check the list of available export formats for a report. You can launch the web portal by starting a web browser and typing the Reporting Services web portal URL in the address bar (by default it is http://```<Reporting_Services_server_name>```/reports/). Select one of the reports available in your web portal and pull the Export dropdown list. You should see the list of export formats including the ones provided by the Aspose.PDF for Reporting Services extension. Select PDF via Aspose.PDF item.
 
  
 {{% /alert %}}
 
 ![todo:image_alt_text](install-to-report-server_1.png)
 
-点击所选项。它将以所选格式生成报告，发送给客户端，并根据您的浏览器设置，要么显示保存文件对话框让您选择导出报告的保存位置，要么自动将文件下载到您的下载文件夹。
+Click the selected item. It will generate the report in the selected format, send it to the client, and, depending on your web browser settings, either show you the Save File dialog to choose where to save the exported report, or automatically download the file to the your Downloads folder.
 
 {{% alert color="primary" %}}
-恭喜，您已成功安装 Aspose.Pdf for Reporting Services 并将报告导出为 PDF 文档！
+Congratulations, you’ve successfully installed Aspose.PDF for Reporting Services and exported a report as a PDF document!
 {{% /alert %}}
-
-
-
-
 

--- a/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
+++ b/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Install to Report Server
-linktitle: Install to Report Server
+title: 安装到报表服务器
+linktitle: 安装到报表服务器
 type: docs
 weight: 10
 url: /reportingservices/install-to-report-server/
@@ -9,52 +9,38 @@ lastmod: "2021-06-05"
 
 {{% alert color="primary" %}}
 
-You only need to follow these steps if you install Aspose.PDF for Reporting Services manually, not using the MSI installer. MSI installer performs all necessary installation and registration actions automatically.
+如果您手动安装 Aspose.PDF for Reporting Services，而不是使用 MSI 安装程序，则只需执行这些步骤。 MSI 安装程序自动执行所有必要的安装和注册操作。
 
 {{% /alert %}}
 
-In the following steps, you will need to copy and modify files in the directory where Microsoft SQL Server Reporting Services is installed. The SSRS 2016 assembly is located in the \Bin\SSRS2016 directory of the zip package; the SSRS 2017 assembly is located in the \Bin\SSRS2017 directory; the SSRS 2019 assembly is located in the \Bin\SSRS2019 directory; the SSRS 2022 assembly is located in the \Bin\SSRS2022 directory; the Power BI Report Server assembly is located in the \Bin\PowerBI directory. 
+在以下步骤中，您将需要复制并修改 Microsoft SQL Server Reporting Services 安装目录中的文件。 SSRS 2016程序集位于zip包的\Bin\SSRS2016目录下； SSRS 2017 程序集位于 \Bin\SSRS2017 目录中； SSRS 2019 程序集位于 \Bin\SSRS2019 目录中； SSRS 2022 程序集位于 \Bin\SSRS2022 目录中； Power BI 报表服务器程序集位于 \Bin\PowerBI 目录中。
 
-{{% alert color="primary" %}}
+**步骤 1.** 找到报表服务器安装目录。 Microsoft SQL Server 的根目录通常为C:\Program Files\Microsoft SQL Server。 Reporting Services 2016、Reporting Services 2017 及更高版本以及 Power BI 报表服务器的进一步流程略有不同：
 
-**Step 1.** Locate the Report Server installation directory. The root directory for Microsoft SQL Server is usually C:\Program Files\Microsoft SQL Server. Further process is slightly different for Reporting Services 2016, Reporting Services 2017 and later, and Power BI Report Server:
+- 默认情况下，Report Server 2016 安装在 C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer 目录中。如果您使用自定义命名实例而不是默认实例，则默认路径将为 C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
+- 默认情况下，Report Server 2017 及更高版本安装在 C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer 目录中。
+- Power BI 报表服务器默认安装在 C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer 目录中。
 
-- Report Server 2016 by default is installed in the C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer directory. If you are using custom named instances instead of the default one, the default path will be C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
-- Report Server 2017 and later by default is installed in the C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer directory.
-- Power BI Report Server by default is installed in the C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer directory.
+在下文中，Reporting Services 的安装目录（上述路径之一）将被引用为 `<Instance>`。
 
-In the following text the installation directory of the Reporting Services (one of the aforementioned paths) will be referenced to as ```<Instance>```.
-{{% /alert %}}
+**步骤2.** 将相应SSRS版本的Aspose.Pdf.ReportingServices.dll复制到`<Instance>\bin`文件夹。
 
-{{% alert color="primary" %}}
-**Step 2.** Copy Aspose.Pdf.ReportingServices.dll for the corresponding SSRS version to the ```<Instance>```\bin folder.
-{{% /alert %}}
+**步骤 3.** 将 Aspose.PDF for Reporting Services 注册为渲染扩展。打开 `<Instance>\rsreportserver.config` 文件并将以下行添加到 `<Render>` 元素中：
 
-{{% alert color="primary" %}}
-**Step 3.** Register Aspose.PDF for Reporting Services as a rendering extension. Open the ```<Instance>```\rsreportserver.config file and add the following lines into the ```<Render>``` element:
-{{% /alert %}}
+## 例子
 
-**Example**
-
-{{< highlight csharp >}}
-
- <Render>
+```xml
+<Render>
 ...
-<!--Start here.-->
-
 <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices"/>
-
 </Render>
+```
 
-{{< /highlight >}}
+**步骤 4.** 为 Aspose.PDF for Reporting Services 提供执行权限。打开`<Instance>\rssrvpolicy.config` 文件并将以下文本添加为​​第二个外部`<CodeGroup>` 元素中的最后一项，该元素应为`<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):`
 
-{{% alert color="primary" %}}
-**Step 4.** Provide Aspose.PDF for Reporting Services with permissions to execute. Open the ```<Instance>```\rssrvpolicy.config file and add the following text as the last item in the second to outer ```<CodeGroup>``` element (which should be ```<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):```
-{{% /alert %}}
+## 例子
 
-**Example**
-
-{{< highlight csharp >}}
+```xml
 
  <CodeGroup>
 ...
@@ -77,20 +63,14 @@ Name="Aspose.Pdf_for_Reporting_Services" Description="This code group grants ful
 </CodeGroup>
 
 </CodeGroup>
+```
 
-{{< /highlight >}}
+**步骤 5.** 验证 Aspose.PDF for Reporting Services 是否已成功安装。打开 Reporting Services Web 门户并检查报表的可用导出格式列表。您可以通过启动 Web 浏览器并在地址栏中键入 Reporting Services Web 门户 URL（默认情况下为http://@@KEEP_0@@/reports/).）来启动 Web 门户。选择 Web 门户中可用的报告之一并拉出“导出”下拉列表。您应该看到导出格式列表，包括 Aspose.PDF for Reporting Services 扩展提供的格式。通过 Aspose.PDF 项选择 PDF。
 
-{{% alert color="primary" %}}
-**Step 5.** Verify that Aspose.PDF for Reporting Services was installed successfully. Open the Reporting Services web portal and check the list of available export formats for a report. You can launch the web portal by starting a web browser and typing the Reporting Services web portal URL in the address bar (by default it is http://```<Reporting_Services_server_name>```/reports/). Select one of the reports available in your web portal and pull the Export dropdown list. You should see the list of export formats including the ones provided by the Aspose.PDF for Reporting Services extension. Select PDF via Aspose.PDF item.
+![Install to report server](install-to-report-server_1.png)
 
- 
-{{% /alert %}}
+单击所选项目。它将以所选格式生成报告，将其发送到客户端，并且根据您的 Web 浏览器设置，显示“保存文件”对话框以选择保存导出报告的位置，或自动将文件下载到您的“下载”文件夹。
 
-![todo:image_alt_text](install-to-report-server_1.png)
+恭喜，您已成功安装 Aspose.PDF for Reporting Services 并将报告导出为 PDF 文档！
 
-Click the selected item. It will generate the report in the selected format, send it to the client, and, depending on your web browser settings, either show you the Save File dialog to choose where to save the exported report, or automatically download the file to the your Downloads folder.
-
-{{% alert color="primary" %}}
-Congratulations, you’ve successfully installed Aspose.PDF for Reporting Services and exported a report as a PDF document!
-{{% /alert %}}
 

--- a/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
+++ b/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
@@ -1,25 +1,24 @@
 ---
-title: 使用配置工具进行安装
-linktitle: 使用配置工具进行安装
+title: 使用配置工具安装
+linktitle: 使用配置工具安装
 type: docs
 weight: 30
 url: /zh/reportingservices/install-with-configuring-tool/
-description: 使用配置工具无缝集成的 Aspose.PDF for Reporting Services 安装分步指南。
-lastmod: "2026-06-19"
+description: 使用配置工具无缝集成 Aspose.PDF for Reporting Services 的分步安装指南。
+lastmod: "2026-07-29"
 ---
 
-Aspose.PDF for Reporting Services 配置工具可以帮助您为任何受支持的报表服务器 (RS) 版本配置 Aspose.PDF for Reporting Services 扩展。目前支持 RS2016、RS2017、RS2019、RS2022 和 Power BI Report Server。该配置工具需要 .NET Framework 4.8。
+Aspose.PDF for Reporting Services 配置工具可以帮助您为所有受支持的报表服务器（RS）版本配置 Aspose.PDF for Reporting Services 扩展。目前它支持 RS2016、RS2017、RS2019、RS2022 以及 Power BI Report Server。该配置工具需要 .NET Framework 4.8。
 
-如果您想安装扩展并在报表服务器上注册它，请选择 \u0027Register\u0027 操作类型。若要取消注册并卸载扩展，请选择 \u0027Unregister\u0027 操作类型。
+如果您想安装扩展并在报表服务器上注册，请选择 ‘Register’ 操作类型。要注销并卸载扩展，请选择 ‘Unregister’ 操作类型。
 
 ![todo:image_alt_text](install-with-configuring-tool_1.png)
 
 **以下步骤详细描述了如何使用它：**
 
-1. 输入或浏览 Aspose.Pdf for Reporting Services 扩展的 DLL 文件路径；
-1. 选择相应的操作类型：Register 或 Unregister；
-1. 选择对应于您想要配置的 Report Server 版本的选项卡。请确保您选择的 DLL 文件适用于您的 RS 版本。如果机器上未安装所请求的产品版本，配置工具会以提示的形式通知您。如果您正在为指定的 RS2016 实例（而非默认的 \u0027MSSQLSERVER\u0027 实例）配置扩展，请输入自定义实例名称，然后按下 \u0027Refresh\u0027 按钮。
-1. 确保底部文本框中显示的配置文件路径和名称是正确的。如果不正确，您可以按下 \u0027Refresh\u0027 按钮尝试重新查找 RS 实例，或手动查找它们。
-1. 按下 \u0027Config\u0027 按钮。工具将尝试执行所请求的配置，并告知您配置是否成功。
+1. 输入或浏览 Aspose.PDF for Reporting Services 扩展的 DLL 文件路径；
+1. 选择相应的操作类型：注册或注销；
+1. 选择对应于您要配置的报表服务器版本的选项卡。请确保您选择的 DLL 文件适用于您的 RS 版本。如果机器上未安装所需版本的产品，配置工具会以提示形式通知您。如果您正在为命名的 RS2016 实例（而非默认的 \u0027MSSQLSERVER\u0027 实例）配置扩展，请输入自定义实例名称，然后点击 \u0027Refresh\u0027 按钮。
+1. 确保底部文本框中显示的配置文件路径和名称正确。如果不正确，您可以按下 \u0027Refresh\u0027 按钮再次尝试查找 RS 实例，或者手动查找它们。
+1. 按下 \u0027Config\u0027 按钮。工具现在将尝试执行请求的配置，并会告知您配置是否成功。
  
-

--- a/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
+++ b/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
@@ -3,22 +3,21 @@ title: 使用配置工具安装
 linktitle: 使用配置工具安装
 type: docs
 weight: 30
-url: /zh/reportingservices/install-with-configuring-tool/
-description: 使用配置工具无缝集成 Aspose.PDF for Reporting Services 的分步安装指南。
-lastmod: "2026-07-29"
+url: /reportingservices/install-with-configuring-tool/
+description: 使用配置工具安装 Aspose.PDF for Reporting Services 的分步指南以实现无缝集成。
+lastmod: "2021-06-05"
 ---
 
-Aspose.PDF for Reporting Services 配置工具可以帮助您为所有受支持的报表服务器（RS）版本配置 Aspose.PDF for Reporting Services 扩展。目前它支持 RS2016、RS2017、RS2019、RS2022 以及 Power BI Report Server。该配置工具需要 .NET Framework 4.8。
+Aspose.PDF for Reporting Services 配置工具可以帮助您为任何受支持的报表服务器 (RS) 版本配置 Aspose.PDF for Reporting Services 扩展。目前它支持RS2016、RS2017、RS2019、RS2022和Power BI报表服务器。配置工具需要 .NET Framework 4.8。
 
-如果您想安装扩展并在报表服务器上注册，请选择 ‘Register’ 操作类型。要注销并卸载扩展，请选择 ‘Unregister’ 操作类型。
+如果要安装扩展并将其注册到报表服务器，请选择 `Register` 操作类型。要取消注册和卸载扩展，请选择 `Unregister` 操作类型。
 
-![todo:image_alt_text](install-with-configuring-tool_1.png)
+![Install with configuring tool](install-with-configuring-tool_1.png)
 
 **以下步骤详细描述了如何使用它：**
 
-1. 输入或浏览 Aspose.PDF for Reporting Services 扩展的 DLL 文件路径；
-1. 选择相应的操作类型：注册或注销；
-1. 选择对应于您要配置的报表服务器版本的选项卡。请确保您选择的 DLL 文件适用于您的 RS 版本。如果机器上未安装所需版本的产品，配置工具会以提示形式通知您。如果您正在为命名的 RS2016 实例（而非默认的 \u0027MSSQLSERVER\u0027 实例）配置扩展，请输入自定义实例名称，然后点击 \u0027Refresh\u0027 按钮。
-1. 确保底部文本框中显示的配置文件路径和名称正确。如果不正确，您可以按下 \u0027Refresh\u0027 按钮再次尝试查找 RS 实例，或者手动查找它们。
-1. 按下 \u0027Config\u0027 按钮。工具现在将尝试执行请求的配置，并会告知您配置是否成功。
- 
+1. 输入或浏览Aspose.PDF for Reporting Services扩展的DLL文件的路径；
+1. 选择对应的动作类型：注册或取消注册；
+1. 选择与您要配置的报表服务器版本相对应的选项卡。请确保您选择了适用于您的 RS 版本的 DLL 文件。如果机器上没有安装所请求的产品版本，配置工具会提示您。如果您要为指定的 RS2016 实例（不是默认的“MSSQLSERVER”实例）配置扩展，请输入自定义实例名称，然后按“刷新”按钮。
+1. 确保底部文本框中显示的配置文件路径和名称正确。如果没有，您可以按“刷新”按钮再次尝试查找 RS 实例，或者您可以手动查找它们。
+1. 按“配置”按钮。该工具现在将尝试进行所请求的配置，并通知您配置是否成功。

--- a/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
+++ b/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
@@ -5,20 +5,19 @@ type: docs
 weight: 10
 url: /zh/reportingservices/install-with-msi-installer/
 description: 了解如何使用 MSI 安装程序安装 Aspose.PDF for Reporting Services。这是一份快速设置的简明指南。
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-您可以使用 MSI 安装程序来安装 Aspose.Pdf for Reporting Services。运行 Aspose.Pdf.ReportingServices.msi 并按照安装程序提供的步骤进行操作。安装程序会将程序集和其他文件复制到指定目录，并在 Reporting Services 的默认实例上安装该产品。除非您想按照 ‘Configure Aspose.Pdf for Reporting Services’ 部分所述添加特殊配置参数，否则无需手动复制或修改任何文件。
+您可以使用 MSI 安装程序来安装 Aspose.PDF for Reporting Services。运行 Aspose.Pdf.ReportingServices.msi 并按照安装程序提供的步骤进行操作。安装程序会将程序集和其他文件复制到指定目录，并在 Reporting Services 的默认实例上安装该产品。除非您想按照‘Configure Aspose.PDF for Reporting Services’部分中描述的方式添加特殊配置参数，否则无需手动复制或修改任何文件。
 
-自动安装是大多数情况下最好的选项。然而，在某些情况下您可能需要手动安装产品，例如：
+自动安装是适用于大多数情况的最佳选项。不过，在某些情况下您可能需要手动安装产品，例如：
  
 - 由于 I/O 安全问题，自动安装失败。
-- 您需要在 Reporting Services 2016 的命名实例（非默认实例）或多个实例上安装该产品。
-- 您升级到最新版本，只想替换程序集，而不是使用 MSI 安装程序卸载旧版本再安装新版本。
+- 您需要在 Reporting Services 2016 的命名（非默认）实例或多个实例上安装该产品。
+- 您升级到最新版本，只想替换程序集，而不是使用 MSI 安装程序卸载旧版本并安装新版本。
  
 {{% alert color="primary" %}}
 
-注意：请留意，在后者情况下，您可能会导致其他组件（例如离线文档）未升级到相应的版本。
+注意：请注意，在后者的情况下，您可能会导致其他组件（例如离线文档）未升级到相应的版本。
 
 {{% /alert %}}
-

--- a/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
+++ b/zh/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
@@ -1,23 +1,23 @@
 ---
-title: 使用 MSI 安装程序进行安装
-linktitle: 使用 MSI 安装程序进行安装
+title: 使用 MSI 安装程序安装
+linktitle: 使用 MSI 安装程序安装
 type: docs
 weight: 10
-url: /zh/reportingservices/install-with-msi-installer/
-description: 了解如何使用 MSI 安装程序安装 Aspose.PDF for Reporting Services。这是一份快速设置的简明指南。
-lastmod: "2026-07-29"
+url: /reportingservices/install-with-msi-installer/
+description: 了解如何使用 MSI 安装程序安装 Aspose.PDF for Reporting Services。快速设置的简单指南。
+lastmod: "2021-06-05"
 ---
 
-您可以使用 MSI 安装程序来安装 Aspose.PDF for Reporting Services。运行 Aspose.Pdf.ReportingServices.msi 并按照安装程序提供的步骤进行操作。安装程序会将程序集和其他文件复制到指定目录，并在 Reporting Services 的默认实例上安装该产品。除非您想按照‘Configure Aspose.PDF for Reporting Services’部分中描述的方式添加特殊配置参数，否则无需手动复制或修改任何文件。
+您可以使用 MSI 安装程序安装 Aspose.PDF for Reporting Services。运行 Aspose.Pdf.ReportingServices.msi 并按照安装程序提供的步骤进行操作。安装程序会将程序集和其他文件复制到指定目录，并将产品安装在 Reporting Services 的默认实例上。您不需要手动复制或修改任何文件，除非您想要添加特殊配置参数，如“为 Reporting Services 配置 Aspose.PDF”部分中所述。
 
-自动安装是适用于大多数情况的最佳选项。不过，在某些情况下您可能需要手动安装产品，例如：
- 
+自动安装是在大多数情况下有效的最佳选择。但是，在某些情况下您可能需要手动安装该产品，例如：
+
 - 由于 I/O 安全问题，自动安装失败。
-- 您需要在 Reporting Services 2016 的命名（非默认）实例或多个实例上安装该产品。
-- 您升级到最新版本，只想替换程序集，而不是使用 MSI 安装程序卸载旧版本并安装新版本。
+- 您需要在 Reporting Services 2016 的指定（非默认）实例或多个实例上安装该产品。
+- 您升级到最新版本，只想替换程序集，而不是卸载旧版本并使用 MSI 安装程序安装新版本。
  
 {{% alert color="primary" %}}
 
-注意：请注意，在后者的情况下，您可能会导致其他组件（例如离线文档）未升级到相应的版本。
+注意：请注意，在后一种情况下，您可能会遇到其他组件（例如离线文档）未升级到相应版本的情况。
 
 {{% /alert %}}

--- a/zh/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
+++ b/zh/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
@@ -1,23 +1,23 @@
 ---
-title: 许可证
-linktitle: 许可证
+title: License
+linktitle: License
 
 type: docs
 weight: 70
-url: /zh/reportingservices/license-aspose-pdf-for-reporting-services/
-description: 了解 Aspose.PDF for Reporting Services 的授权选项。了解如何激活许可证并解锁全部功能。
-lastmod: "2026-06-19"
+url: /reportingservices/license-aspose-pdf-for-reporting-services/
+description: Understand licensing options for Aspose.PDF for Reporting Services. Find out how to activate your license and unlock full functionality.
+lastmod: "2021-06-05"
 ---
 
-**Aspose.Pdf for Reporting Services** 评估版提供与正式版相同的功能集合，唯一区别是使用评估版时生成的 PDF 中会出现评估水印。请访问我们的网站，下载产品版本，并在评估模式下开始探索我们完整功能集的产品。
+**Aspose.PDF for Reporting Services** evaluation version provide the same set of features as present in Licensed version, except for the evaluation watermark in resultant PDF when using evaluation version. Please visit our website and download the product version and start exploring our product with complete set of features in an evaluation mode.
 
-当您对评估满意时， [购买许可证](https://purchase.aspose.com/buy). 在购买之前，请确保您已了解并同意许可证订阅条款。
+When you are happy with your evaluation, [buy a license](https://purchase.aspose.com/buy). Before purchasing, make sure you understand and agree to the license subscription terms.
 
-许可证将在订单付款后可从订单页面下载。许可证是一个明文、经过数字签名的 XML 文件。许可证包含诸如客户名称、购买的产品以及许可证类型等信息。请勿修改许可证文件的内容，因为这将导致许可证失效。
+The license will be available for download from the order page after the order is paid. The license is a clear text, digitally signed XML file. The license contains information such as the client's name, the purchased product and the type of the license. Do not modify the content of the license file as it will invalidate the license.
 
-## 服务器授权
+## Licensing a Server
 
-下载许可证文件并将其复制到 C:\Program Files\Microsoft SQL Server\```<Instance>``\Reporting Services\ReportServer\bin, or C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin, or C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin folder on the server (the same folder where the Aspose.Pdf.ReportingServices.dll is placed).
+Download the license file and copy it to the C:\Program Files\Microsoft SQL Server\```<Instance>``\Reporting Services\ReportServer\bin, or C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin, or C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin folder on the server (the same folder where the Aspose.Pdf.ReportingServices.dll is placed).
 
 ```<Instance>``` is the subdirectory name that corresponds to the Microsoft SQL Server 2016 instance you want to license.
 
@@ -50,4 +50,3 @@ Please note that that supported license file names are Aspose.PDF.ReportingServi
 You may also request a 30 days temporary license to test the product. Please visit the following link for more information on how to get Temporary license. [Get a Temporary License](https://purchase.aspose.com/temporary-license).
 
 {{% /alert %}}
-

--- a/zh/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
+++ b/zh/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
@@ -1,52 +1,50 @@
 ---
-title: License
-linktitle: License
+title: 执照
+linktitle: 执照
 
 type: docs
 weight: 70
 url: /reportingservices/license-aspose-pdf-for-reporting-services/
-description: Understand licensing options for Aspose.PDF for Reporting Services. Find out how to activate your license and unlock full functionality.
+description: 了解 Aspose.PDF for Reporting Services 的许可选项。了解如何激活您的许可证并解锁全部功能。
 lastmod: "2021-06-05"
 ---
 
-**Aspose.PDF for Reporting Services** evaluation version provide the same set of features as present in Licensed version, except for the evaluation watermark in resultant PDF when using evaluation version. Please visit our website and download the product version and start exploring our product with complete set of features in an evaluation mode.
+**Aspose.PDF for Reporting Services** 评估版本提供与许可版本相同的功能集，但使用评估版本时生成的 PDF 中的评估水印除外。请访问我们的网站并下载产品版本，并开始在评估模式下探索我们具有完整功能的产品。
 
-When you are happy with your evaluation, [buy a license](https://purchase.aspose.com/buy). Before purchasing, make sure you understand and agree to the license subscription terms.
+如果您对评估感到满意，请[购买许可证](https://purchase.aspose.com/buy)。购买之前，请确保您理解并同意许可证订阅条款。
 
-The license will be available for download from the order page after the order is paid. The license is a clear text, digitally signed XML file. The license contains information such as the client's name, the purchased product and the type of the license. Do not modify the content of the license file as it will invalidate the license.
+订单付款后，即可从订单页面下载许可证。该许可证是经过数字签名的明文 XML 文件。许可证包含客户名称、购买的产品和许可证类型等信息。请勿修改许可证文件的内容，否则许可证将失效。
 
-## Licensing a Server
+## 授权服务器
 
-Download the license file and copy it to the C:\Program Files\Microsoft SQL Server\```<Instance>``\Reporting Services\ReportServer\bin, or C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin, or C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin folder on the server (the same folder where the Aspose.Pdf.ReportingServices.dll is placed).
+下载许可证文件并将其复制到服务器上的 C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\bin 或 C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin 或 C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin 文件夹（与许可证所在的文件夹相同） Aspose.Pdf.ReportingServices.dll 已放置）。
 
-```<Instance>``` is the subdirectory name that corresponds to the Microsoft SQL Server 2016 instance you want to license.
+`<Instance>` 是与您要许可的 Microsoft SQL Server 2016 实例对应的子目录名称。
 
-The default instance directory for Microsoft SQL Server 2016 is MSRS13.MSSQLSERVER.
-For the Microsoft SQL Server 2017 and later the default instance path is C:\Program Files\Microsoft SQL Server\SSRS.
-For the Power BI Report Server the default instance path is C:\Program Files\Microsoft Power BI Report Server\PBIRS.
+Microsoft SQL Server 2016 的默认实例目录是 MSRS13.MSSQLSERVER。
+对于 Microsoft SQL Server 2017 及更高版本，默认实例路径为 C:\Program Files\Microsoft SQL Server\SSRS。
+对于 Power BI 报表服务器，默认实例路径为 C:\Program Files\Microsoft Power BI 报表服务器\PBIRS。
 
-**PDF generated using “Territory sales drilldown” report**
+**使用“区域销售深入分析”报告生成的 PDF**
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_1.png)
+![License-Territory sales drilldown](license-aspose-pdf-for-reporting-services_1.png)
 
+**使用“销售订单详细信息”报告生成 PDF**
 
-**PDF generated using “Sales Order details” report**
+![License-Sales Order details](license-aspose-pdf-for-reporting-services_2.png)
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_2.png)
+如果初始化许可证时出现问题，则会在生成的 PDF 文档中显示评估水印，如下所示。
 
-If there is a problem while initializing the license, an evaluation watermark is displayed in the resultant PDF document as specified below.
+**使用带有水印的“区域销售深入分析”生成的 PDF 文档**
 
-**PDF document generated using “Territory Sales Drilldown” with watermark**
+![License-Territory Sales Drilldown](license-aspose-pdf-for-reporting-services_3.png)
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_3.png)
+请注意，支持的许可证文件名为 Aspose.PDF.ReportingServices.lic、Aspose.Total.ReportingServices.lic 和 Aspose.Total.Product.Family.lic。如果该文件有任何其他名称，请重命名。
 
-Please note that that supported license file names are Aspose.PDF.ReportingServices.lic, Aspose.Total.ReportingServices.lic and Aspose.Total.Product.Family.lic. If the file has any other name, please rename it.
-
-
-## Temporary License
+## 临时牌照
 
 {{% alert color="primary" %}}
 
-You may also request a 30 days temporary license to test the product. Please visit the following link for more information on how to get Temporary license. [Get a Temporary License](https://purchase.aspose.com/temporary-license).
+您还可以请求 30 天的临时许可证来测试产品。请访问以下链接，了解有关如何获得临时许可证的更多信息。 [获取临时许可证](https://purchase.aspose.com/temporary-license)。
 
 {{% /alert %}}

--- a/zh/reportingservices/product-overview/_index.md
+++ b/zh/reportingservices/product-overview/_index.md
@@ -1,11 +1,11 @@
 ---
-title: 产品概览
-linktitle: 产品概览
+title: 产品概述
+linktitle: 产品概述
 type: docs
 weight: 10
 url: /zh/reportingservices/product-overview/
-description: Aspose.PDF for Reporting Services 概述 – 一个用于将 SSRS 报表渲染为 PDF 并具备高级布局功能的综合解决方案。
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services 的概述——一种综合解决方案，用于将 SSRS 报表渲染为 PDF，并具备高级布局功能。
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
@@ -16,16 +16,15 @@ lastmod: "2026-06-19"
 
 ## 欢迎使用 Aspose.PDF for Reporting Services！
 
-Microsoft SQL Server Reporting Services 满足了许多组织面临的需求——构建商业智能和报告解决方案的需求。迄今为止，开发人员必须将报告嵌入其应用程序中，或组织必须购买昂贵且有时存在问题的第三方报告解决方案。现在，Microsoft SQL Server Reporting Services 提供了一个完整的企业级报告分发解决方案，使企业能够更好、更快地做出决策。
+Microsoft SQL Server Reporting Services 满足了许多组织面临的需求——构建商业智能和报告解决方案的需求。直到现在，开发人员必须将报告嵌入到他们的应用程序中，或者组织必须购买昂贵且有时有问题的第三方报告解决方案。现在，Microsoft SQL Server Reporting Services 提供了一个完整的企业级报告分发解决方案，使企业能够更好更快地做出决策。
 
-**Aspose.Pdf for Reporting Services** 是 Aspose 的另一项独特解决方案，使在 Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 和 Power BI Report Server 中生成 PDF 报告成为可能。所有 RDL 报告功能，包括表格、矩阵、图表和图像，都以最高精度转换为 PDF。
+**Aspose.PDF for Reporting Services** 是 Aspose 的另一项独特解决方案，使在 Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 和 Power BI Report Server 中生成 PDF 报告成为可能。所有 RDL 报告功能，包括表格、矩阵、图表和图像，都以最高精度转换为 PDF。
 
-Microsoft SQL Server Reporting Services 具备将报告导出为 PDF 文档的内置功能，但缺乏对终端用户提供必要的技术支持。Aspose.Pdf 致力于提供卓越且高效的技术支持。
+Microsoft SQL Server Reporting Services 具备将报告导出为 PDF 文档的内置功能，但缺乏为最终用户提供必要的技术支持。Aspose.Pdf 致力于提供卓越且高效的技术支持。
 
-Aspose.Pdf for Reporting Services 在服务器上创建文档，而不使用 Adobe.Pdf SDK。Aspose.Pdf for Reporting Services 在内部使用 Aspose.Pdf for .NET – 世界级的服务器端文档处理和转换组件。
+Aspose.PDF for Reporting Services 在服务器上创建文档，而不使用 Adobe.Pdf SDK。Aspose.PDF for Reporting Services 在内部使用 Aspose.PDF for .NET – 世界级的服务器端文档处理和转换组件。
 
 ## Aspose.PDF for Reporting Services 使得可以将任何报告导出为 PDF 格式。
 
 ![todo:image_alt_text](product-overview_2.png)
-
 

--- a/zh/reportingservices/product-overview/_index.md
+++ b/zh/reportingservices/product-overview/_index.md
@@ -3,9 +3,9 @@ title: 产品概述
 linktitle: 产品概述
 type: docs
 weight: 10
-url: /zh/reportingservices/product-overview/
-description: Aspose.PDF for Reporting Services 的概述——一种综合解决方案，用于将 SSRS 报表渲染为 PDF，并具备高级布局功能。
-lastmod: "2026-07-29"
+url: /reportingservices/product-overview/
+description: Aspose.PDF for Reporting Services 概述 – 一个利用高级布局功能将 SSRS 报告渲染为 PDF 的综合解决方案。
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
@@ -14,17 +14,17 @@ lastmod: "2026-07-29"
 
 {{% /alert %}}
 
-## 欢迎使用 Aspose.PDF for Reporting Services！
+## 欢迎使用 Aspose.PDF 报告服务！
 
-Microsoft SQL Server Reporting Services 满足了许多组织面临的需求——构建商业智能和报告解决方案的需求。直到现在，开发人员必须将报告嵌入到他们的应用程序中，或者组织必须购买昂贵且有时有问题的第三方报告解决方案。现在，Microsoft SQL Server Reporting Services 提供了一个完整的企业级报告分发解决方案，使企业能够更好更快地做出决策。
+Microsoft SQL Server Reporting Services 满足了许多组织面临的需求 - 构建商业智能和报告解决方案的需求。到目前为止，开发人员需要将报告嵌入到他们的应用程序中，或者组织需要购买昂贵且有时存在问题的第三方报告解决方案。现在，Microsoft SQL Server Reporting Services 提供了在整个企业内分发报告的完整解决方案；使企业能够更好更快地做出决策。
 
-**Aspose.PDF for Reporting Services** 是 Aspose 的另一项独特解决方案，使在 Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 和 Power BI Report Server 中生成 PDF 报告成为可能。所有 RDL 报告功能，包括表格、矩阵、图表和图像，都以最高精度转换为 PDF。
+**Aspose.PDF for Reporting Services** 是 Aspose 的另一个独特解决方案，它可以在 Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 和 Power BI Report Server 中生成 PDF 报告。所有 RDL 报告功能，包括表格、矩阵、图表和图像，都会以最高精度转换为 PDF。
 
-Microsoft SQL Server Reporting Services 具备将报告导出为 PDF 文档的内置功能，但缺乏为最终用户提供必要的技术支持。Aspose.Pdf 致力于提供卓越且高效的技术支持。
+Microsoft SQL Server Reporting Services 具有将报表导出为 PDF 文档的内置功能，但缺乏为最终用户提供必要的技术支持。 Aspose.Pdf致力于提供至高无上、高效的技术支持。
 
-Aspose.PDF for Reporting Services 在服务器上创建文档，而不使用 Adobe.Pdf SDK。Aspose.PDF for Reporting Services 在内部使用 Aspose.PDF for .NET – 世界级的服务器端文档处理和转换组件。
+Aspose.PDF for Reporting Services 在服务器上创建文档，无需使用 Adob​​e.Pdf SDK。 Aspose.PDF for Reporting Services 内部使用 Aspose.PDF for .NET – 用于服务器端文档处理和转换的世界级组件。
 
-## Aspose.PDF for Reporting Services 使得可以将任何报告导出为 PDF 格式。
+## Aspose.PDF for Reporting Services 可以导出 PDF 格式的任何报告
 
-![todo:image_alt_text](product-overview_2.png)
+![Product Overview](product-overview_2.png)
 

--- a/zh/reportingservices/sample-reports-gallery/_index.md
+++ b/zh/reportingservices/sample-reports-gallery/_index.md
@@ -1,37 +1,37 @@
 ---
-title: 示例报告画廊
-linktitle: 示例报告画廊
+title: 样本报告库
+linktitle: 样本报告库
 type: docs
 weight: 40
-url: /zh/reportingservices/sample-reports-gallery/
+url: /reportingservices/sample-reports-gallery/
 description: 探索使用 Aspose.PDF for Reporting Services 生成的示例报告。了解您的 SSRS 报告如何转换为精美的 PDF 输出。
-lastmod: "2026-07-29"
+lastmod: "2024-05-05"
 ---
 
 {{% alert color="primary" %}}
 
-此画廊展示了由 Aspose.PDF for Reporting Services 导出的 PDF 报告。
+该库演示了 Aspose.PDF for Reporting Services 导出的 PDF 报告。
 
 {{% /alert %}}
 
-此处展示的大多数报告来自 Adventure Works 数据库。Adventure Works 是 Microsoft SQL Server 的示例数据库，可从 Microsoft 下载。 [这里](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
+此处显示的大多数报告均来自 Adventure Works 数据库。 Adventure Works 是 Microsoft SQL Server 的示例数据库，可从 Microsoft 下载 [这里](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
 
 ## 公司销售
 
-![公司销售  PDF 报告](sample-reports-gallery_1.png)
+![PDF 格式的公司销售报告](sample-reports-gallery_1.png)
 
-## 员工销售汇总
+## 员工销售总结
 
-![员工销售汇总 PDF 报告](sample-reports-gallery_2.png)
+![PDF 格式的员工销售总结报告](sample-reports-gallery_2.png)
 
 ## 产品目录
 
-![PDF 中的产品目录报告](sample-reports-gallery_3.png)
+![PDF 格式的产品目录报告](sample-reports-gallery_3.png)
 
 ## 产品线销售
 
-![PDF 中的产品线销售报告](sample-reports-gallery_4.png)
+![PDF 格式的产品线销售报告](sample-reports-gallery_4.png)
 
-## 销售订单详情
+## 销售订单详细信息
 
-![PDF 中的销售订单详情报告](sample-reports-gallery_5.png)
+![PDF 格式的销售订单详细信息报告](sample-reports-gallery_5.png)

--- a/zh/reportingservices/sample-reports-gallery/_index.md
+++ b/zh/reportingservices/sample-reports-gallery/_index.md
@@ -4,13 +4,13 @@ linktitle: 示例报告画廊
 type: docs
 weight: 40
 url: /zh/reportingservices/sample-reports-gallery/
-description: 探索使用 Aspose.PDF for Reporting Services 生成的示例报告。了解您的 SSRS 报告如何转化为精美的 PDF 输出。
-lastmod: "2026-06-19"
+description: 探索使用 Aspose.PDF for Reporting Services 生成的示例报告。了解您的 SSRS 报告如何转换为精美的 PDF 输出。
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-此画廊展示了由 Aspose.Pdf for Reporting Services 导出的 PDF 报告。
+此画廊展示了由 Aspose.PDF for Reporting Services 导出的 PDF 报告。
 
 {{% /alert %}}
 
@@ -20,9 +20,9 @@ lastmod: "2026-06-19"
 
 ![公司销售  PDF 报告](sample-reports-gallery_1.png)
 
-## 员工销售摘要
+## 员工销售汇总
 
-![员工销售摘要 PDF 报告](sample-reports-gallery_2.png)
+![员工销售汇总 PDF 报告](sample-reports-gallery_2.png)
 
 ## 产品目录
 
@@ -35,4 +35,3 @@ lastmod: "2026-06-19"
 ## 销售订单详情
 
 ![PDF 中的销售订单详情报告](sample-reports-gallery_5.png)
-

--- a/zh/reportingservices/supported-file-formats/_index.md
+++ b/zh/reportingservices/supported-file-formats/_index.md
@@ -4,13 +4,13 @@ linktitle: 支持的文件格式
 type: docs
 weight: 20
 url: /zh/reportingservices/supported-file-formats/
-description: 查看 Aspose.PDF for Reporting Services 支持的文件格式。轻松将您的 SSRS 报表渲染为 PDF、DOC、XLS 等。
-lastmod: "2026-06-19"
+description: 查看 Aspose.PDF for Reporting Services 支持的文件格式。轻松将 SSRS 报表渲染为 PDF、DOC、XLS 等格式。
+lastmod: "2026-07-29"
 ---
 
 ## 支持的加载格式
 
-下表显示了 Aspose.PDF for Reporting Services 可以加载的文件格式。
+以下表格列出了 Aspose.PDF for Reporting Services 可以加载的文件格式。
 
 |**格式**|**描述**|
 | :- | :- |
@@ -19,7 +19,7 @@ lastmod: "2026-06-19"
 
 ## 支持的保存格式
 
-以下表格指示使用 Aspose.PDF for Reporting Services 时可以将文档保存的文件格式。 
+下表显示了使用 Aspose.PDF for Reporting Services 时可以将文档保存为的文件格式。 
 
 |**格式**|**描述**|
 | :- | :- |
@@ -27,4 +27,3 @@ lastmod: "2026-06-19"
 |PDF/A |将文档保存为 PDF/A 格式|
 |[XPS](https://docs.fileformat.com/page-description-language/xps/)|将文档保存为 XML Paper Specification 格式|
 |EPUB|将文档保存为电子书文件格式|
-

--- a/zh/reportingservices/supported-file-formats/_index.md
+++ b/zh/reportingservices/supported-file-formats/_index.md
@@ -3,27 +3,27 @@ title: 支持的文件格式
 linktitle: 支持的文件格式
 type: docs
 weight: 20
-url: /zh/reportingservices/supported-file-formats/
-description: 查看 Aspose.PDF for Reporting Services 支持的文件格式。轻松将 SSRS 报表渲染为 PDF、DOC、XLS 等格式。
-lastmod: "2026-07-29"
+url: /reportingservices/supported-file-formats/
+description: 查看 Reporting Services 支持的 Aspose.PDF 文件格式。轻松将 SSRS 报告呈现为 PDF、DOC、XLS 等格式。
+lastmod: "2021-06-05"
 ---
 
 ## 支持的加载格式
 
-以下表格列出了 Aspose.PDF for Reporting Services 可以加载的文件格式。
+下表列出了 Aspose.PDF for Reporting Services 可以加载的文件格式。
 
 |**格式**|**描述**|
 | :- | :- |
-|RDL|报告定义语言|
-|[HTML](https://docs.fileformat.com/web/html/)|超文本标记语言|
+|重定义层|报告定义语言|
+|[超文本标记语言](https://docs.fileformat.com/web/html/)|超文本标记语言|
 
 ## 支持的保存格式
 
-下表显示了使用 Aspose.PDF for Reporting Services 时可以将文档保存为的文件格式。 
+下表列出了使用 Aspose.PDF for Reporting Services 可以保存文档的文件格式。 
 
 |**格式**|**描述**|
 | :- | :- |
-|[PDF](https://docs.fileformat.com/pdf/)|将文档保存为 PDF 格式|
+|[PDF](https://docs.fileformat.com/pdf/)|保存文档为PDF格式|
 |PDF/A |将文档保存为 PDF/A 格式|
-|[XPS](https://docs.fileformat.com/page-description-language/xps/)|将文档保存为 XML Paper Specification 格式|
-|EPUB|将文档保存为电子书文件格式|
+|[XPS](https://docs.fileformat.com/page-description-language/xps/)|以 XML 纸张规范格式保存文档|
+|EPUB|以电子书文件格式保存文档|

--- a/zh/reportingservices/technical-articles/_index.md
+++ b/zh/reportingservices/technical-articles/_index.md
@@ -4,11 +4,10 @@ linktitle: 技术文章
 type: docs
 weight: 120
 url: /zh/reportingservices/technical-articles/
-description: 探索 Aspose.PDF for Reporting Services 的技术文章。深入了解和实用技巧，以实现有效的 PDF 渲染。
-lastmod: "2026-06-19"
+description: 探索 Aspose.PDF for Reporting Services 的技术文章。深入了解并获取有效 PDF 渲染的实用技巧。
+lastmod: "2026-07-29"
 ---
 
 **本节包括以下主题：**
-- [从 SQL Reporting Services 迁移到 Aspose.Pdf for Reporting Services](/pdf/zh/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
+- [从 SQL Reporting Services 迁移到 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
 - [SQL Reporting Services 与 MS SharePoint 的集成](/pdf/zh/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/)
-

--- a/zh/reportingservices/technical-articles/_index.md
+++ b/zh/reportingservices/technical-articles/_index.md
@@ -3,11 +3,12 @@ title: 技术文章
 linktitle: 技术文章
 type: docs
 weight: 120
-url: /zh/reportingservices/technical-articles/
-description: 探索 Aspose.PDF for Reporting Services 的技术文章。深入了解并获取有效 PDF 渲染的实用技巧。
-lastmod: "2026-07-29"
+url: /reportingservices/technical-articles/
+description: 浏览 Aspose.PDF for Reporting Services 的技术文章。获得有效 PDF 渲染的深入见解和实用技巧。
+lastmod: "2021-06-05"
 ---
 
 **本节包括以下主题：**
+
 - [从 SQL Reporting Services 迁移到 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
-- [SQL Reporting Services 与 MS SharePoint 的集成](/pdf/zh/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/)
+- [SQL Report Services 与 MS SharePoint 集成](/pdf/zh/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/)

--- a/zh/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
+++ b/zh/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
@@ -1,14 +1,13 @@
 ---
-title: 从 SQL Reporting Services 迁移到 Aspose.Pdf for Reporting Services
-linktitle: 从 SQL Reporting Services 迁移到 Aspose.Pdf for Reporting Services
+title: 从 SQL Reporting Services 迁移到 Aspose.PDF for Reporting Services
+linktitle: 从 SQL Reporting Services 迁移到 Aspose.PDF for Reporting Services
 type: docs
 weight: 10
 url: /zh/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/
-description: 了解如何从 SQL Reporting Services 迁移到 Aspose.PDF for Reporting Services。升级您的 PDF 生成流程。
-lastmod: "2026-06-19"
+description: 了解如何从 SQL Reporting Services 迁移到 Aspose.PDF for Reporting Services。升级您的 PDF 生成过程。
+lastmod: "2026-07-29"
 ---
 
-**此部分包括以下主题：**
+**本章节包括以下主题：**
 
-- [为什么选择 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/why-choose-aspose-pdf-for-reporting-services/)
-
+- [为何选择 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/why-choose-aspose-pdf-for-reporting-services/)

--- a/zh/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
+++ b/zh/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
@@ -3,11 +3,11 @@ title: 从 SQL Reporting Services 迁移到 Aspose.PDF for Reporting Services
 linktitle: 从 SQL Reporting Services 迁移到 Aspose.PDF for Reporting Services
 type: docs
 weight: 10
-url: /zh/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/
-description: 了解如何从 SQL Reporting Services 迁移到 Aspose.PDF for Reporting Services。升级您的 PDF 生成过程。
-lastmod: "2026-07-29"
+url: /reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/
+description: 了解如何从 SQL Reporting Services 迁移到 Aspose.PDF for Reporting Services。升级您的 PDF 生成流程。
+lastmod: "2024-05-05"
 ---
 
-**本章节包括以下主题：**
+**本节包括以下主题：**
 
-- [为何选择 Aspose.PDF for Reporting Services](/pdf/zh/reportingservices/why-choose-aspose-pdf-for-reporting-services/)
+- [为什么选择 Aspose.PDF 进行报告服务](/pdf/zh/reportingservices/why-choose-aspose-pdf-for-reporting-services/)

--- a/zh/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
+++ b/zh/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
@@ -1,36 +1,36 @@
 ---
-title: 为什么选择 Aspose.Pdf 用于 Reporting Services
-linktitle: 为什么选择 Aspose.Pdf 用于 Reporting Services
+title: 为什么选择 Aspose.PDF for Reporting Services
+linktitle: 为什么选择 Aspose.PDF for Reporting Services
 type: docs
 weight: 10
 url: /zh/reportingservices/why-choose-aspose-pdf-for-reporting-services/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-**Aspose.Pdf for Reporting Services** 是一个强大的 .NET 解决方案，可让您使用 Microsoft SQL Server 2016、2017、2019 和 2022 Reporting Services，以及 Microsoft Power BI Report Server 生成 PDF 报告。Aspose.Pdf for Reporting Services 并非独立运行，而是作为 SQL Reporting Services 的渲染扩展。它不仅支持表格、图表、图像、页眉/页脚、线条等基本报表元素，而且还能添加自定义属性，为 SQL Reporting Services 提供额外的功能。使用这些属性时，您可以生成报告设计器不支持的目录（List of Contents）。在生成的 PDF 文档中，您还可以使用报告生成器本身不支持的脚注/尾注。另一个有趣的功能是线条箭头，SQL Reporting Services 也不支持此功能，但 Aspose.Pdf for Reporting Services 能在线条元素的起点或终点添加箭头。此外，Aspose.Pdf for Reporting Services 还提供指定文本对齐方式（Justify 或 FullJustify）的功能，而这在报告设计器中也不受支持。这些文本对齐模式使最终文档格式更佳，阅读更轻松。
+**Aspose.PDF for Reporting Services** 是一个强大的 .NET 解决方案，允许您使用 Microsoft SQL Server 2016、2017、2019 和 2022 Reporting Services 以及 Microsoft Power BI Report Server 生成 PDF 报表。Aspose.PDF for Reporting Services 并非独立运行，而是 SQL Reporting Services 的渲染扩展。它不仅支持表格、图表、图像、页眉/页脚、线条等基本报表元素，还提供添加自定义属性的能力，这为 SQL Reporting Services 增加了额外的优势。使用这些属性时，您可以生成报告设计器不支持的目录列表。生成的 PDF 文档中还可以包含报告生成器本身不支持的脚注/尾注。另一个有趣的功能是可以添加线段箭头，SQL Reporting Services 同样不支持此功能，但 Aspose.PDF for Reporting Services 可以在线段的起始或结束处添加箭头。此外，Aspose.PDF for Reporting Services 提供指定文本对齐方式（Justify 或 FullJustify）的功能，而这在报告设计器中不受支持。这些文本模式使生成的文档格式更佳，易于阅读。
 
-除了前面提到的功能之外，您还可以为报告设置其他一些配置参数，以获得 SQL Reporting Services 原生不支持的功能。以下是 Aspose.Pdf for Reporting Services 提供的此类功能的简要概述。
+除了前面提到的功能之外，您还可以为报表设置其他一些配置参数，以实现 SQL Reporting Services 本身不支持的功能。以下是 Aspose.PDF for Reporting Services 提供的此类功能的简要概述。
 
 ## 安全设置
 
-有时您可能希望导出受密码保护的 PDF 文档，限制文本复制和打印权限。不幸的是，Reporting Services 不支持此功能。不过，您仍然可以使用 Aspose.Pdf for Reporting Services 实现。只需向报告或报告服务器添加相应的安全参数，即可获得具有受限权限的安全 PDF 文档。更多信息，请参阅 'Security Setting' 部分。
+有时您可能希望导出受密码保护的 PDF 文档，并限制文本复制和打印权限。遗憾的是，Reporting Services 不支持此功能。不过，您仍然可以使用 Aspose.PDF for Reporting Services 实现。只需向报表或报表服务器添加相应的安全参数，即可获得具有受限权限的安全 PDF 文档。欲了解更多信息，请参阅 \u0027Security Setting\u0027 部分。
 
 ## 自定义字体嵌入
 
-Reporting Services 设计器不支持文本的嵌入字体；使用 Aspose.Pdf for Reporting Services，您可以轻松将字体信息嵌入 PDF 文档。更多信息，请参阅 'IsFontEmbedded' 部分。
+Reporting Services 设计器不支持文本的嵌入字体；使用 Aspose.PDF for Reporting Services，您可以轻松将字体信息嵌入 PDF 文档。欲了解更多信息，请参阅 \u0027IsFontEmbedded\u0027 部分。
 
 ## XMP 元数据
 
-Reporting Services 设计器不支持嵌入 XMP 元数据。Aspose.Pdf for Reporting Services 提供四个参数（CreationDate、ModifyDate、MetaDataDate 和 CreatorTool）来设置相应的 XMP 元数据。有关更多信息，请参阅 'XMP Metadata' 部分。
+Reporting Services 设计器不支持嵌入 XMP 元数据。Aspose.PDF for Reporting Services 提供四个参数（CreationDate、ModifyDate、MetaDataDate 和 CreatorTool）以设置相应的 XMP 元数据。欲了解更多信息，请参阅 ‘XMP Metadata’ 部分。
 
 ## PDF/A
 
-使用 SQL Server Reporting Services 时，只能以简单格式生成 PDF 文档，且不支持生成 PDF/A 文档。但 Aspose.Pdf for Reporting Services 提供了通过添加单个配置参数来创建符合 PDF/A 标准的文档的功能。有关更多信息，请参阅 'PDF Conformance' 部分。
+使用 SQL Server Reporting Services 时，您只能生成简易格式的 PDF 文档，而不支持生成 PDF/A 文档。但 Aspose.PDF for Reporting Services 提供了通过添加单个配置参数来创建符合 PDF/A 标准的文档的功能。欲了解更多信息，请参阅 ‘PDF Conformance’ 部分。
 
 ## 页面旋转角度
 
-使用 Aspose.Pdf for Reporting Services 时，您可以设置页面在显示或打印时顺时针旋转的角度（度数）。有关更多信息，请参阅 'Page Rotating Angle' 部分。
+使用 Aspose.PDF for Reporting Services 时，您可以设置页面在显示或打印时顺时针旋转的角度（度数）。欲了解更多信息，请参阅 ‘Page Rotating Angle’ 部分。
 
 ## 页面边距大小
 
-Reporting Services 设计器不支持设置页面边距大小。另一方面，Aspose.Pdf for Reporting Services 提供了四个参数来设置相应的页面边距大小。它们是 PageMarginLeft、PageMarginRight、PageMarginTop 和 PageMarginBottom。有关更多信息，请参阅 'Page Margin Size' 部分。
+Reporting Services 设计器不支持设置页面边距大小。Aspose.PDF for Reporting Services 则提供四个参数来设置相应的页面边距大小。它们是 PageMarginLeft、PageMarginRight、PageMarginTop 和 PageMarginBottom。有关更多信息，请参阅 'Page Margin Size' 部分。

--- a/zh/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
+++ b/zh/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
@@ -1,36 +1,36 @@
 ---
-title: 为什么选择 Aspose.PDF for Reporting Services
-linktitle: 为什么选择 Aspose.PDF for Reporting Services
+title: 为什么选择 Aspose.PDF 进行报告服务
+linktitle: 为什么选择 Aspose.PDF 进行报告服务
 type: docs
 weight: 10
-url: /zh/reportingservices/why-choose-aspose-pdf-for-reporting-services/
-lastmod: "2026-07-29"
+url: /reportingservices/why-choose-aspose-pdf-for-reporting-services/
+lastmod: "2021-06-05"
 ---
 
-**Aspose.PDF for Reporting Services** 是一个强大的 .NET 解决方案，允许您使用 Microsoft SQL Server 2016、2017、2019 和 2022 Reporting Services 以及 Microsoft Power BI Report Server 生成 PDF 报表。Aspose.PDF for Reporting Services 并非独立运行，而是 SQL Reporting Services 的渲染扩展。它不仅支持表格、图表、图像、页眉/页脚、线条等基本报表元素，还提供添加自定义属性的能力，这为 SQL Reporting Services 增加了额外的优势。使用这些属性时，您可以生成报告设计器不支持的目录列表。生成的 PDF 文档中还可以包含报告生成器本身不支持的脚注/尾注。另一个有趣的功能是可以添加线段箭头，SQL Reporting Services 同样不支持此功能，但 Aspose.PDF for Reporting Services 可以在线段的起始或结束处添加箭头。此外，Aspose.PDF for Reporting Services 提供指定文本对齐方式（Justify 或 FullJustify）的功能，而这在报告设计器中不受支持。这些文本模式使生成的文档格式更佳，易于阅读。
+**Aspose.PDF for Reporting Services** 是一个强大的 .NET 解决方案，允许您使用 Microsoft SQL Server 2016、2017、2019 和 2022 Reporting Services 以及 Microsoft Power BI 报表服务器生成 PDF 报表。 Aspose.PDF for Reporting Services 并不独立运行，而是 SQL Reporting Services 的渲染扩展。它不仅支持基本的报表元素，例如表格、图表、图像、页眉/页脚、线条等，而且还提供添加自定义属性的功能，这使其能够额外利用 SQL Reporting Services。使用这些属性时，您可以生成报表设计器不支持的内容列表。您可能在生成的 PDF 文档中包含脚注/尾注，而报表生成器本身不支持这些脚注/尾注。另一个有趣的功能是具有线箭头，SQL Reporting Services 也不支持该功能，但 Aspose.PDF for Reporting Services 可以提供在行元素的开头或结尾添加箭头的功能。此外，Aspose.PDF for Reporting Services 提供了指定文本对齐（Justify 或 FullJustify）信息的功能，而报表设计器不支持该功能。这些文本模式使生成的文档格式更好且易于阅读。
 
-除了前面提到的功能之外，您还可以为报表设置其他一些配置参数，以实现 SQL Reporting Services 本身不支持的功能。以下是 Aspose.PDF for Reporting Services 提供的此类功能的简要概述。
+除了前面提到的功能之外，您还可以为报表设置某些其他配置参数，以获得 SQL Reporting Services 本身不支持的功能。以下是 Aspose.PDF for Reporting Services 提供的此类功能的简要概述
 
 ## 安全设置
 
-有时您可能希望导出受密码保护的 PDF 文档，并限制文本复制和打印权限。遗憾的是，Reporting Services 不支持此功能。不过，您仍然可以使用 Aspose.PDF for Reporting Services 实现。只需向报表或报表服务器添加相应的安全参数，即可获得具有受限权限的安全 PDF 文档。欲了解更多信息，请参阅 \u0027Security Setting\u0027 部分。
+有时您可能希望导出受密码保护的 PDF 文档，并具有有限的文本复制和打印权限。遗憾的是，Reporting Services 不支持这种可能性。但是，您仍然可以使用 Aspose.PDF for Reporting Services 来实现它。只需向报表或报表服务器添加相应的安全参数即可获得具有有限权限的安全PDF文档。欲了解更多信息，请参阅“安全设置”部分。
 
 ## 自定义字体嵌入
 
-Reporting Services 设计器不支持文本的嵌入字体；使用 Aspose.PDF for Reporting Services，您可以轻松将字体信息嵌入 PDF 文档。欲了解更多信息，请参阅 \u0027IsFontEmbedded\u0027 部分。
+Reporting Services 设计器不支持文本的嵌入字体；使用 Aspose.PDF for Reporting Services，您可以轻松地将字体信息嵌入到 PDF 文档中。有关更多信息，请参阅“IsFontEmbedded”部分。
 
-## XMP 元数据
+## XMP元数据
 
-Reporting Services 设计器不支持嵌入 XMP 元数据。Aspose.PDF for Reporting Services 提供四个参数（CreationDate、ModifyDate、MetaDataDate 和 CreatorTool）以设置相应的 XMP 元数据。欲了解更多信息，请参阅 ‘XMP Metadata’ 部分。
+Reporting Services 设计器不支持嵌入 XMP 元数据。 Aspose.PDF for Reporting Services 提供了四个参数（CreationDate、ModifyDate、MetaDataDate 和 CreatorTool）来设置相应的 XMP 元数据。有关更多信息，请参阅“XMP 元数据”部分。
 
 ## PDF/A
 
-使用 SQL Server Reporting Services 时，您只能生成简易格式的 PDF 文档，而不支持生成 PDF/A 文档。但 Aspose.PDF for Reporting Services 提供了通过添加单个配置参数来创建符合 PDF/A 标准的文档的功能。欲了解更多信息，请参阅 ‘PDF Conformance’ 部分。
+使用SQL Server Reporting Services时，只能生成简单格式的PDF文档，不支持生成PDF/A文档。但 Aspose.PDF for Reporting Services 提供了通过添加单个配置参数来创建 PDF/A 兼容文档的功能。有关更多信息，请参阅“PDF 一致性”部分。
 
 ## 页面旋转角度
 
-使用 Aspose.PDF for Reporting Services 时，您可以设置页面在显示或打印时顺时针旋转的角度（度数）。欲了解更多信息，请参阅 ‘Page Rotating Angle’ 部分。
+当使用 Aspose.PDF for Reporting Services 时，您可以设置页面在显示或打印时顺时针旋转的度数。欲了解更多信息，请参阅“页面旋转角度”部分。
 
-## 页面边距大小
+## 页边距大小
 
-Reporting Services 设计器不支持设置页面边距大小。Aspose.PDF for Reporting Services 则提供四个参数来设置相应的页面边距大小。它们是 PageMarginLeft、PageMarginRight、PageMarginTop 和 PageMarginBottom。有关更多信息，请参阅 'Page Margin Size' 部分。
+Reporting Services 设计器不支持设置页边距大小。另一方面，Aspose.PDF for Reporting Services 提供了四个参数来设置相应的页边距大小。它们是 PageMarginLeft、PageMarginRight、PageMarginTop 和 PageMarginBottom。有关详细信息，请参阅“页边距大小”部分。

--- a/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
+++ b/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
@@ -4,7 +4,7 @@ linktitle: SQL Reporting Services 与 MS SharePoint 的集成
 type: docs
 weight: 20
 url: /zh/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 **本节包括以下主题：**
@@ -12,5 +12,4 @@ lastmod: "2026-06-19"
 - [介绍](/pdf/zh/reportingservices/introduction/)
 - [设置 Reporting Services](/pdf/zh/reportingservices/setting-up-reporting-services/)
 - [在 Reporting Services 服务器上设置 SharePoint](/pdf/zh/reportingservices/setting-up-sharepoint-on-reporting-services-server/)
-- [Reporting Services 与 SharePoint 的配置](/pdf/zh/reportingservices/reporting-services-and-sharepoint-configuration/)
-
+- [Reporting Services 与 SharePoint 配置](/pdf/zh/reportingservices/reporting-services-and-sharepoint-configuration/)

--- a/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
+++ b/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
@@ -1,15 +1,15 @@
 ---
-title: SQL Reporting Services 与 MS SharePoint 的集成
-linktitle: SQL Reporting Services 与 MS SharePoint 的集成
+title: SQL Report Services 与 MS SharePoint 集成
+linktitle: SQL Report Services 与 MS SharePoint 集成
 type: docs
 weight: 20
-url: /zh/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/
-lastmod: "2026-07-29"
+url: /reportingservices/sql-reporting-services-integration-with-ms-sharepoint/
+lastmod: "2021-06-05"
 ---
 
 **本节包括以下主题：**
 
 - [介绍](/pdf/zh/reportingservices/introduction/)
-- [设置 Reporting Services](/pdf/zh/reportingservices/setting-up-reporting-services/)
-- [在 Reporting Services 服务器上设置 SharePoint](/pdf/zh/reportingservices/setting-up-sharepoint-on-reporting-services-server/)
-- [Reporting Services 与 SharePoint 配置](/pdf/zh/reportingservices/reporting-services-and-sharepoint-configuration/)
+- [设置报告服务](/pdf/zh/reportingservices/setting-up-reporting-services/)
+- [在 Reporting ServicesReporting Services 服务器上设置 SharePoint](/pdf/zh/reportingservices/setting-up-sharepoint-on-reporting-services-server/)
+- [Reporting Services 和 SharePoint 配置](/pdf/zh/reportingservices/reporting-services-and-sharepoint-configuration/)

--- a/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
+++ b/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
@@ -1,15 +1,15 @@
 ---
-title: 介绍
-linktitle: 介绍
+title: 简介
+linktitle: 简介
 type: docs
 weight: 10
 url: /zh/reportingservices/introduction/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF for Reporting Services 多年来在通过 SQL Reporting Services 生成 PDF 方面表现出色，并提供了多种配置和参数化选项，这些选项在 SQL Reporting Services 中默认不支持。最近我们收到了一些关于 Aspose.PDF for Reporting Services 与 SharePoint 集成的请求。本文将重点关注 MS SharePoint 2010。在继续之前，假设您已经搭建了 SharePoint Farm。在本例中我们将使用完整的 SharePoint Cloud。不过这些步骤在 SharePoint Foundation Server 上也类似。
+Aspose.PDF for Reporting Services 多年来在通过 SQL Reporting Services 生成 PDF 方面表现卓越，并且提供了多种配置和参数化选项，这些选项在 SQL Reporting Services 中默认不受支持。最近我们收到了一些关于 Aspose.PDF for Reporting Services 与 SharePoint 集成的需求。本文将重点关注 MS SharePoint 2010。在继续之前，假设您已经搭建好了 SharePoint Farm。本文示例使用完整的 SharePoint Cloud，但对于 SharePoint Foundation Server，步骤类似。
 
 {{% /alert %}}
 
@@ -17,38 +17,37 @@ Aspose.PDF for Reporting Services 多年来在通过 SQL Reporting Services 生�
 
 在继续之前，让我们先看看在准备本文时参考的主题。
 
-- [Reporting Services 与 SharePoint 技术集成概览](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
-- [在 SharePoint 集成模式下的 Reporting Services 部署拓扑](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
+- [Reporting Services 与 SharePoint 技术集成概述](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
+- [Reporting Services 在 SharePoint 集成模式下的部署拓扑](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
 - [为 SharePoint 2010 集成配置 Reporting Services](http://msdn.microsoft.com/en-us/library/bb326356.aspx)
 
 {{% /alert %}}
 
 ## 环境设置
 
-我们的设置包括 4 台服务器。它包括域控制器、SQL Server、SharePoint Server 和一台用于 Reporting Services 的服务器。您可以选择在同一台机器上同时运行 SharePoint 和 Reporting Services，这将稍微简化部署，我会指出其中的一些差异。
+我们的设置包括 4 台服务器。它包括域控制器、SQL Server、SharePoint Server 和一台用于 Reporting Services 的服务器。您可以选择将 SharePoint 与 Reporting Services 部署在同一台机器上，这样可以简化一些，我将指出其中的一些差异。
 
 ## 安装前提条件
 
 {{% alert color="primary" %}}
 
-Reporting Services 的 SharePoint 插件是实现集成正常运行的关键组件之一。该插件需安装在 SharePoint 农场中的任何 Web Front Ends (WFE) 上，同时也需要在 Central Admin 服务器上安装。SQL 2008 R2 与 SharePoint 2010 的一个新变化是，2008 R2 插件现在成为 SharePoint 安装的前提条件。这意味着在您安装 SharePoint 时会自动部署 RS 插件。下图已展示并突出显示了这一点。实际上，这避免了我们在安装插件时在 SP 2007 与 RS 2008 上遇到的许多问题。
+Reporting Services 的 SharePoint Add‑In 是实现集成正常工作的重要组件之一。该 Add‑In 需要安装在 SharePoint 农场中的任何 Web 前端 (WFE) 上，以及 Central Admin 服务器。SQL 2008 R2 与 SharePoint 2010 的一个新变化是，2008 R2 Add‑In 现在是 SharePoint 安装的前提条件。这意味着在安装 SharePoint 时会自动部署 RS Add‑In。下图已展示并突出显示了这一点。这实际上避免了我们在使用 SP 2007 和 RS 2008 安装 Add‑In 时遇到的许多问题。
 
 ![todo:image_alt_text](introduction_1.png)
 
-**Image1 :- SharePoint 的 Reporting Services 加载项**
+**Image1 :- Reporting Services Share Point 加载项**
 {{% /alert %}}
 
 ## SharePoint 身份验证
 
-**在我们进入 RS 集成部分之前，我想指出关于 SharePoint 农场的一个问题，即您如何设置站点。更具体地说，您如何配置站点的身份验证。是使用经典模式还是声明模式。此选择在开始时非常重要。我认为一旦完成后就无法更改此选项。如果可以更改，也不是一个简单的过程。**
+**在我们进入 RS 集成部分之前，我想指出关于 SharePoint 农场的一个关键点，即您如何设置站点。更具体地说，您如何为站点配置身份验证。是使用经典模式还是 Claims 模式。这个选择在起始阶段非常重要。我认为一旦完成后无法更改此选项。如果可以更改，也不是一个简单的过程。
 
-NOTE: ***Reporting Services 2008 R2 不支持声明模式***
+NOTE: ***Reporting Services 2008 R2 不支持 Claims***
 
-即使您选择将 SharePoint 站点设置为使用 Claims，Reporting Services 本身并不具备 Claims 感知能力。不过，这会影响 Reporting Services 的身份验证方式。那么，从 Reporting Services 的角度来看有什么区别？关键在于您是否想将用户凭据转发到数据源。Classic:- 可以使用 Kerberos 并将用户的凭据转发到后端数据源（需要使用 Kerberos）。Claims:- 使用 Claims 令牌而不是 Windows 令牌。RS 将始终在此情形下使用受信任身份验证，并且只能访问 SPUser 令牌。您需要在数据源中存储您的凭据。
+即使您选择将 SharePoint 站点使用 Claims，Reporting Services 本身并未实现对 Claims 的感知。话虽如此，这确实会影响 Reporting Services 的身份验证方式。那么，从 Reporting Services 的角度来看，有何区别？关键在于您是否希望将用户凭据转发到数据源。Classic:- 可以使用 Kerberos 并将用户的凭据转发到后端数据源（需要使用 Kerberos）。Claims:- 使用 Claims 令牌而非 Windows 令牌。RS 在此情形下会始终使用受信任身份验证，并且只能访问 SPUser 令牌。您需要在数据源中存储您的凭据。
 
 Classic :- 可以使用 Kerberos 并将用户的凭据转发到后端数据源（需要使用 Kerberos）。
 
-Claims :- 使用 Claims 令牌而不是 Windows 令牌。RS 将始终在此情形下使用受信任身份验证，并且只能访问 SPUser 令牌。您需要在数据源中存储您的凭据。
+Claims :- 使用 Claims 令牌而非 Windows 令牌。RS 在此情形下会始终使用受信任身份验证，并且只能访问 SPUser 令牌。您需要在数据源中存储您的凭据。
 
-目前我们只想专注于 RS 的设置。此时 SharePoint 已安装在我的 SharePoint 服务器上，并在端口 80 上设置了 Classic Auth 站点。在 RS 服务器上，我刚刚安装了 Reporting Services，仅此而已。
-
+目前我们只想专注于 RS 的设置。此时 SharePoint 已经安装在我的 SharePoint Box 上，并使用 Classic Auth 站点在端口 80 上进行设置。在 RS 服务器上，我刚刚安装了 Reporting Services，仅此而已。

--- a/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
+++ b/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
@@ -1,53 +1,53 @@
 ---
-title: 简介
-linktitle: 简介
+title: 介绍
+linktitle: 介绍
 type: docs
 weight: 10
-url: /zh/reportingservices/introduction/
-lastmod: "2026-07-29"
+url: /reportingservices/introduction/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF for Reporting Services 多年来在通过 SQL Reporting Services 生成 PDF 方面表现卓越，并且提供了多种配置和参数化选项，这些选项在 SQL Reporting Services 中默认不受支持。最近我们收到了一些关于 Aspose.PDF for Reporting Services 与 SharePoint 集成的需求。本文将重点关注 MS SharePoint 2010。在继续之前，假设您已经搭建好了 SharePoint Farm。本文示例使用完整的 SharePoint Cloud，但对于 SharePoint Foundation Server，步骤类似。
+多年来，Aspose.PDF for Reporting Services 在通过 SQL Reporting Services 生成 PDF 方面表现非常出色，它提供了 SQL Reporting Services 默认情况下不支持的各种配置和参数化选项。最近，我们收到了一些有关 Aspose.PDF 与 SharePoint 集成 Reporting Services 的请求。在本文中，我们将重点关注 MS SharePoint 2010。在继续之前，我们假设您已经设置了 SharePoint 场。在此示例中，我们将使用完整的 SharePoint Cloud。不过，SharePoint Foundation Server 的步骤类似。
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-在继续之前，让我们先看看在准备本文时参考的主题。
+在继续之前，让我们先看一下在准备本文期间参考过的参考主题。
 
-- [Reporting Services 与 SharePoint 技术集成概述](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
-- [Reporting Services 在 SharePoint 集成模式下的部署拓扑](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
+- [Reporting Services 和 SharePoint 技术集成概述](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
+- [SharePoint 集成模式下 Reporting Services 的部署拓扑](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
 - [为 SharePoint 2010 集成配置 Reporting Services](http://msdn.microsoft.com/en-us/library/bb326356.aspx)
 
 {{% /alert %}}
 
 ## 环境设置
 
-我们的设置包括 4 台服务器。它包括域控制器、SQL Server、SharePoint Server 和一台用于 Reporting Services 的服务器。您可以选择将 SharePoint 与 Reporting Services 部署在同一台机器上，这样可以简化一些，我将指出其中的一些差异。
+输出设置由 4 台服务器组成。它包括域控制器、SQL Server、SharePoint Server 和 Reporting Services 服务器。您可以选择将 SharePoint 和 Reporting Services 放在同一个盒子上，这会稍微简化这一点，我将指出一些差异。
 
-## 安装前提条件
+## 安装先决条件
 
 {{% alert color="primary" %}}
 
-Reporting Services 的 SharePoint Add‑In 是实现集成正常工作的重要组件之一。该 Add‑In 需要安装在 SharePoint 农场中的任何 Web 前端 (WFE) 上，以及 Central Admin 服务器。SQL 2008 R2 与 SharePoint 2010 的一个新变化是，2008 R2 Add‑In 现在是 SharePoint 安装的前提条件。这意味着在安装 SharePoint 时会自动部署 RS Add‑In。下图已展示并突出显示了这一点。这实际上避免了我们在使用 SP 2007 和 RS 2008 安装 Add‑In 时遇到的许多问题。
+SharePoint 的 Reporting Services 外接程序是使集成正常工作的关键组件之一。该加载项需要与中央管理服务器一起安装在 SharePoint 场中的任何 Web 前端 (WFE) 上。 SQL 2008 R2 和 SharePoint 2010 的新变化之一是 2008 R2 加载项现在是 SharePoint 安装的先决条件。这意味着当您安装 SharePoint 时，将安装 RS 加载项。它已在下图中显示并突出显示。这实际上避免了我们在安装插件时在 SP 2007 和 RS 2008 中看到的许多问题。
 
-![todo:image_alt_text](introduction_1.png)
+![Introduction](introduction_1.png)
 
-**Image1 :- Reporting Services Share Point 加载项**
+**图片 1：- Share Point 的报告服务插件**
 {{% /alert %}}
 
 ## SharePoint 身份验证
 
-**在我们进入 RS 集成部分之前，我想指出关于 SharePoint 农场的一个关键点，即您如何设置站点。更具体地说，您如何为站点配置身份验证。是使用经典模式还是 Claims 模式。这个选择在起始阶段非常重要。我认为一旦完成后无法更改此选项。如果可以更改，也不是一个简单的过程。
+**在我们开始讨论 RS 集成部分之前，我想指出有关 SharePoint 场的一件事是如何设置站点。更具体地说，如何配置站点的身份验证。无论是经典还是索赔。这个选择在一开始就很重要。我不认为完成后您可以更改此选项。如果你能改变它，这将不是一个简单的过程。
 
-NOTE: ***Reporting Services 2008 R2 不支持 Claims***
+注意：***Reporting Services 2008 R2 不支持声明***
 
-即使您选择将 SharePoint 站点使用 Claims，Reporting Services 本身并未实现对 Claims 的感知。话虽如此，这确实会影响 Reporting Services 的身份验证方式。那么，从 Reporting Services 的角度来看，有何区别？关键在于您是否希望将用户凭据转发到数据源。Classic:- 可以使用 Kerberos 并将用户的凭据转发到后端数据源（需要使用 Kerberos）。Claims:- 使用 Claims 令牌而非 Windows 令牌。RS 在此情形下会始终使用受信任身份验证，并且只能访问 SPUser 令牌。您需要在数据源中存储您的凭据。
+即使您选择 SharePoint 网站使用声明，Reporting Services 本身也无法识别声明。也就是说，它确实会影响身份验证与 Reporting Services 的配合方式。那么，从 Reporting Services 的角度来看有什么区别呢？这取决于您是否要将用户凭据转发到数据源。经典：- 可以使用 Kerberos 并将用户的凭据转发到后端数据源（为此需要使用 Kerberos）。声明：- 使用声明令牌而不是 Windows 令牌。在这种情况下，RS 将始终使用受信任的身份验证，并且只能访问 SPUser 令牌。您需要将您的凭据存储在数据源中。
 
-Classic :- 可以使用 Kerberos 并将用户的凭据转发到后端数据源（需要使用 Kerberos）。
+经典：- 可以使用 Kerberos 并将用户的凭据转发到后端数据源（为此需要使用 Kerberos。
 
-Claims :- 使用 Claims 令牌而非 Windows 令牌。RS 在此情形下会始终使用受信任身份验证，并且只能访问 SPUser 令牌。您需要在数据源中存储您的凭据。
+声明：- 使用声明令牌而不是 Windows 令牌。在这种情况下，RS 将始终使用受信任的身份验证，并且只能访问 SPUser 令牌。您需要将您的凭据存储在数据源中。
 
-目前我们只想专注于 RS 的设置。此时 SharePoint 已经安装在我的 SharePoint Box 上，并使用 Classic Auth 站点在端口 80 上进行设置。在 RS 服务器上，我刚刚安装了 Reporting Services，仅此而已。
+现在我们只想关注 RS 的设置。此时，SharePoint 已安装在我的 SharePoint Box 上，并在端口 80 上设置了经典身份验证站点。在 RS 服务器上，我刚刚安装了 Reporting Services，仅此而已。

--- a/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
+++ b/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
@@ -4,41 +4,41 @@ linktitle: Reporting Services 和 SharePoint 配置
 type: docs
 weight: 40
 url: /zh/reportingservices/reporting-services-and-sharepoint-configuration/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-现在，SharePoint 已在 RS 服务器上安装并配置，且 RS 已通过 Reporting Services Configuration Manager 完成设置，我们可以继续在 Central Admin 中进行配置。RS 2008 R2 已大大简化了此过程。我们过去需要执行三步才能实现此功能，而现在只需一步。
+现在，SharePoint 已经在 RS 服务器上安装并配置，且 RS 已通过 Reporting Services Configuration Manager 完成设置，我们可以继续在 Central Admin 中进行配置。RS 2008 R2 实际上大大简化了此过程。我们过去需要执行一个 3 步的过程才能使其工作，而现在只需一步。
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-我们想要访问 Central Administrator 网站，然后进入 General Application Settings。在底部我们会看到 Reporting Services。
+我们想要访问 Central Administrator 网站，然后进入 General Application Settings。在页面底部会看到 Reporting Services。
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_1.png)
 **Image1**:- SharePoint 配置对话框
 
-选择 "Reporting Services Integration" 链接。随后将显示以下屏幕。
+选择 "Reporting Services Integration" 链接。将显示以下屏幕。
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_2.png)
 **Image2**:- 指定 Reporting Services 集成凭据
 
 {{% /alert %}}
 
-## Web 服务 URL:
+## Web Service URL:
 
-**我们将提供在 Reporting Services 配置管理器中找到的报告服务器的 URL。**
+**我们将在 Reporting Services 配置管理器中找到的报告服务器的 URL 提供给您。**
 
-## 身份验证模式:
+## Authentication Mode:
 
-**我们还将选择一种身份验证模式。以下 MSDN 链接详细介绍了这些内容。
+**我们还将选择一个身份验证模式。以下 MSDN 链接详细说明了这些内容。
 SharePoint 集成模式下 Reporting Services 的安全概述**
 
 {{% alert color="primary" %}}
 
-**简而言之，如果您的站点使用声明式身份验证，则无论此处选择什么，您始终会使用受信任身份验证。如果您想传递 Windows 凭据，请选择 Windows 身份验证。对于受信任身份验证，我们将传递 SPUser 令牌，而不依赖 Windows 凭据。如果您已为经典模式站点配置了 NTLM 并且 RS 已设置为 NTLM，您也应使用受信任身份验证。要使用 Windows 身份验证并将其传递给数据源，需要 Kerberos。**
+**简而言之，如果您的站点使用声明式身份验证，无论此处选择什么，您都将使用受信任身份验证。如果您想传递 Windows 凭据，应选择 Windows 身份验证。对于受信任身份验证，我们将传递 SPUser 令牌，而不依赖 Windows 凭据。如果您已为经典模式站点配置了 NTLM 并且 RS 也设置为 NTLM，您也应使用受信任身份验证。使用 Windows 身份验证并将其传递给数据源需要 Kerberos。**
 
 {{% /alert %}}
 
@@ -46,7 +46,7 @@ SharePoint 集成模式下 Reporting Services 的安全概述**
 
 {{% alert color="primary" %}}
 
-**这使您可以选择在所有站点集合上激活 Reporting Services，或者选择要激活的特定站点集合。这实际上意味着哪些站点能够使用 Reporting Services。完成后，您应该会看到以下结果**
+**这让您可以选择在所有站点集合上激活 Reporting Services，或者仅选择您想要激活的站点集合。这实际上意味着哪些站点可以使用 Reporting Services。完成后，您应该会看到以下结果**
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_3.png)
 
@@ -55,24 +55,24 @@ SharePoint 集成模式下 Reporting Services 的安全概述**
 
 {{% alert color="primary" %}}
 
-返回到 ReportServer URL 时，我们应该看到类似如下的内容
+返回 ReportServer URL 时，我们应该看到类似以下内容
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_4.png)
 
 **Image4:**- Reporting Services 已成功连接到 SharePoint 环境
 
-**NOTE:** ***如果您的 SharePoint 站点已配置 SSL，它将不会出现在此列表中。这是已知问题，并不表示有问题。您的报告仍应正常工作。***
+**NOTE:** ***如果您的 SharePoint 站点已配置为 SSL，它将不会出现在此列表中。这是已知问题，并不意味着出现了问题。您的报告仍应正常工作。***
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-既然我们已成功集成这两个产品，现已准备好在 SharePoint 2010 中使用 Reporting Services。与之前的版本一样，我们在“Site Collection Feature”（在配置 Reporting Services 集成时激活）中拥有一个功能。安装过程还向站点添加了 3 种内容类型。在 Image 7 中我们可以看到其中 2 种内容类型已添加到文档库，以创建自定义报告，如下图 Image5 所示。
+现在我们已经成功集成了两个产品，准备在 SharePoint 2010 中使用 Reporting Services。与之前的版本一样，我们在“Site Collection Feature”（在配置 Reporting Services Integration 时激活）中有一个功能。安装还向我们的网站添加了 3 种内容类型。在 Image 7 中可以看到其中 2 种内容类型已在文档库中添加，用于创建自定义报告，如下图 Image5 所示。
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_5.png)
 
 **Image5:**- Report Builder
 
-“Reporter Builder” 是一个 ActiveX 控件，因此我们需要在服务器上下载它，正如下面的 Image 6 所示。
+“Reporter Builder” 是一个 ActiveX 控件，所以我们需要在服务器上下载它，如下图 Image 6 所示。
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_6.png)
 
@@ -81,7 +81,7 @@ SharePoint 集成模式下 Reporting Services 的安全概述**
 
 {{% alert color="primary" %}}
 
-下载过程完成后，加载 “Report Builder” 控件。现在我们可以设计我们的第一个报告，如下图 Image7 所示。
+下载过程完成后，加载 “Report Builder” 控件。现在我们准备好设计我们的第一个报告，如下图 Image7 所示。
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_7.png)
 
@@ -90,11 +90,10 @@ SharePoint 集成模式下 Reporting Services 的安全概述**
 
 {{% alert color="primary" %}}
 
-创建报告后，我们可以将其保存在已创建的文档库中，以便在 SharePoint 2010 中存放报告。必须使用另一种内容类型来创建共享连接作为数据源，并将其保存在 SharePoint 的文档库中。我们可以创建文档库，添加此内容类型，然后即可拥有可用于更改报告数据源的连接。
+创建报告后，我们可以将其保存到已创建的文档库中，以放置在 SharePoint 2010 中的报告。必须使用另一种内容类型来创建共享连接作为数据源，并将其保存到 SharePoint 中的文档库。我们可以创建文档库，添加此内容类型，随后即可拥有可用的连接，以更改报告的数据源。
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_8.png)
 
-**Image8:**- Aspose.PDF for Reporting Services 与 MS SharePoint 成功集成
+**Image8:**- 成功集成 Aspose.PDF for Reporting Services 与 MS SharePoint
 {{% /alert %}}
-
 

--- a/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
+++ b/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
@@ -3,42 +3,42 @@ title: Reporting Services 和 SharePoint 配置
 linktitle: Reporting Services 和 SharePoint 配置
 type: docs
 weight: 40
-url: /zh/reportingservices/reporting-services-and-sharepoint-configuration/
-lastmod: "2026-07-29"
+url: /reportingservices/reporting-services-and-sharepoint-configuration/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-现在，SharePoint 已经在 RS 服务器上安装并配置，且 RS 已通过 Reporting Services Configuration Manager 完成设置，我们可以继续在 Central Admin 中进行配置。RS 2008 R2 实际上大大简化了此过程。我们过去需要执行一个 3 步的过程才能使其工作，而现在只需一步。
+现在，SharePoint 已在 RS 服务器上安装和配置，并且 RS 已通过 Reporting Services 配置管理器进行设置和设置，我们可以继续在 Central Admin 中进行配置。 RS 2008 R2 确实简化了这个过程。我们过去有一个 3 步流程，您必须执行该流程才能使其发挥作用。现在我们只差一步了。
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-我们想要访问 Central Administrator 网站，然后进入 General Application Settings。在页面底部会看到 Reporting Services。
+我们想要访问中央管理员网站，然后进入常规应用程序设置。在底部，我们将看到报告服务。
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_1.png)
-**Image1**:- SharePoint 配置对话框
+![Configuration-step1](reporting-services-and-sharepoint-configuration_1.png)
+**图片1**：- SharePoint 配置对话框
 
-选择 "Reporting Services Integration" 链接。将显示以下屏幕。
+选择“Reporting Services 集成”链接。将显示以下屏幕。
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_2.png)
-**Image2**:- 指定 Reporting Services 集成凭据
+![Configuration-step2](reporting-services-and-sharepoint-configuration_2.png)
+**Image2**：- 指定 Reporting Services 集成凭据
 
 {{% /alert %}}
 
-## Web Service URL:
+## 网络服务网址：
 
-**我们将在 Reporting Services 配置管理器中找到的报告服务器的 URL 提供给您。**
+**我们将提供在 Reporting Services 配置管理器中找到的报表服务器的 URL。**
 
-## Authentication Mode:
+## 认证方式：
 
-**我们还将选择一个身份验证模式。以下 MSDN 链接详细说明了这些内容。
+**我们还将选择一种身份验证模式。以下 MSDN 链接详细介绍了这些内容。
 SharePoint 集成模式下 Reporting Services 的安全概述**
 
 {{% alert color="primary" %}}
 
-**简而言之，如果您的站点使用声明式身份验证，无论此处选择什么，您都将使用受信任身份验证。如果您想传递 Windows 凭据，应选择 Windows 身份验证。对于受信任身份验证，我们将传递 SPUser 令牌，而不依赖 Windows 凭据。如果您已为经典模式站点配置了 NTLM 并且 RS 也设置为 NTLM，您也应使用受信任身份验证。使用 Windows 身份验证并将其传递给数据源需要 Kerberos。**
+**简而言之，如果您的网站使用声明身份验证，则无论您在此处选择什么，您都将始终使用受信任的身份验证。如果您想传递 Windows 凭据，则需要选择 Windows 身份验证。对于可信身份验证，我们将传递 SPUser 令牌，而不依赖于 Windows 凭据。如果您已为 NTLM 配置了经典模式站点并且为 NTLM 设置了 RS，您还需要使用受信任的身份验证。需要 Kerberos 来使用 Windows 身份验证并将其传递给您的数据源。**
 
 {{% /alert %}}
 
@@ -46,54 +46,54 @@ SharePoint 集成模式下 Reporting Services 的安全概述**
 
 {{% alert color="primary" %}}
 
-**这让您可以选择在所有站点集合上激活 Reporting Services，或者仅选择您想要激活的站点集合。这实际上意味着哪些站点可以使用 Reporting Services。完成后，您应该会看到以下结果**
+**这为您提供了在所有网站集上激活 Reporting Services 的选项，或者您可以选择要在哪些网站集上激活它。这实际上意味着哪些站点将能够使用 Reporting Services。完成后，您应该看到以下结果**
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_3.png)
+![Configuration-step3](reporting-services-and-sharepoint-configuration_3.png)
 
-**Image3:**- Reporting Services 与 SharePoint 环境成功集成
+**图片 3：**- Reporting Services 与 SharePoint 环境成功集成
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-返回 ReportServer URL 时，我们应该看到类似以下内容
+返回到 ReportServer URL，我们应该看到类似于以下内容的内容
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_4.png)
+![Configuration-step4](reporting-services-and-sharepoint-configuration_4.png)
 
-**Image4:**- Reporting Services 已成功连接到 SharePoint 环境
+**图片4：**- Reporting Services 已成功连接 SharePoint 环境
 
-**NOTE:** ***如果您的 SharePoint 站点已配置为 SSL，它将不会出现在此列表中。这是已知问题，并不意味着出现了问题。您的报告仍应正常工作。***
+**注意：** ***如果您的 SharePoint 网站配置了 SSL，则它不会显示在此列表中。这是一个已知问题，并不意味着存在问题。您的报告应该仍然有效。***
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-现在我们已经成功集成了两个产品，准备在 SharePoint 2010 中使用 Reporting Services。与之前的版本一样，我们在“Site Collection Feature”（在配置 Reporting Services Integration 时激活）中有一个功能。安装还向我们的网站添加了 3 种内容类型。在 Image 7 中可以看到其中 2 种内容类型已在文档库中添加，用于创建自定义报告，如下图 Image5 所示。
+现在我们已经成功集成了这两个产品，我们已经准备好在 SharePoint 2010 中使用 Reporting Services。与之前的版本一样，我们在“网站集功能”中拥有一个功能（在配置 Reporting Services 集成时激活）。此外，安装还添加了 3 种内容类型以添加​​到我们的网站。在图 7 中，我们可以看到文档库中添加了其中 2 个内容类型，以使用 来创建自定义报告，如下面的图 5 所示。
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_5.png)
+![Configuration-step5](reporting-services-and-sharepoint-configuration_5.png)
 
-**Image5:**- Report Builder
+**图片 5：**- 报告生成器
 
-“Reporter Builder” 是一个 ActiveX 控件，所以我们需要在服务器上下载它，如下图 Image 6 所示。
+“Reporter Builder”是一个 ActiveX 控件，因此我们需要通过服务器下载它，如下图 6 所示。
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_6.png)
+![Configuration-step6](reporting-services-and-sharepoint-configuration_6.png)
 
-**Image6:**- 下载并安装 Report Builder
+**图片 6：**- 下载并安装报表生成器
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-下载过程完成后，加载 “Report Builder” 控件。现在我们准备好设计我们的第一个报告，如下图 Image7 所示。
+下载过程完成后，加载“Report Builder”控件。现在我们准备设计我们的第一份报告，如下图 7 所示。
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_7.png)
+![Configuration-step7](reporting-services-and-sharepoint-configuration_7.png)
 
-**Image7:**- Report Builder – 新建报告向导
+**图片 7：**- 报告生成器 – 新的报告生成向导
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-创建报告后，我们可以将其保存到已创建的文档库中，以放置在 SharePoint 2010 中的报告。必须使用另一种内容类型来创建共享连接作为数据源，并将其保存到 SharePoint 中的文档库。我们可以创建文档库，添加此内容类型，随后即可拥有可用的连接，以更改报告的数据源。
+创建报告后，我们可以将其保存在为将报告放入 SharePoint 2010 中而创建的文档库中。必须使用其他内容类型来创建共享连接作为数据源，并将它们保存在 SharePoint 的文档库中。我们可以创建一个文档库，添加此内容类型，然后我们可以使用我们的连接来更改报告的数据源。
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_8.png)
+![Configuration-step8](reporting-services-and-sharepoint-configuration_8.png)
 
-**Image8:**- 成功集成 Aspose.PDF for Reporting Services 与 MS SharePoint
+**图片 8：**- Aspose.PDF for Reporting Services 与 MS SharePoint 成功集成
 {{% /alert %}}
 

--- a/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
+++ b/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
@@ -1,100 +1,100 @@
 ---
-title: 设置 Reporting Services
-linktitle: 设置 Reporting Services
+title: 设置报告服务
+linktitle: 设置报告服务
 type: docs
 weight: 20
-url: /zh/reportingservices/setting-up-reporting-services/
-lastmod: "2026-07-29"
+url: /reportingservices/setting-up-reporting-services/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-我们在 Reporting Services 服务器的第一站是 Reporting Services 配置管理器。
+我们在 Reporting Services 服务器上的第一站是 Reporting Services 配置管理器。
 
 {{% /alert %}}
 
-## 服务账户：
+## 服务帐号：
 
-**请务必了解您在 Reporting Services 中使用的服务账户。如果我们遇到问题，可能与您使用的服务账户有关。默认是 Network Service。当我们部署新版本时，始终使用域账户，因为这通常是会出现问题的地方。对于该服务器实例，我们使用了名为 RSService 的域账户。**
+**请务必了解您用于 Reporting Services 的服务帐户。如果我们遇到问题，可能与您使用的服务帐户有关。默认为网络服务。当我们部署新版本时，我们总是使用域帐户，因为这就是我们可能遇到问题的地方。对于此服务器实例，我们使用了名为 RSService 的域帐户。**
 
-![todo:image_alt_text](setting-up-reporting-services_1.png)
+![Set Up](setting-up-reporting-services_1.png)
 
-**Image1:- 设置服务账户**
+**图片1：- 设置服务帐户**
 
-## Web Service URL：
+## 网络服务网址：
 
 {{% alert color="primary" %}}
 
-**我们需要配置 Web Service URL。这是承载 Web Services Reporting Services 使用的 Web Services 的 ReportServer 虚拟目录 (vdir)，也是 SharePoint 将要通信的目标。除非您想自定义 vdir 的属性（即 SSL、端口、主机头等…），否则只需点击此处的 Apply 即可，操作完成。**
-![todo:image_alt_text](setting-up-reporting-services_2.png)
+**我们需要配置 Web 服务 URL。这是承载 Reporting Services 使用的 Web 服务以及 SharePoint 将与之通信的 ReportServer 虚拟目录 (vdir)。除非您想自定义 vdir 的属性（即 SSL、端口、主机标头等），否则您应该只需单击此处的“应用”即可开始。**
+![Web Service URL](setting-up-reporting-services_2.png)
 
-**Image2:- 设置 Web Service URL 后，一旦 Web Service URL 已设置，您应该能够看到以下结果**
+**Image2:- 设置 Web 服务 URL 设置 Web 服务 URL 后，您应该能够看到以下结果**
 
-![todo:image_alt_text](setting-up-reporting-services_3.png)
+![Web Service URL Results](setting-up-reporting-services_3.png)
 
-**Image3:- 成功设置 Web Service URL**
+**Image3:- 成功设置 Web 服务 URL**
 {{% /alert %}}
 
 ## 数据库：
 
-**我们需要创建 Reporting Services 目录数据库。此数据库可以放置在任何 SQL 2008 或 SQL 2008 R2 数据库引擎上。SQL11 也可以正常工作，但仍处于 BETA 阶段。此操作默认会创建两个数据库：ReportServer 和 ReportServerTempDB。**
+**我们需要创建 Reporting Services 目录数据库。它可以放置在任何 SQL 2008 或 SQL 2008 R2 数据库引擎上。 SQL11 也可以正常工作，但仍处于测试阶段。默认情况下，此操作将创建两个数据库：ReportServer 和 ReportServerTempDB。**
 
 {{% alert color="primary" %}}
-**另一关键步骤是确保为数据库类型选择 SharePoint 集成。做出此选择后将无法更改。**
+**另一个重要步骤是确保您选择 SharePoint Integrated 作为数据库类型。一旦做出选择，就无法更改。**
 
-![todo:image_alt_text](setting-up-reporting-services_4.png)
+![Creating Report Server Database](setting-up-reporting-services_4.png)
 
 **Image4:- 创建报表服务器数据库**
 
-![todo:image_alt_text](setting-up-reporting-services_5.png)
+![Setting up Database Server and Authentication Type](setting-up-reporting-services_5.png)
 
-**Image5:- 设置数据库服务器和身份验证类型**
+**图 5：- 设置数据库服务器和身份验证类型**
 
-![todo:image_alt_text](setting-up-reporting-services_6.png)
+![Setting up Database Name and Mode](setting-up-reporting-services_6.png)
 
 **Image6:- 设置数据库名称和模式**
 {{% /alert %}}
 
-**对于凭据，这就是报表服务器与 SQL Server 通信的方式。无论您选择哪个帐户，都将通过 RSExecRole 获得在 Catalog 数据库以及一些系统数据库中的特定权限。MSDB 是其中一个用于订阅的数据库，因为我们使用 SQL Agent。**
+**对于凭据，这是报表服务器与 SQL Server 通信的方式。无论您选择什么帐户，都将通过 RSExecRole 在目录数据库以及一些系统数据库中获得某些权限。 MSDB 是用于订阅使用的数据库之一，因为我们使用 SQL 代理。**
 
-![todo:image_alt_text](setting-up-reporting-services_7.png)
+![Setting up Report Server database credentials](setting-up-reporting-services_7.png)
 
-**Image7:- 设置报表服务器数据库凭据**
+**图 7：- 设置报表服务器数据库凭据**
 
 {{% alert color="primary" %}}
 
-**一旦指定了数据库凭据，我们应该能够获得如下所示的结果。**
+**指定数据库凭据后，我们应该能够获得如下指定的结果。**
 
-![todo:image_alt_text](setting-up-reporting-services_8.png)
+![Report Server database creation progress](setting-up-reporting-services_8.png)
 
-**Image8:- 报表服务器数据库创建进度**
+**Image8:- 报告服务器数据库创建进度**
 
-![todo:image_alt_text](setting-up-reporting-services_9.png)
+![Report Server database completion summary](setting-up-reporting-services_9.png)
 
-**Image9:- 报表服务器数据库完成摘要**
+**Image9:- Report Server 数据库完成摘要**
 {{% /alert %}}
 
-## 报告管理器 URL:
+## 报告管理器网址：
 
-**当我们处于 SharePoint 集成模式时，可以跳过 Report Manager URL，因为它未被使用。SharePoint 是我们的前端。Report Manager 无法工作。**
+**我们可以跳过报表管理器 URL，因为当我们处于 SharePoint 集成模式时不会使用它。 SharePoint 是我们的前端。报告管理器不起作用。**
 
 ## 加密密钥：
 
 {{% alert color="primary" %}}
-**备份您的加密密钥，并确保您知道它们的存放位置。如果遇到需要迁移数据库或恢复数据库的情况，您将需要这些密钥。**
+**备份您的加密密钥并确保您知道它们的保存位置。如果您遇到需要迁移数据库或恢复数据库的情况，您将需要这些。**
 
-![todo:image_alt_text](setting-up-reporting-services_10.png)
+![Report Server Encryption key backup](setting-up-reporting-services_10.png)
 
-**Image10:- 报表服务器加密密钥备份**
+**图片 10：- 报表服务器加密密钥备份**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**恭喜！我们已成功使用配置管理器配置了 Reporting Services。如果您在“Web Service URL”选项卡中浏览该 URL，应该会看到类似以下内容。**
+**恭喜！我们已使用配置管理器成功配置了 Reporting Services。如果您浏览到“Web 服务 URL”选项卡上的 URL，它应该显示类似于以下内容的内容。**
 
-![todo:image_alt_text](setting-up-reporting-services_11.png)
+![Report Server access after installation](setting-up-reporting-services_11.png)
 
-**Image11:- 安装后报告服务器访问**
+**图片 11：- 安装后访问报表服务器**
 
-**错误原因：SharePoint 已在我们的 WFE 上安装，我们已完成 Reporting Services 的设置。在本例中，Reporting Services 和 SharePoint 位于不同的机器上。如果它们在同一台机器上，就不会出现此错误。实际上我们需要在 RS 服务器上安装 SharePoint。这意味着 IIS 也将被启用。**
+**错误原因：SharePoint 已安装在我们的 WFE 上，并且我们完成了 Reporting Services 的设置。在此示例中，Reporting Services 和 SharePoint 位于不同的计算机上。如果它们位于同一台计算机上，您就不会看到此错误。从技术上讲，我们需要在 RS Box 上安装 SharePoint。这意味着 IIS 也将被启用。**
 {{% /alert %}}
 

--- a/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
+++ b/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
@@ -4,7 +4,7 @@ linktitle: 设置 Reporting Services
 type: docs
 weight: 20
 url: /zh/reportingservices/setting-up-reporting-services/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
@@ -13,9 +13,9 @@ lastmod: "2026-06-19"
 
 {{% /alert %}}
 
-## 服务账户:
+## 服务账户：
 
-**确保了解您在报表服务中使用的服务账户。如果遇到问题，可能与您使用的服务账户有关。默认是 Network Service。当我们部署新构建时，总是使用域账户，因为这往往是问题的根源。对于此服务器实例，我们使用了名为 RSService 的域账户。**
+**请务必了解您在 Reporting Services 中使用的服务账户。如果我们遇到问题，可能与您使用的服务账户有关。默认是 Network Service。当我们部署新版本时，始终使用域账户，因为这通常是会出现问题的地方。对于该服务器实例，我们使用了名为 RSService 的域账户。**
 
 ![todo:image_alt_text](setting-up-reporting-services_1.png)
 
@@ -25,26 +25,26 @@ lastmod: "2026-06-19"
 
 {{% alert color="primary" %}}
 
-**我们需要配置 Web Service URL。这是承载 Reporting Services 使用的 Web Services 的 ReportServer 虚拟目录（vdir），也是 SharePoint 将要通信的对象。除非您想自定义 vdir 的属性（例如 SSL、端口、主机标头等），否则只需点击此处的“应用”，即可完成设置。**
+**我们需要配置 Web Service URL。这是承载 Web Services Reporting Services 使用的 Web Services 的 ReportServer 虚拟目录 (vdir)，也是 SharePoint 将要通信的目标。除非您想自定义 vdir 的属性（即 SSL、端口、主机头等…），否则只需点击此处的 Apply 即可，操作完成。**
 ![todo:image_alt_text](setting-up-reporting-services_2.png)
 
-**Image2:- 设置 Web Service URL 完成后，您应该能够看到以下结果**
+**Image2:- 设置 Web Service URL 后，一旦 Web Service URL 已设置，您应该能够看到以下结果**
 
 ![todo:image_alt_text](setting-up-reporting-services_3.png)
 
-**Image3:- Web Service URL 设置成功**
+**Image3:- 成功设置 Web Service URL**
 {{% /alert %}}
 
 ## 数据库：
 
-**我们需要创建 Reporting Services Catalog 数据库。它可以放置在任何 SQL 2008 或 SQL 2008 R2 数据库引擎上。SQL11 也可以正常工作，但仍处于 BETA 阶段。此操作默认会创建两个数据库：ReportServer 和 ReportServerTempDB。**
+**我们需要创建 Reporting Services 目录数据库。此数据库可以放置在任何 SQL 2008 或 SQL 2008 R2 数据库引擎上。SQL11 也可以正常工作，但仍处于 BETA 阶段。此操作默认会创建两个数据库：ReportServer 和 ReportServerTempDB。**
 
 {{% alert color="primary" %}}
-**此过程的另一个重要步骤是确保为数据库类型选择 SharePoint Integrated。一旦做出此选择，就无法更改。**
+**另一关键步骤是确保为数据库类型选择 SharePoint 集成。做出此选择后将无法更改。**
 
 ![todo:image_alt_text](setting-up-reporting-services_4.png)
 
-**Image4:- 创建报告服务器数据库**
+**Image4:- 创建报表服务器数据库**
 
 ![todo:image_alt_text](setting-up-reporting-services_5.png)
 
@@ -55,15 +55,15 @@ lastmod: "2026-06-19"
 **Image6:- 设置数据库名称和模式**
 {{% /alert %}}
 
-**对于凭据，这是报告服务器与 SQL Server 通信的方式。无论您选择哪个帐户，都将在 Catalog 数据库以及通过 RSExecRole 的几个系统数据库中赋予一定权限。MSDB 是其中一个用于订阅的数据库，因为我们使用 SQL Agent。**
+**对于凭据，这就是报表服务器与 SQL Server 通信的方式。无论您选择哪个帐户，都将通过 RSExecRole 获得在 Catalog 数据库以及一些系统数据库中的特定权限。MSDB 是其中一个用于订阅的数据库，因为我们使用 SQL Agent。**
 
 ![todo:image_alt_text](setting-up-reporting-services_7.png)
 
-**Image7:- 设置报告服务器数据库凭据**
+**Image7:- 设置报表服务器数据库凭据**
 
 {{% alert color="primary" %}}
 
-**一旦指定了数据库凭据，我们应该能够得到以下所示的结果。**
+**一旦指定了数据库凭据，我们应该能够获得如下所示的结果。**
 
 ![todo:image_alt_text](setting-up-reporting-services_8.png)
 
@@ -74,28 +74,27 @@ lastmod: "2026-06-19"
 **Image9:- 报表服务器数据库完成摘要**
 {{% /alert %}}
 
-## 报表管理器 URL:
+## 报告管理器 URL:
 
-**我们可以跳过 Report Manager URL，因为在 SharePoint 集成模式下它不被使用。SharePoint 是我们的前端。Report Manager 无法工作。**
+**当我们处于 SharePoint 集成模式时，可以跳过 Report Manager URL，因为它未被使用。SharePoint 是我们的前端。Report Manager 无法工作。**
 
 ## 加密密钥：
 
 {{% alert color="primary" %}}
-**备份您的加密密钥，并确保您知道它们保存位置。如果出现需要迁移数据库或恢复数据库的情况，您将需要这些密钥。**
+**备份您的加密密钥，并确保您知道它们的存放位置。如果遇到需要迁移数据库或恢复数据库的情况，您将需要这些密钥。**
 
 ![todo:image_alt_text](setting-up-reporting-services_10.png)
 
-**Image10:- Report Server 加密密钥备份**
+**Image10:- 报表服务器加密密钥备份**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**恭喜！我们已成功使用配置管理器配置了 Reporting Services。如果您在“Web Service URL”选项卡中浏览该 URL，它应该显示类似如下的内容。**
+**恭喜！我们已成功使用配置管理器配置了 Reporting Services。如果您在“Web Service URL”选项卡中浏览该 URL，应该会看到类似以下内容。**
 
 ![todo:image_alt_text](setting-up-reporting-services_11.png)
 
 **Image11:- 安装后报告服务器访问**
 
-**错误原因：SharePoint 已安装在我们的 WFE 上，我们已完成 Reporting Services 的设置。在此示例中，Reporting Services 和 SharePoint 位于不同的机器上。如果它们在同一台机器上，您就不会看到此错误。技术上我们需要在 RS 服务器上安装 SharePoint。这意味着 IIS 也将被启用。**
+**错误原因：SharePoint 已在我们的 WFE 上安装，我们已完成 Reporting Services 的设置。在本例中，Reporting Services 和 SharePoint 位于不同的机器上。如果它们在同一台机器上，就不会出现此错误。实际上我们需要在 RS 服务器上安装 SharePoint。这意味着 IIS 也将被启用。**
 {{% /alert %}}
-
 

--- a/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
+++ b/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
@@ -4,22 +4,22 @@ linktitle: 在 Reporting Services 服务器上设置 SharePoint
 type: docs
 weight: 30
 url: /zh/reportingservices/setting-up-sharepoint-on-reporting-services-server/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-现在我们需要执行与 SharePoint WFE 相同的步骤。首先要完成 Prereq uisites 安装，完成后启动 SharePoint 安装。
+现在我们需要执行与 SharePoint WFE 相同的步骤。第一件事是完成 Prereq uisites 安装，一旦完成，就启动 SharePoint 设置。
 
 {{% /alert %}}
 
-对于设置，我选择服务器场并进行完整安装以匹配我的 SharePoint Box，因为我不想进行独立的 SharePoint 安装。
+对于设置，我选择 Server Farm 并进行完整安装以匹配我的 SharePoint Box，因为我不想为 SharePoint 使用独立安装。
 
 ## SharePoint 配置
 
 {{% alert color="primary" %}}
 
-**在 SharePoint 配置向导中，我们希望连接到现有的服务器农场。**
+**在 SharePoint Configuration Wizard 中，我们希望连接到现有的 Server Farm。**
 
 ![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_1.png)
 
@@ -28,7 +28,7 @@ lastmod: "2026-06-19"
 
 {{% alert color="primary" %}}
 
-**然后我们将其指向我们农场使用的 SharePoint_Config 数据库。如果您不知道它的位置，可以通过 Central Admin 的 System Settings -> Manager Servers 在此农场中查找。**
+**我们随后会将其指向我们农场使用的 SharePoint_Config 数据库。如果您不知道它在哪里，可以通过中央管理的系统设置 -> 管理服务器 来查找此农场。**
 
 ![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_2.png)
 
@@ -41,10 +41,9 @@ lastmod: "2026-06-19"
 
 {{% alert color="primary" %}}
 
-**一旦向导完成，这就是我们目前在报告服务器盒子上需要做的全部工作。返回 ReportServer URL 时，我们会看到另一个错误，但那是因为我们尚未通过 Central Administrator 进行配置。**
+**一旦向导完成，这就是我们目前在 Report Server 机器上需要做的全部工作。返回 ReportServer URL 时，我们会看到另一个错误，但那是因为我们尚未通过 Central Administrator 进行配置。**
 
 ![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_4.png)
 
 **Image4:- 报告服务器错误**
 {{% /alert %}}
-

--- a/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
+++ b/zh/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
@@ -1,49 +1,49 @@
 ---
-title: 在 Reporting Services 服务器上设置 SharePoint
-linktitle: 在 Reporting Services 服务器上设置 SharePoint
+title: 在 Reporting ServicesReporting Services 服务器上设置 SharePoint
+linktitle: 在 Reporting ServicesReporting Services 服务器上设置 SharePoint
 type: docs
 weight: 30
-url: /zh/reportingservices/setting-up-sharepoint-on-reporting-services-server/
-lastmod: "2026-07-29"
+url: /reportingservices/setting-up-sharepoint-on-reporting-services-server/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-现在我们需要执行与 SharePoint WFE 相同的步骤。第一件事是完成 Prereq uisites 安装，一旦完成，就启动 SharePoint 设置。
+现在我们需要执行与 SharePoint WFE 类似的步骤。首先是完成 Prereq uisites 安装，完成后启动 SharePoint 设置。
 
 {{% /alert %}}
 
-对于设置，我选择 Server Farm 并进行完整安装以匹配我的 SharePoint Box，因为我不想为 SharePoint 使用独立安装。
+对于设置，我选择服务器场和完整安装以匹配我的 SharePoint Box，因为我不想要 SharePoint 的独立安装。
 
 ## SharePoint 配置
 
 {{% alert color="primary" %}}
 
-**在 SharePoint Configuration Wizard 中，我们希望连接到现有的 Server Farm。**
+**在 SharePoint 配置向导中，我们想要连接到现有场。**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_1.png)
+![SharePoint 配置向导](setting-up-sharepoint-on-reporting-services-server_1.png)
 
-**Image1:- SharePoint 配置向导**
+**图片1：- SharePoint 配置向导**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**我们随后会将其指向我们农场使用的 SharePoint_Config 数据库。如果您不知道它在哪里，可以通过中央管理的系统设置 -> 管理服务器 来查找此农场。**
+**然后，我们将其指向我们场正在使用的 SharePoint_Config 数据库。如果您不知道这是在哪里，您可以通过中央管理通过系统设置 -> 该场中的管理服务器来查找。**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_2.png)
+![SharePoint 配置数据库](setting-up-sharepoint-on-reporting-services-server_2.png)
 
 **Image2:- 指定数据库配置设置**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_3.png)
+![SharePoint 配置向导](setting-up-sharepoint-on-reporting-services-server_3.png)
 
-**Image3:- SharePoint 配置向导**
+**图片3：- SharePoint 配置向导**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**一旦向导完成，这就是我们目前在 Report Server 机器上需要做的全部工作。返回 ReportServer URL 时，我们会看到另一个错误，但那是因为我们尚未通过 Central Administrator 进行配置。**
+**向导完成后，这就是我们现在需要在报表服务器盒上执行的操作。返回到 ReportServer URL，我们将看到另一个错误，但那是因为我们尚未通过 Central Administrator 配置它。**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_4.png)
+![SharePoint 配置错误](setting-up-sharepoint-on-reporting-services-server_4.png)
 
 **Image4:- 报告服务器错误**
 {{% /alert %}}


### PR DESCRIPTION
## Summary
- rebuild zh/reportingservices from en/reportingservices
- regenerate Markdown translations with the Hugo translation CLI
- preserve the locale asset set and backfill five CLI restoration failures from the existing Chinese pages to keep the folder complete

## Validation
- matched English eportingservices file and Markdown counts
- checked that no @@DOC_TRANSLATE_ placeholders remain
