### PR TITLE
Translate reportingservices to Portuguese

### DIFF
--- a/en/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
+++ b/en/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
@@ -30,7 +30,7 @@ In the following example, the report contains a Textbox with the value `AsposePd
 
 ## Example
 
-```cs
+```xml
 <Textbox Name="Textbox1">
 ...
 <Paragraphs>

--- a/pt/reportingservices/_index.md
+++ b/pt/reportingservices/_index.md
@@ -1,47 +1,47 @@
 ---
-title: Documentation
+title: Documentação
 linktitle:  Aspose.PDF for Reporting Services
 second_title: Aspose.PDF for Reporting Services
 type: docs
 weight: 120
 url: /reportingservices/
-description: Discover Aspose.PDF for Reporting Services. Generate PDF reports directly from SQL Server Reporting Services (SSRS) with advanced customization.
+description: Descubra Aspose.PDF para Reporting Services. Gere relatórios em PDF diretamente do SQL Server Reporting Services (SSRS) com personalização avançada.
 is_root: true
 lastmod: "2024-05-05"
 ---
 
 {{% alert color="primary" %}}
 
-![Aspose.PDF for Reporting Services Logo](home_5.png)
+![Aspose.PDF para logotipo do Reporting Services](home_5.png)
 
-## Welcome to Aspose.PDF for Reporting Services
+## Bem-vindo ao Aspose.PDF para Reporting Services
 
-Microsoft SQL Server Reporting Services fulfills a need that many organizations have: the need to build business intelligence and reporting solutions. Until now, developers were required to embed reports into their applications, or organizations were required to buy expensive and sometimes problematic third-party reporting solutions. Now, Microsoft SQL Server Reporting Services offers a complete solution for distributing reports across the enterprise; enabling businesses to make decisions better and faster.
+O Microsoft SQL Server Reporting Services atende a uma necessidade que muitas organizações têm: a necessidade de criar soluções de business intelligence e relatórios. Até agora, os desenvolvedores eram obrigados a incorporar relatórios em seus aplicativos ou as organizações eram obrigadas a comprar soluções de relatórios de terceiros caras e às vezes problemáticas. Agora, o Microsoft SQL Server Reporting Services oferece uma solução completa para distribuição de relatórios em toda a empresa; permitindo que as empresas tomem decisões melhores e mais rápidas.
 
 {{% /alert %}}
 
-## Topics
+## Tópicos
 
-- [Product Overview](/pdf/reportingservices/product-overview/)
-- [Supported File Formats](/pdf/reportingservices/supported-file-formats/)
-- [Features](/pdf/reportingservices/features/)
-- [Sample Reports Gallery](/pdf/reportingservices/sample-reports-gallery/)
-- [Install Aspose.PDF for Reporting Services](/pdf/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [License Aspose.PDF for Reporting Services](/pdf/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [Configure Aspose.PDF for Reporting Services](/pdf/reportingservices/configure-aspose-pdf-for-reporting-services/)
-- [Expand Report Items Properties](/pdf/reportingservices/expand-report-items-properties/)
-- [Evaluate Aspose.PDF for Reporting Services](/pdf/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
+- [Visão geral do produto](/pdf/pt/reportingservices/product-overview/)
+- [Formatos de arquivo suportados](/pdf/pt/reportingservices/supported-file-formats/)
+- [Características](/pdf/pt/reportingservices/features/)
+- [Galeria de exemplos de relatórios](/pdf/pt/reportingservices/sample-reports-gallery/)
+- [Instale Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [Licença Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [Configurar Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [Expanda Propriedades de Itens de Relatório](/pdf/pt/reportingservices/expand-report-items-properties/)
+- [Avalie Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
 
-## Aspose.PDF for Reporting Services Resources
+## Aspose.PDF para recursos do Reporting Services
 
-- [Aspose.PDF for Reporting Services Product Overview](/pdf/reportingservices/product-overview/)
-- [Aspose.PDF for Reporting Services Supported File Formats](/pdf/reportingservices/supported-file-formats/)
-- [Aspose.PDF for Reporting Services Features](/pdf/reportingservices/features/)
-- [Aspose.PDF for Reporting Services Release Notes](https://releases.aspose.com/pdf/reportingservices/release-notes/)
-- [Download Aspose.PDF for Reporting Services](https://releases.aspose.com/pdf/reportingservices/)
-- [Sample Reports Gallery Aspose.PDF for Reporting Services](/pdf/reportingservices/sample-reports-gallery/)
-- [Install Aspose.PDF for Reporting Services](/pdf/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [License Aspose.PDF for Reporting Services](/pdf/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [Configure Aspose.PDF for Reporting Services](/pdf/reportingservices/configure-aspose-pdf-for-reporting-services/)
-- [Expand Report Items Properties](/pdf/reportingservices/expand-report-items-properties/)
-- [Evaluate Aspose.PDF for Reporting Services](/pdf/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
+- [Aspose.PDF para visão geral do produto Reporting Services](/pdf/pt/reportingservices/product-overview/)
+- [Aspose.PDF para formatos de arquivo suportados pelo Reporting Services](/pdf/pt/reportingservices/supported-file-formats/)
+- [Aspose.PDF para recursos do Reporting Services](/pdf/pt/reportingservices/features/)
+- [Aspose.PDF para notas de versão do Reporting Services](https://releases.aspose.com/pdf/reportingservices/release-notes/)
+- [Baixe Aspose.PDF para Reporting Services](https://releases.aspose.com/pdf/reportingservices/)
+- [Galeria de exemplos de relatórios Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/sample-reports-gallery/)
+- [Instale Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [Licença Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [Configurar Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [Expanda Propriedades de Itens de Relatório](/pdf/pt/reportingservices/expand-report-items-properties/)
+- [Avalie Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/)

--- a/pt/reportingservices/_index.md
+++ b/pt/reportingservices/_index.md
@@ -1,48 +1,47 @@
 ---
-title: Documentação
+title: Documentation
 linktitle:  Aspose.PDF for Reporting Services
 second_title: Aspose.PDF for Reporting Services
 type: docs
 weight: 120
-url: /pt/reportingservices/
-description: Descubra o Aspose.PDF for Reporting Services. Gere relatórios PDF diretamente do SQL Server Reporting Services (SSRS) com personalização avançada.
+url: /reportingservices/
+description: Discover Aspose.PDF for Reporting Services. Generate PDF reports directly from SQL Server Reporting Services (SSRS) with advanced customization.
 is_root: true
-lastmod: "2026-06-19"
+lastmod: "2024-05-05"
 ---
 
 {{% alert color="primary" %}}
 
-![Aspose.PDF for Reporting Services Logotipo](home_5.png)
+![Aspose.PDF for Reporting Services Logo](home_5.png)
 
-## Bem-vindo ao Aspose.PDF for Reporting Services
+## Welcome to Aspose.PDF for Reporting Services
 
-Microsoft SQL Server Reporting Services atende a uma necessidade que muitas organizações têm: a necessidade de criar soluções de inteligência empresarial e de relatórios. Até agora, os desenvolvedores eram obrigados a incorporar relatórios em suas aplicações, ou as organizações eram obrigadas a comprar soluções de relatórios de terceiros caras e, às vezes, problemáticas. Agora, o Microsoft SQL Server Reporting Services oferece uma solução completa para distribuir relatórios em toda a empresa; permitindo que as empresas tomem decisões melhores e mais rápidas.
+Microsoft SQL Server Reporting Services fulfills a need that many organizations have: the need to build business intelligence and reporting solutions. Until now, developers were required to embed reports into their applications, or organizations were required to buy expensive and sometimes problematic third-party reporting solutions. Now, Microsoft SQL Server Reporting Services offers a complete solution for distributing reports across the enterprise; enabling businesses to make decisions better and faster.
 
 {{% /alert %}}
 
-## Tópicos
+## Topics
 
-- [Visão geral do produto](/pdf/pt/reportingservices/product-overview/)
-- [Formatos de arquivo suportados](/pdf/pt/reportingservices/supported-file-formats/)
-- [Recursos](/pdf/pt/reportingservices/features/)
-- [Galeria de Relatórios de Exemplo](/pdf/pt/reportingservices/sample-reports-gallery/)
-- [Instalar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [Licenciar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [Configurar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/configure-aspose-pdf-for-reporting-services/)
-- [Expandir Propriedades dos Itens de Relatório](/pdf/pt/reportingservices/expand-report-items-properties/)
-- [Avaliar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
+- [Product Overview](/pdf/reportingservices/product-overview/)
+- [Supported File Formats](/pdf/reportingservices/supported-file-formats/)
+- [Features](/pdf/reportingservices/features/)
+- [Sample Reports Gallery](/pdf/reportingservices/sample-reports-gallery/)
+- [Install Aspose.PDF for Reporting Services](/pdf/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [License Aspose.PDF for Reporting Services](/pdf/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [Configure Aspose.PDF for Reporting Services](/pdf/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [Expand Report Items Properties](/pdf/reportingservices/expand-report-items-properties/)
+- [Evaluate Aspose.PDF for Reporting Services](/pdf/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
 
-## Aspose.PDF for Reporting Services Recursos
+## Aspose.PDF for Reporting Services Resources
 
-- [Aspose.PDF for Reporting Services Visão geral do produto](/pdf/pt/reportingservices/product-overview/)
-- [Aspose.PDF for Reporting Services Formatos de arquivo suportados](/pdf/pt/reportingservices/supported-file-formats/)
-- [Aspose.PDF for Reporting Services Funcionalidades](/pdf/pt/reportingservices/features/)
-- [Aspose.PDF for Reporting Services Notas de versão](https://releases.aspose.com/pdf/reportingservices/release-notes/)
-- [Baixar Aspose.PDF for Reporting Services](https://releases.aspose.com/pdf/reportingservices/)
-- [Galeria de Relatórios de Exemplo Aspose.PDF for Reporting Services](/pdf/pt/reportingservices/sample-reports-gallery/)
-- [Instalar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [Licenciar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [Configurar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/configure-aspose-pdf-for-reporting-services/)
-- [Expandir Propriedades dos Itens de Relatório](/pdf/pt/reportingservices/expand-report-items-properties/)
-- [Avaliar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
-
+- [Aspose.PDF for Reporting Services Product Overview](/pdf/reportingservices/product-overview/)
+- [Aspose.PDF for Reporting Services Supported File Formats](/pdf/reportingservices/supported-file-formats/)
+- [Aspose.PDF for Reporting Services Features](/pdf/reportingservices/features/)
+- [Aspose.PDF for Reporting Services Release Notes](https://releases.aspose.com/pdf/reportingservices/release-notes/)
+- [Download Aspose.PDF for Reporting Services](https://releases.aspose.com/pdf/reportingservices/)
+- [Sample Reports Gallery Aspose.PDF for Reporting Services](/pdf/reportingservices/sample-reports-gallery/)
+- [Install Aspose.PDF for Reporting Services](/pdf/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [License Aspose.PDF for Reporting Services](/pdf/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [Configure Aspose.PDF for Reporting Services](/pdf/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [Expand Report Items Properties](/pdf/reportingservices/expand-report-items-properties/)
+- [Evaluate Aspose.PDF for Reporting Services](/pdf/reportingservices/evaluate-aspose-pdf-for-reporting-services/)

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
@@ -1,15 +1,15 @@
 ---
 title: Configurar
-linktitle: Configurar
+linktitle: Configure
 
 type: docs
 weight: 80
-url: /pt/reportingservices/configure-aspose-pdf-for-reporting-services/
-description: Aprenda como configurar o Aspose.PDF for Reporting Services para personalizar as configurações de saída de PDF dos seus relatórios SSRS de forma eficiente.
-lastmod: "2026-07-29"
+url: /reportingservices/configure-aspose-pdf-for-reporting-services/
+description: Aprenda como configurar o Aspose.PDF para Reporting Services para personalizar as configurações de saída de PDF para seus relatórios SSRS com eficiência.
+lastmod: "2021-06-05"
 ---
 
 ## Esta seção inclui os seguintes tópicos:
 
-- [Definir Parâmetros](/pdf/pt/reportingservices/setting-parameters/)
-- [Parâmetros Suportados](/pdf/pt/reportingservices/supported-parameters/)
+- [Definir parâmetros](/pdf/pt/reportingservices/setting-parameters/)
+- [Parâmetros suportados](/pdf/pt/reportingservices/supported-parameters/)

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
@@ -5,12 +5,11 @@ linktitle: Configurar
 type: docs
 weight: 80
 url: /pt/reportingservices/configure-aspose-pdf-for-reporting-services/
-description: Saiba como configurar o Aspose.PDF for Reporting Services para personalizar as configurações de saída do PDF nos seus relatórios SSRS de forma eficiente.
-lastmod: "2026-06-19"
+description: Aprenda como configurar o Aspose.PDF for Reporting Services para personalizar as configurações de saída de PDF dos seus relatórios SSRS de forma eficiente.
+lastmod: "2026-07-29"
 ---
 
 ## Esta seção inclui os seguintes tópicos:
 
-- [Definir parâmetros](/pdf/pt/reportingservices/setting-parameters/)
-- [Parâmetros suportados](/pdf/pt/reportingservices/supported-parameters/)
-
+- [Definir Parâmetros](/pdf/pt/reportingservices/setting-parameters/)
+- [Parâmetros Suportados](/pdf/pt/reportingservices/supported-parameters/)

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
@@ -1,22 +1,22 @@
 ---
-title: Configuração de Parâmetros
-linktitle: Configuração de Parâmetros
+title: Setting Parameters
+linktitle: Setting Parameters
 type: docs
 weight: 10
-url: /pt/reportingservices/setting-parameters/
-description: Descubra como definir parâmetros para a renderização de PDF no Aspose.PDF for Reporting Services. Alcance controle preciso sobre a saída.
-lastmod: "2026-06-19"
+url: /reportingservices/setting-parameters/
+description: Find out how to set parameters for PDF rendering in Aspose.PDF for Reporting Services. Achieve precise control over output.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Você pode especificar certos parâmetros de configuração que afetam como o Aspose.Pdf for Reporting Services gera documentos. Esta seção descreve esse processo.
+You can specify certain configuration parameters that affect how Aspose.PDF for Reporting Services generates documents. This section describes this process.
 
 {{% /alert %}}
 
-Para configurar o Aspose.Pdf para Reporting Services, você precisa editar o arquivo C:\\Program Files\\Microsoft SQL Server\\<Instance>\\Reporting Services\\ReportServer\\rsreportserver.config. Este é um arquivo XML e a configuração do renderizador está dentro do ```<Extension>``` elemento correspondente ao renderizador Aspose.PDF.
+To configure Aspose.PDF for Reporting Services, you need to edit the C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config file. This is an XML file and the renderer configuration is inside the ```<Extension>``` element corresponding to the Aspose.PDF renderer.
 
-**Exemplo**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -35,15 +35,14 @@ For PageOrientation -->
 
 {{% alert color="primary" %}}
 
-Se você quiser definir parâmetros para um arquivo de relatório específico, mas não para todos os relatórios no servidor, pode adicionar um parâmetro de relatório para o relatório específico no Report Builder conforme as etapas a seguir (por exemplo, iremos adicionar um parâmetro ‘IsLandscape’ mostrado anteriormente):
+If you want to set parameters for specific report file but not for every report on the server, you can add a report parameter for the specific report in the Report Builder as the following steps (for example, we’ll add an 'IsLandscape' parameter shown earlier):
 
-1. Abra o relatório no Report Designer, clique com o botão direito na pasta ‘Parameters’ no painel ‘Report Data’ e selecione ‘Add Parameter…’ (ou, alternativamente, abra a lista ‘New’ e selecione ‘Parameter…’).
+1. Open the report in the Report Designer, right-click on the 'Parameters' folder in the 'Report Data' pane, and select 'Add Parameter…' (or, alternately, pull down the 'New' list and select 'Parameter…').
  
 ![todo:image_alt_text](setting-parameters_1.png)
 
-1. Na caixa de diálogo ‘Report Parameter Properties’, crie o parâmetro chamado ‘IsLandscape’, com o tipo de dado Boolean, e adicione o valor True na guia ‘Default Values’.
+1. In the 'Report Parameter Properties' dialog, create the parameter named 'IsLandscape', with the data type of Boolean, and add the value True in the 'Default Values' tab.
 
 ![todo:image_alt_text](setting-parameters_2.png)
 
 {{% /alert %}}
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
@@ -1,27 +1,26 @@
 ---
-title: Definir Parâmetros
-linktitle: Definir Parâmetros
+title: Definir parâmetros
+linktitle: Setting Parameters
 type: docs
 weight: 10
-url: /pt/reportingservices/setting-parameters/
-description: Descubra como definir parâmetros para a renderização de PDF no Aspose.PDF for Reporting Services e obter controle preciso sobre a saída.
-lastmod: "2026-07-29"
+url: /reportingservices/setting-parameters/
+description: Descubra como definir parâmetros para renderização de PDF em Aspose.PDF para Reporting Services. Obtenha controle preciso sobre a produção.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Você pode especificar determinados parâmetros de configuração que afetam a forma como o Aspose.PDF for Reporting Services gera documentos. Esta seção descreve esse processo.
+Você pode especificar determinados parâmetros de configuração que afetam como o Aspose.PDF for Reporting Services gera documentos. Esta seção descreve esse processo.
 
 {{% /alert %}}
 
-Para configurar o Aspose.PDF for Reporting Services, você precisa editar o arquivo `C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config`. Esse é um arquivo XML, e a configuração do renderizador fica dentro do elemento ```<Extension>``` correspondente ao renderizador Aspose.PDF.
+Para configurar Aspose.Pdf para Reporting Services, você precisa editar o arquivo `C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config`. Este é um arquivo XML e a configuração do renderizador está dentro do elemento `<Extension>` correspondente ao renderizador Aspose.PDF.
 
-**Example**
+## Exemplo
 
-{{< highlight csharp >}}
-
+```xml
 <Render>
-...
+…
 <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
 <!--Insert configuration elements for exporting to PDF here. The following is an example
 For PageOrientation -->
@@ -30,19 +29,18 @@ For PageOrientation -->
     </Configuration>
 </Extension>
 </Render>
-
-{{< /highlight >}}
+```
 
 {{% alert color="primary" %}}
 
-Se você quiser definir parâmetros para um arquivo de relatório específico, mas não para todos os relatórios no servidor, poderá adicionar um parâmetro de relatório para esse relatório no Report Builder seguindo as etapas abaixo. Neste exemplo, adicionaremos o parâmetro `IsLandscape` mostrado anteriormente.
+Se desejar definir parâmetros para um arquivo de relatório específico, mas não para todos os relatórios no servidor, você poderá adicionar um parâmetro de relatório para o relatório específico no Report Builder conforme as etapas a seguir (por exemplo, adicionaremos um parâmetro 'IsLandscape' mostrado anteriormente):
 
-1. Abra o relatório no Report Designer, clique com o botão direito na pasta `Parameters` no painel `Report Data` e selecione `Add Parameter...` (ou, alternativamente, abra a lista `New` e selecione `Parameter...`).
- 
-![todo:image_alt_text](setting-parameters_1.png)
+1. Abra o relatório no Report Designer, clique com o botão direito na pasta 'Parâmetros' no painel 'Dados do relatório' e selecione 'Adicionar parâmetro...' (ou, alternativamente, abra a lista 'Novo' e selecione 'Parâmetro...').
 
-1. Na caixa de diálogo `Report Parameter Properties`, crie o parâmetro chamado `IsLandscape`, defina o tipo de dado como Boolean e adicione o valor True na guia `Default Values`.
+![Parameters set up. Step 1](setting-parameters_1.png)
 
-![todo:image_alt_text](setting-parameters_2.png)
+1. Na caixa de diálogo 'Propriedades do parâmetro do relatório', crie o parâmetro denominado 'IsLandscape', com o tipo de dados Booleano, e adicione o valor True na guia 'Valores padrão'.
+
+![Parameters set up. Step 2](setting-parameters_2.png)
 
 {{% /alert %}}

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
@@ -5,10 +5,10 @@ type: docs
 weight: 20
 url: /pt/reportingservices/supported-parameters/
 description: Explore os parâmetros suportados no Aspose.PDF for Reporting Services para controlar e personalizar a renderização de PDF com facilidade.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-Um relatório parametrizado é um relatório que aceita valores de entrada usados no processamento do relatório. Com um relatório parametrizado, você pode variar a saída de um relatório com base nos valores definidos quando o relatório é executado. Aspose.Pdf for Reporting Services suporta dois tipos de parâmetros: parâmetros do servidor de relatórios e parâmetros do relatório. Os parâmetros do servidor de relatórios são usados para todos os relatórios no servidor de relatórios. Se você quiser tornar alguns parâmetros adequados para relatórios específicos, deve usar os parâmetros do relatório.
+Um relatório parametrizado é um relatório que aceita valores de entrada usados no processamento do relatório. Com um relatório parametrizado, você pode variar a saída de um relatório com base nos valores definidos quando o relatório é executado. O Aspose.PDF for Reporting Services suporta dois tipos de parâmetros: parâmetros do servidor de relatórios e parâmetros de relatório. Os parâmetros do servidor de relatórios são usados para todos os relatórios no servidor de relatórios. Se você quiser tornar alguns parâmetros adequados para relatórios específicos, deve usar parâmetros de relatório.
 
 Atualmente, o renderizador Aspose.Pdf suporta uma ampla variedade de parâmetros, como:
 
@@ -17,12 +17,11 @@ Atualmente, o renderizador Aspose.Pdf suporta uma ampla variedade de parâmetros
 - [Orientação da página](/pdf/pt/reportingservices/page-orientation/)
 - [Formatação HTML](/pdf/pt/reportingservices/html-formatting/)
 - [Configuração de Segurança](/pdf/pt/reportingservices/security-setting/)
-- [A Fonte Está Incorporada](/pdf/pt/reportingservices/isfontembedded/)
+- [IsFontEmbedded](/pdf/pt/reportingservices/isfontembedded/)
 - [Tamanho da Página](/pdf/pt/reportingservices/pagesize/)
 - [Tamanho da margem da página](/pdf/pt/reportingservices/page-margin-size/)
 - [Metadados XMP](/pdf/pt/reportingservices/xmp-metadata/)
-- [Informação de depuração](/pdf/pt/reportingservices/debug-information/)
+- [Informação de Depuração](/pdf/pt/reportingservices/debug-information/)
 - [Conformidade PDF_A](/pdf/pt/reportingservices/pdf_a-conformance/)
-
 
 

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
@@ -1,27 +1,25 @@
 ---
 title: Parâmetros suportados
-linktitle: Parâmetros suportados
+linktitle: Supported Parameters
 type: docs
 weight: 20
-url: /pt/reportingservices/supported-parameters/
-description: Explore os parâmetros suportados no Aspose.PDF for Reporting Services para controlar e personalizar a renderização de PDF com facilidade.
-lastmod: "2026-07-29"
+url: /reportingservices/supported-parameters/
+description: Explore os parâmetros suportados no Aspose.PDF for Reporting Services para controlar e personalizar sua renderização de PDF com facilidade.
+lastmod: "2021-06-05"
 ---
 
-Um relatório parametrizado é um relatório que aceita valores de entrada usados no processamento do relatório. Com um relatório parametrizado, você pode variar a saída de um relatório com base nos valores definidos quando o relatório é executado. O Aspose.PDF for Reporting Services suporta dois tipos de parâmetros: parâmetros do servidor de relatórios e parâmetros de relatório. Os parâmetros do servidor de relatórios são usados para todos os relatórios no servidor de relatórios. Se você quiser tornar alguns parâmetros adequados para relatórios específicos, deve usar parâmetros de relatório.
+Um relatório parametrizado é um relatório que aceita valores de entrada usados ​​no processamento de relatórios. Com um relatório parametrizado, você pode variar a saída de um relatório com base nos valores definidos quando o relatório é executado. Aspose.PDF for Reporting Services oferece suporte a dois tipos de parâmetros: parâmetros do servidor de relatório e parâmetros de relatório. Os parâmetros do servidor de relatórios são usados ​​para todos os relatórios no servidor de relatórios. Se quiser tornar alguns parâmetros adequados para relatórios específicos, você deve usar parâmetros de relatório.
 
-Atualmente, o renderizador Aspose.Pdf suporta uma ampla variedade de parâmetros, como:
+Atualmente, o renderizador Aspose.Pdf oferece suporte a uma ampla gama de parâmetros, como:
 
 **Esta seção inclui os seguintes tópicos:**
 
 - [Orientação da página](/pdf/pt/reportingservices/page-orientation/)
 - [Formatação HTML](/pdf/pt/reportingservices/html-formatting/)
-- [Configuração de Segurança](/pdf/pt/reportingservices/security-setting/)
+- [Configuração de segurança](/pdf/pt/reportingservices/security-setting/)
 - [IsFontEmbedded](/pdf/pt/reportingservices/isfontembedded/)
-- [Tamanho da Página](/pdf/pt/reportingservices/pagesize/)
+- [Tamanho da página](/pdf/pt/reportingservices/pagesize/)
 - [Tamanho da margem da página](/pdf/pt/reportingservices/page-margin-size/)
 - [Metadados XMP](/pdf/pt/reportingservices/xmp-metadata/)
-- [Informação de Depuração](/pdf/pt/reportingservices/debug-information/)
+- [Informações de depuração](/pdf/pt/reportingservices/debug-information/)
 - [Conformidade PDF_A](/pdf/pt/reportingservices/pdf_a-conformance/)
-
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
@@ -1,36 +1,38 @@
 ---
-title: Informação de Depuração
-linktitle: Informação de Depuração
+title: Informações de depuração
+linktitle: Debug Information
 type: docs
 weight: 90
-url: /pt/reportingservices/debug-information/
-description: Acesse e analise informações de depuração da renderização de PDF no Aspose.PDF for Reporting Services para solucionar problemas de maneira eficaz.
-lastmod: "2026-07-29"
+url: /reportingservices/debug-information/
+description: Acesse e analise informações de depuração para renderização de PDF no Aspose.PDF for Reporting Services para solucionar problemas de maneira eficaz.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-É inevitável que haja algo errado na renderização ou no resultado renderizado. Por algumas razões, como sigilo ou privacidade, não conseguimos obter a fonte de dados usada no relatório do usuário, portanto não pudemos reproduzir o erro no relatório. Para tornar a comunicação entre clientes e desenvolvedores mais fácil e fluida, adicionamos este parâmetro. Se você encontrar problemas ao renderizar seu relatório com Aspose.PDF for Reporting Services, por favor defina este parâmetro no relatório; então você receberá o documento renderizado no formato XML. Em seguida, por favor publique o arquivo XML para nós no fórum do produto.
+É inevitável que haja algo errado com a renderização ou com o resultado renderizado. Por alguns motivos, como sigilo ou privacidade, não conseguimos obter a fonte de dados utilizada no relatório do usuário e, portanto, não conseguimos reproduzir o erro no relatório. Para tornar a comunicação entre clientes e desenvolvedores mais fácil e tranquila, adicionamos este parâmetro. Se você encontrar problemas ao renderizar seu relatório com Aspose.PDF para Reporting Services, defina este parâmetro de relatório, então você obterá o documento renderizado com o formato XML. Depois disso, poste o arquivo XML para nós no fórum do produto.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Nome do Parâmetro**: SavingXmlFormat  
-**Tipo de Dados**: Boolean  
-**Valores suportados**: True, False (padrão)  
 
-**Exemplo**
-{{< highlight csharp >}}
+```txt
+Parameter Name: SavingXmlFormat
+Date Type: Boolean  
+Values supported**: True, False (default)
+```
 
+## Exemplo
+
+```xml
 <Render>
 ...
 <Extension Name="APPDF" Type=" Aspose.PDF.ReportingServices.Renderer,Aspose.PDF.ReportingServices">
 <Configuration>
-<SavingXmlFormat > Verdadeiro </SavingXmlFormat>
+<SavingXmlFormat > True </SavingXmlFormat>
 </Configuration>
 </Extension>
 </Render>
-
-{{< /highlight >}}
+```
 
 {{% /alert %}}

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
@@ -1,22 +1,22 @@
 ---
-title: Informações de depuração
-linktitle: Informações de depuração
+title: Informação de Depuração
+linktitle: Informação de Depuração
 type: docs
 weight: 90
 url: /pt/reportingservices/debug-information/
-description: Acesse e analise informações de depuração da renderização de PDF no Aspose.PDF for Reporting Services para solucionar problemas de forma eficaz.
-lastmod: "2026-06-19"
+description: Acesse e analise informações de depuração da renderização de PDF no Aspose.PDF for Reporting Services para solucionar problemas de maneira eficaz.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-É inevitável que algo esteja errado com a renderização ou com o resultado renderizado. Por razões como sigilo ou privacidade, não podemos obter a fonte de dados usada no relatório do usuário, portanto não conseguimos reproduzir o erro no relatório. Para tornar a comunicação entre clientes e desenvolvedores mais fácil e fluida, adicionamos este parâmetro. Se você encontrar problemas ao renderizar seu relatório com Aspose.PDF for Reporting Services, defina este parâmetro de relatório; assim você receberá o documento renderizado no formato XML. Em seguida, publique o arquivo XML para nós no fórum do produto.
+É inevitável que haja algo errado na renderização ou no resultado renderizado. Por algumas razões, como sigilo ou privacidade, não conseguimos obter a fonte de dados usada no relatório do usuário, portanto não pudemos reproduzir o erro no relatório. Para tornar a comunicação entre clientes e desenvolvedores mais fácil e fluida, adicionamos este parâmetro. Se você encontrar problemas ao renderizar seu relatório com Aspose.PDF for Reporting Services, por favor defina este parâmetro no relatório; então você receberá o documento renderizado no formato XML. Em seguida, por favor publique o arquivo XML para nós no fórum do produto.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 **Nome do Parâmetro**: SavingXmlFormat  
-**Tipo de Data**: Boolean  
+**Tipo de Dados**: Boolean  
 **Valores suportados**: True, False (padrão)  
 
 **Exemplo**
@@ -26,7 +26,7 @@ lastmod: "2026-06-19"
 ...
 <Extension Name="APPDF" Type=" Aspose.PDF.ReportingServices.Renderer,Aspose.PDF.ReportingServices">
 <Configuration>
-<SavingXmlFormat > True </SavingXmlFormat>
+<SavingXmlFormat > Verdadeiro </SavingXmlFormat>
 </Configuration>
 </Extension>
 </Render>
@@ -34,4 +34,3 @@ lastmod: "2026-06-19"
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
@@ -46,6 +46,6 @@ Values supported: True, False (default)
 
 Se desejar adicionar esse parâmetro no Report Designer, use o tipo de dados `Boolean`.
 
-Atualmente Aspose.Pdf para Reporting Services oferece suporte a um subconjunto de todas as tags HTML. Você pode encontrar mais informações no Aspose.PDF [Documentation](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
+Atualmente Aspose.Pdf para Reporting Services oferece suporte a um subconjunto de todas as tags HTML. Você pode encontrar mais informações em Aspose.PDF [Documentação](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
 
 {{% /alert %}}

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
@@ -1,35 +1,35 @@
 ---
-title: Formatação HTML
-linktitle: Formatação HTML
+title: HTML Formatting
+linktitle: HTML Formatting
 type: docs
 weight: 20
-url: /pt/reportingservices/html-formatting/
-description: Habilite a formatação HTML em relatórios PDF usando Aspose.PDF for Reporting Services. Adicione estilos e estrutura com facilidade.
-lastmod: "2026-06-19"
+url: /reportingservices/html-formatting/
+description: Enable HTML formatting in PDF reports using Aspose.PDF for Reporting Services. Add styles and structure with ease.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Às vezes, você pode desejar exportar texto em caixas de texto com formatação. Infelizmente, o Reporting Services não oferece suporte a isso. No entanto, ainda é possível implementá‑lo usando Aspose.PDF for Reporting Services. Basta habilitar um modo especial no qual todo o texto nas caixas de texto é tratado como HTML e inserir as tags HTML necessárias para formatar o texto no documento de saída. Por exemplo, para ter texto normal, em negrito e itálico na mesma caixa de texto, insira o seguinte valor na caixa de texto:
+Sometimes you might wish to export text in textboxes with formatting. Unfortunately, Reporting Services does not support this. However, you still can implement it using Aspose.PDF for Reporting Services. Just enable a special mode in which all text in textboxes is treated as HTML and put the necessary HTML tags to format the text in the output document. For example, to have normal, bold and italic text in the same textbox, enter the following textbox value:
 
-Alguma parte deste texto é ```<b>bold</b>``` e outro texto é ```<i>italic</i>```.
+Some of this text is ```<b>bold</b>``` and other text is ```<i>italic</i>```.
 
-Ao exportar, o texto ficará assim: parte deste texto está **bold** e outro texto está *italic*.
+When exported, the text will look like as some of this text is **bold** and other text is *italic*.
 
-Observe que esta abordagem tem algumas limitações
+Please note that this approach has some limitations
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-- A formatação não é visível no tempo de design (no Report Builder, no portal web do Reporting Services etc.). Em vez disso, você verá o texto HTML na forma de texto simples com tags.
-- A extensão de renderização Aspose.PDF for Reporting Services reconhece e formata corretamente o código HTML em caixas de texto. O renderizador PDF padrão do Reporting Services exportará essa marcação como texto simples.
+- The formatting isn’t visible in design time (in the Report Builder, Reporting Services web portal etc.). Instead, you will see the HTML text in form of plain text with tags.
+- Aspose.PDF for Reporting Services rendering extension recognizes and properly formats HTML code in textboxes. The default PDF renderer of Reporting Services will export this markup as plain text.
 
-**Nome do Parâmetro**: IsHtmlTagSupported  
-**Tipo de Dados**: Boolean  
-**Valores suportados**: True, False (padrão)   
+**Parameter Name**: IsHtmlTagSupported  
+**Date Type**: Boolean  
+**Values supported**: True, False (default)   
 
-**Exemplo**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -44,10 +44,9 @@ Observe que esta abordagem tem algumas limitações
 
 {{< /highlight >}}
 
-Se você quiser adicionar este parâmetro no Report Designer, use o tipo de dados 'Boolean'.
+If you want to add this parameter in the Report Designer, use the 'Boolean' data type.
 
  
-Atualmente Aspose.Pdf for Reporting Services suporta um subconjunto de todas as tags HTML. Você pode encontrar mais informações na documentação do Aspose.PDF [Documentação](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
+Currently Aspose.PDF for Reporting Services supports a subset of all the HTML tags. You may find more information in the Aspose.PDF [Documentation](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
 
 {{% /alert %}}
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
@@ -1,39 +1,40 @@
 ---
-title: HTML Formatting
+title: Formatação HTML
 linktitle: HTML Formatting
 type: docs
 weight: 20
 url: /reportingservices/html-formatting/
-description: Enable HTML formatting in PDF reports using Aspose.PDF for Reporting Services. Add styles and structure with ease.
+description: Habilite a formatação HTML em relatórios PDF usando Aspose.PDF para Reporting Services. Adicione estilos e estrutura com facilidade.
 lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Sometimes you might wish to export text in textboxes with formatting. Unfortunately, Reporting Services does not support this. However, you still can implement it using Aspose.PDF for Reporting Services. Just enable a special mode in which all text in textboxes is treated as HTML and put the necessary HTML tags to format the text in the output document. For example, to have normal, bold and italic text in the same textbox, enter the following textbox value:
+Às vezes você pode querer exportar texto em caixas de texto com formatação. Infelizmente, o Reporting Services não oferece suporte para isso. No entanto, você ainda pode implementá-lo usando Aspose.PDF para Reporting Services. Basta ativar um modo especial no qual todo o texto nas caixas de texto é tratado como HTML e colocar as tags HTML necessárias para formatar o texto no documento de saída. Por exemplo, para ter texto normal, em negrito e itálico na mesma caixa de texto, insira o seguinte valor de caixa de texto:
 
-Some of this text is ```<b>bold</b>``` and other text is ```<i>italic</i>```.
+Parte deste texto é `<b>bold</b>` e outro texto é `<i>italic</i>`.
 
-When exported, the text will look like as some of this text is **bold** and other text is *italic*.
+Quando exportado, o texto terá a aparência de parte deste texto em **negrito** e outro texto em *itálico*.
 
-Please note that this approach has some limitations
+Observe que esta abordagem tem algumas limitações
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-- The formatting isn’t visible in design time (in the Report Builder, Reporting Services web portal etc.). Instead, you will see the HTML text in form of plain text with tags.
-- Aspose.PDF for Reporting Services rendering extension recognizes and properly formats HTML code in textboxes. The default PDF renderer of Reporting Services will export this markup as plain text.
+- A formatação não é visível em tempo de design (no Report Builder, no portal da Web Reporting Services etc.). Em vez disso, você verá o texto HTML na forma de texto simples com tags.
+- A extensão de renderização Aspose.PDF para Reporting Services reconhece e formata corretamente o código HTML em caixas de texto. O renderizador de PDF padrão do Reporting Services exportará essa marcação como texto simples.
 
-**Parameter Name**: IsHtmlTagSupported  
-**Date Type**: Boolean  
-**Values supported**: True, False (default)   
+```text
+Parameter Name: IsHtmlTagSupported  
+Date Type: Boolean  
+Values supported: True, False (default)   
+```
 
-**Example**
+## Exemplo
 
-{{< highlight csharp >}}
-
- <Render>
+```xml
+<Render>
 ...
     <Extension Name="APPDF" Type=" Aspose.PDF.ReportingServices.Renderer,Aspose.PDF.ReportingServices ">
     <Configuration>
@@ -41,12 +42,10 @@ Please note that this approach has some limitations
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
+Se desejar adicionar esse parâmetro no Report Designer, use o tipo de dados `Boolean`.
 
-If you want to add this parameter in the Report Designer, use the 'Boolean' data type.
-
- 
-Currently Aspose.PDF for Reporting Services supports a subset of all the HTML tags. You may find more information in the Aspose.PDF [Documentation](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
+Atualmente Aspose.Pdf para Reporting Services oferece suporte a um subconjunto de todas as tags HTML. Você pode encontrar mais informações no Aspose.PDF [Documentation](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
 
 {{% /alert %}}

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
@@ -4,12 +4,12 @@ linktitle: IsFontEmbedded
 type: docs
 weight: 50
 url: /pt/reportingservices/isfontembedded/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-O designer do RS não oferece suporte à fonte incorporada para texto; com o Aspose.PDF for Reporting Services você pode incorporar facilmente informações de fontes em seu documento PDF.
+O RS designer não oferece suporte à fonte incorporada para texto; com Aspose.PDF for Reporting Services você pode incorporar facilmente informações de fonte ao seu documento PDF.
 
 {{% /alert %}}
 
@@ -25,7 +25,7 @@ O designer do RS não oferece suporte à fonte incorporada para texto; com o Asp
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsFontEmbedded>True</IsFontEmbedded>
+    <IsFontEmbedded>Verdadeiro</IsFontEmbedded>
     </Configuration>
     </Extension>
 </Render>
@@ -33,4 +33,3 @@ O designer do RS não oferece suporte à fonte incorporada para texto; com o Asp
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
@@ -3,33 +3,31 @@ title: IsFontEmbedded
 linktitle: IsFontEmbedded
 type: docs
 weight: 50
-url: /pt/reportingservices/isfontembedded/
-lastmod: "2026-07-29"
+url: /reportingservices/isfontembedded/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-O RS designer não oferece suporte à fonte incorporada para texto; com Aspose.PDF for Reporting Services você pode incorporar facilmente informações de fonte ao seu documento PDF.
+O designer RS ​​não oferece suporte à fonte incorporada para texto; com Aspose.PDF for Reporting Services você pode incorporar facilmente informações de fonte em seu documento PDF.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**Nome do Parâmetro**: IsFontEmbedded  
-**Tipo de Dados**: Boolean  
-**Valores suportados**: True, False (padrão)  
+```txt
+Parameter Name: IsFontEmbedded  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**Exemplo**
-{{< highlight csharp >}}
+## Exemplo
 
+```xml
 <Render>
-…
+...
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsFontEmbedded>Verdadeiro</IsFontEmbedded>
+    <IsFontEmbedded>True</IsFontEmbedded>
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
@@ -5,34 +5,34 @@ type: docs
 weight: 70
 url: /pt/reportingservices/page-margin-size/
 description: Ajuste os tamanhos das margens da página em relatórios PDF com Aspose.PDF for Reporting Services para melhorar a legibilidade e o layout.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-O designer de relatórios do Reporting Services não suporta a definição do tamanho das margens da página. Aspose.Pdf for Reporting Services fornece quatro parâmetros para definir o tamanho correspondente da margem da página, que são:
+O designer de relatórios do Reporting Services não suporta a definição do tamanho das margens da página. Aspose.PDF for Reporting Services fornece quatro parâmetros para definir o tamanho correspondente da margem da página, que são:
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 1)  
-**Nome do parâmetro**: PageMarginLeft  
-**Tipo de Dados**: Float  
+**Nome do Parâmetro**: PageMarginLeft  
+**Tipo de Data**: Float  
 **Valores suportados**:  Qualquer número positivo ou zero
 
 2)  
 **Nome do Parâmetro**: PageMarginRight  
-**Tipo de Dados**: Float  
+**Tipo de Data**: Float  
 **Valores suportados**:  Qualquer número positivo ou zero
 
 3)  
 **Nome do Parâmetro**: PageMarginTop  
-**Tipo de Dados**: Float  
+**Tipo de Data**: Float  
 **Valores suportados**:  Qualquer número positivo ou zero
 
 4)  
 **Nome do Parâmetro**: PageMarginBottom  
-**Tipo de Dados**: Float  
+**Tipo de Data**: Float  
 **Valores suportados**:  Qualquer número positivo ou zero
 
 **Exemplo**
@@ -54,4 +54,3 @@ O designer de relatórios do Reporting Services não suporta a definição do ta
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
@@ -1,44 +1,46 @@
 ---
 title: Tamanho da margem da página
-linktitle: Tamanho da margem da página
+linktitle: Page margin size
 type: docs
 weight: 70
-url: /pt/reportingservices/page-margin-size/
-description: Ajuste os tamanhos das margens da página em relatórios PDF com Aspose.PDF for Reporting Services para melhorar a legibilidade e o layout.
-lastmod: "2026-07-29"
+url: /reportingservices/page-margin-size/
+description: Ajuste os tamanhos das margens das páginas em relatórios PDF com Aspose.PDF para Reporting Services para melhorar a legibilidade e o layout.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-O designer de relatórios do Reporting Services não suporta a definição do tamanho das margens da página. Aspose.PDF for Reporting Services fornece quatro parâmetros para definir o tamanho correspondente da margem da página, que são:
+O designer de relatórios do Reporting Services não dá suporte à configuração do tamanho das margens da página. Aspose.PDF para Reporting Services fornece quatro parâmetros para definir o tamanho da margem da página correspondente, são eles:
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-1)  
-**Nome do Parâmetro**: PageMarginLeft  
-**Tipo de Data**: Float  
-**Valores suportados**:  Qualquer número positivo ou zero
+```text
+Parameter Name: PageMarginLeft  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-2)  
-**Nome do Parâmetro**: PageMarginRight  
-**Tipo de Data**: Float  
-**Valores suportados**:  Qualquer número positivo ou zero
+```text
+Parameter Name: PageMarginRight  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-3)  
-**Nome do Parâmetro**: PageMarginTop  
-**Tipo de Data**: Float  
-**Valores suportados**:  Qualquer número positivo ou zero
+```text
+Parameter Name: PageMarginTop  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-4)  
-**Nome do Parâmetro**: PageMarginBottom  
-**Tipo de Data**: Float  
-**Valores suportados**:  Qualquer número positivo ou zero
+```text
+Parameter Name: PageMarginBottom  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-**Exemplo**
+## Exemplo
 
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type=" Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices ">
@@ -50,7 +52,4 @@ O designer de relatórios do Reporting Services não suporta a definição do ta
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
@@ -1,16 +1,16 @@
 ---
-title: Orientação da Página
-linktitle: Orientação da Página
+title: Orientação da página
+linktitle: Orientação da página
 type: docs
 weight: 10
 url: /pt/reportingservices/page-orientation/
 description: Configure a orientação da página para relatórios PDF no Aspose.PDF for Reporting Services. Personalize layouts para melhor apresentação.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Report Definition Language não permite especificar a orientação das páginas no relatório explicitamente. Com Aspose.Pdf for Reporting Services você pode instruir facilmente o exportador a gerar documentos PDF com orientação de página paisagem. A orientação padrão é retrato.
+Report Definition Language não permite especificar a orientação das páginas no relatório explicitamente. Com o Aspose.PDF for Reporting Services você pode instruir facilmente o exportador a produzir documentos PDF com orientação de página paisagem. A orientação padrão é retrato.
 
 {{% /alert %}}
 
@@ -27,7 +27,7 @@ A orientação padrão é retrato.
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsLandscape>True</IsLandscape>
+    <IsLandscape>Verdadeiro</IsLandscape>
     </Configuration>
     </Extension>
 </Render>
@@ -35,4 +35,3 @@ A orientação padrão é retrato.
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
@@ -1,37 +1,36 @@
 ---
 title: Orientação da página
-linktitle: Orientação da página
+linktitle: Page Orientation
 type: docs
 weight: 10
-url: /pt/reportingservices/page-orientation/
-description: Configure a orientação da página para relatórios PDF no Aspose.PDF for Reporting Services. Personalize layouts para melhor apresentação.
-lastmod: "2026-07-29"
+url: /reportingservices/page-orientation/
+description: Configure a orientação da página para relatórios PDF em Aspose.PDF para Reporting Services. Personalize layouts para uma melhor apresentação.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Definition Language não permite especificar a orientação das páginas no relatório explicitamente. Com o Aspose.PDF for Reporting Services você pode instruir facilmente o exportador a produzir documentos PDF com orientação de página paisagem. A orientação padrão é retrato.
+A linguagem de definição de relatório não permite especificar explicitamente a orientação das páginas do relatório. Com Aspose.PDF for Reporting Services você pode facilmente instruir o exportador a produzir documentos PDF com orientação de página paisagem. A orientação padrão é retrato.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+The default orientation is portrait.
+Parameter Name: IsLandscape
+Date Type: Boolean
+Values supported: True, False (default)
+```
 
-A orientação padrão é retrato.
-**Nome do parâmetro**: IsLandscape
-**Tipo de dado**: Boolean
-**Valores suportados**: True, False (default)
+## Exemplo
 
-**Exemplo**
-{{< highlight csharp >}}
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsLandscape>Verdadeiro</IsLandscape>
+    <IsLandscape>True</IsLandscape>
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
-
-{{% /alert %}}

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
@@ -1,29 +1,28 @@
 ---
-title: PageSize
+title: Tamanho da página
 linktitle: PageSize
 type: docs
 weight: 60
-url: /pt/reportingservices/pagesize/
-description: Personalize os tamanhos de página para relatórios PDF no Aspose.PDF for Reporting Services para atender a requisitos específicos de documentos.
-lastmod: "2026-07-29"
+url: /reportingservices/pagesize/
+description: Personalize tamanhos de página para relatórios PDF no Aspose.PDF for Reporting Services para atender a requisitos específicos de documentos.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-O designer de relatórios do Reporting Services não suporta tamanhos de página comuns como A4, B5, Letter e assim por diante. Com o Aspose.PDF for Reporting Services, você pode obtê‑lo como no exemplo a seguir.
+O designer de relatórios do Reporting Services não oferece suporte a tamanhos de página comuns, como A4, B5, Carta e assim por diante. Com Aspose.PDF for Reporting Services, você pode obtê-lo como no exemplo a seguir.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+Parameter Name: PageSize  
+Date Type: String  
+Values supported: A0, A1, A2, A3, A4, A5, A6, B5, Letter, Legal, Ledger, P11x17  
+```
 
-**Nome do Parâmetro**: PageSize  
-**Tipo de Data**: String  
-**Valores suportados**: A0, A1, A2, A3, A4, A5, A6, B5, Letter, Legal, Ledger, P11x17  
+## Exemplo
 
-**Exemplo**
-
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
@@ -32,7 +31,4 @@ O designer de relatórios do Reporting Services não suporta tamanhos de página
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
@@ -4,19 +4,19 @@ linktitle: PageSize
 type: docs
 weight: 60
 url: /pt/reportingservices/pagesize/
-description: Personalize os tamanhos de página para relatórios PDF no Aspose.PDF for Reporting Services para atender a requisitos específicos de documento.
-lastmod: "2026-06-19"
+description: Personalize os tamanhos de página para relatórios PDF no Aspose.PDF for Reporting Services para atender a requisitos específicos de documentos.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-O designer de relatórios do Reporting Services não suporta tamanhos de página comuns, como A4, B5, Letter e assim por diante. Com o Aspose.Pdf for Reporting Services, você pode obtê-lo como no exemplo a seguir.
+O designer de relatórios do Reporting Services não suporta tamanhos de página comuns como A4, B5, Letter e assim por diante. Com o Aspose.PDF for Reporting Services, você pode obtê‑lo como no exemplo a seguir.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**Nome do parâmetro**: PageSize  
+**Nome do Parâmetro**: PageSize  
 **Tipo de Data**: String  
 **Valores suportados**: A0, A1, A2, A3, A4, A5, A6, B5, Letter, Legal, Ledger, P11x17  
 
@@ -36,4 +36,3 @@ O designer de relatórios do Reporting Services não suporta tamanhos de página
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
@@ -4,15 +4,15 @@ linktitle: Conformidade PDF_A
 type: docs
 weight: 100
 url: /pt/reportingservices/pdf_a-conformance/
-description: Habilite a conformidade PDF/A no Aspose.PDF for Reporting Services. Crie documentos compatíveis com arquivamento sem esforço.
-lastmod: "2026-06-19"
+description: Ative a conformidade PDF/A no Aspose.PDF for Reporting Services. Crie documentos compatíveis com arquivamento sem esforço.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Você pode obter uma introdução à Conformidade PDF/A (PDF Arquivável) na documentação do Aspose.PDF.
+Você pode obter uma introdução à conformidade PDF/A (PDF Arquivável) na documentação do Aspose.PDF.
 
-Se você quiser criar um documento PDF/A, adicione o seguinte parâmetro de relatório.
+Se você deseja criar um documento PDF/A, adicione o seguinte parâmetro de relatório.
 
 {{% /alert %}}
 
@@ -37,4 +37,3 @@ Se você quiser criar um documento PDF/A, adicione o seguinte parâmetro de rela
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
@@ -1,31 +1,30 @@
 ---
 title: Conformidade PDF_A
-linktitle: Conformidade PDF_A
+linktitle: PDF_A Conformance
 type: docs
 weight: 100
-url: /pt/reportingservices/pdf_a-conformance/
-description: Ative a conformidade PDF/A no Aspose.PDF for Reporting Services. Crie documentos compatíveis com arquivamento sem esforço.
-lastmod: "2026-07-29"
+url: /reportingservices/pdf_a-conformance/
+description: Habilite a conformidade com PDF/A em Aspose.PDF para Reporting Services. Crie documentos compatíveis com arquivamento sem esforço.
+lastmod: "2025-05-22"
 ---
 
 {{% alert color="primary" %}}
 
-Você pode obter uma introdução à conformidade PDF/A (PDF Arquivável) na documentação do Aspose.PDF.
+Você pode obter uma introdução à conformidade com PDF/A (PDF arquivável) na documentação do Aspose.PDF.
 
 Se você deseja criar um documento PDF/A, adicione o seguinte parâmetro de relatório.
 
 {{% /alert %}}
 
+```text
+Parameter Name: PdfConformance  
+Date Type: String  
+Values supported: PdfA1A, PdfA1B, PdfA2A, PdfA2B, PdfA2U, PdfA3A, PdfA3B, PdfA3U, PdfA4, PdfA4E, PdfA4F  
+```
 
-{{% alert color="primary" %}}
+## Exemplo
 
-**Nome do Parâmetro**: PdfConformance  
-**Tipo de Dados**: String  
-**Valores suportados**: PdfA1A, PdfA1B, PdfA2A, PdfA2B, PdfA2U, PdfA3A, PdfA3B, PdfA3U, PdfA4, PdfA4E, PdfA4F  
-
-**Exemplo**
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
@@ -34,6 +33,4 @@ Se você deseja criar um documento PDF/A, adicione o seguinte parâmetro de rela
     </Configuration>
     </Extension>
 </Render>
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
@@ -1,65 +1,72 @@
 ---
-title: Configuração de Segurança
-linktitle: Configuração de Segurança
+title: Configuração de segurança
+linktitle: Security Setting
 type: docs
 weight: 30
-url: /pt/reportingservices/security-setting/
-lastmod: "2026-07-29"
+url: /reportingservices/security-setting/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-A segurança sempre foi a questão mais importante em todas as áreas, seja a proteção de uma rede ou de um documento PDF. Os documentos são tornados seguros por diversos motivos possíveis: o autor do documento pode querer manter o conteúdo do documento seguro e não deseja permitir que outros o alterem, etc.
+A segurança sempre foi a questão mais importante em todos os campos, seja na proteção de uma rede ou de um documento PDF. Os documentos são protegidos por vários motivos possíveis: o redator do documento pode querer manter o conteúdo do documento seguro e não querer permitir que outros o alterem, etc.
 
-Aspose.PDF for Reporting Services tem cuidado muito bem desses aspectos de segurança ao fornecer esses recursos aos desenvolvedores que podem ser úteis para proteger seus documentos PDF. Portanto, ele contém vários parâmetros que permitem aos desenvolvedores aplicar diferentes medidas de segurança aos documentos PDF.
+Aspose.PDF for Reporting Services cuidou muito desses aspectos de segurança, fornecendo esses recursos aos desenvolvedores que podem ser úteis para proteger seus documentos PDF. Portanto, contém uma série de parâmetros que permitem aos desenvolvedores aplicar diferentes medidas de segurança aos documentos PDF.
 
-Uma dessas medidas é proteger o documento PDF com senha durante a criptografia. Você também pode restringir ou permitir a modificação de conteúdo, a cópia do conteúdo, a impressão do documento ou permitir/desativar o preenchimento de formulários. Esses recursos atualmente não são suportados pelo Exportador PDF padrão do SQL Reporting Services, mas você pode implementá‑los usando Aspose.PDF for Reporting Services. Basta adicionar os parâmetros de segurança correspondentes a um relatório ou ao arquivo de configuração do servidor de relatórios, e você poderá criar documentos PDF seguros com privilégios limitados.
+Uma dessas medidas é proteger o documento PDF com senha durante a criptografia. Você também pode restringir ou permitir modificação de conteúdo, cópia de conteúdo, impressão de documentos ou permitir/desabilitar preenchimento de formulários. No momento, esses recursos não são suportados pelo SQL Reporting Services PDF Exporter padrão, mas você pode implementar esses recursos usando Aspose.PDF para Reporting Services. Basta adicionar parâmetros de segurança correspondentes a um relatório ou arquivo de configuração do servidor de relatório e você poderá criar documentos PDF seguros com privilégios limitados.
 
-Atualmente, o renderizador Aspose.PDF for Reporting Services suporta os seguintes atributos de segurança:
+Atualmente, o renderizador Aspose.PDF para Reporting Services dá suporte aos seguintes atributos de segurança:
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+Parameter Name: User Password  
+Date Type: String  
+Values supported: Any plain text
+```
 
-**Nome do Parâmetro**: Senha do Usuário  
-**Tipo de Dados**: String  
-**Valores suportados**: Qualquer texto simples
+```text
+Parameter Name: Master Password  
+Date Type: String  
+Values supported: Any plain text 
+```
 
-**Nome do Parâmetro**: Senha Mestra  
-**Tipo de Dados**: String  
-**Valores suportados**: Qualquer texto simples 
+```text
+Parameter Name: IsCopyingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default) 
+```
 
-**Nome do parâmetro**: IsCopyingAllowed  
-**Tipo de dado**: Boolean  
-**Valores suportados**: True, False (default)  
+```text
+Parameter Name: IsPrintingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**Nome do parâmetro**: IsPrintingAllowed  
-**Tipo de dado**: Boolean  
-**Valores suportados**: True, False (default)  
+```text
+Parameter Name: IsContentsModifyingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default) 
+```
 
-**Nome do parâmetro**: IsContentsModifyingAllowed  
-**Tipo de dado**: Boolean  
-**Valores suportados**: True, False (default)  
+```text
+Parameter Name: IsFormFillingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**Nome do parâmetro**: IsFormFillingAllowed  
-**Tipo de dado**: Boolean  
-**Valores suportados**: True, False (default)  
+## Exemplo
 
-**Exemplo**
-
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
     <UserPassword>aspose</UserPassword>
-    <IsCopyingAllowed>Falso</IsCopyingAllowed>
-    <IsPrintingAllowed>Falso</IsPrintingAllowed>
+    <IsCopyingAllowed>False</IsCopyingAllowed>
+    <IsPrintingAllowed>False</IsPrintingAllowed>
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
-
-{{% /alert %}}

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
@@ -4,45 +4,45 @@ linktitle: Configuração de Segurança
 type: docs
 weight: 30
 url: /pt/reportingservices/security-setting/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-A segurança sempre foi a questão mais importante em todos os campos, seja na proteção de uma rede ou de um documento PDF. Os documentos são protegidos por muitos motivos possíveis: o autor do documento pode querer manter o conteúdo do documento seguro e não querer permitir que outros o alterem, etc.
+A segurança sempre foi a questão mais importante em todas as áreas, seja a proteção de uma rede ou de um documento PDF. Os documentos são tornados seguros por diversos motivos possíveis: o autor do documento pode querer manter o conteúdo do documento seguro e não deseja permitir que outros o alterem, etc.
 
-Aspose.Pdf for Reporting Services tem se preocupado muito com esses aspectos de segurança, oferecendo esses recursos aos desenvolvedores que podem ser úteis para proteger seus documentos PDF. Portanto, ele contém diversos parâmetros que permitem aos desenvolvedores aplicar diferentes medidas de segurança aos documentos PDF.
+Aspose.PDF for Reporting Services tem cuidado muito bem desses aspectos de segurança ao fornecer esses recursos aos desenvolvedores que podem ser úteis para proteger seus documentos PDF. Portanto, ele contém vários parâmetros que permitem aos desenvolvedores aplicar diferentes medidas de segurança aos documentos PDF.
 
-Uma dessas medidas é proteger o documento PDF com senha durante a criptografia. Você também pode restringir ou permitir a modificação do conteúdo, a cópia do conteúdo, a impressão do documento ou habilitar/desabilitar o preenchimento de formulários. Esses recursos no momento não são suportados pelo Exportador PDF padrão do SQL Reporting Services, mas você pode implementá-los usando o Aspose.Pdf for Reporting Services. Basta adicionar os parâmetros de segurança correspondentes a um relatório ou ao arquivo de configuração do servidor de relatórios, e você poderá criar documentos PDF seguros com privilégios limitados.
+Uma dessas medidas é proteger o documento PDF com senha durante a criptografia. Você também pode restringir ou permitir a modificação de conteúdo, a cópia do conteúdo, a impressão do documento ou permitir/desativar o preenchimento de formulários. Esses recursos atualmente não são suportados pelo Exportador PDF padrão do SQL Reporting Services, mas você pode implementá‑los usando Aspose.PDF for Reporting Services. Basta adicionar os parâmetros de segurança correspondentes a um relatório ou ao arquivo de configuração do servidor de relatórios, e você poderá criar documentos PDF seguros com privilégios limitados.
 
-Atualmente, o renderizador Aspose.Pdf for Reporting Services suporta os seguintes atributos de segurança:
+Atualmente, o renderizador Aspose.PDF for Reporting Services suporta os seguintes atributos de segurança:
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**Nome do parâmetro**: Senha do Usuário  
-**Tipo de data**: String  
+**Nome do Parâmetro**: Senha do Usuário  
+**Tipo de Dados**: String  
 **Valores suportados**: Qualquer texto simples
 
-**Nome do parâmetro**: Senha mestre  
-**Tipo de data**: String  
+**Nome do Parâmetro**: Senha Mestra  
+**Tipo de Dados**: String  
 **Valores suportados**: Qualquer texto simples 
 
-**Nome do Parâmetro**: IsCopyingAllowed  
-**Tipo de Dados**: Boolean  
+**Nome do parâmetro**: IsCopyingAllowed  
+**Tipo de dado**: Boolean  
 **Valores suportados**: True, False (default)  
 
-**Nome do Parâmetro**: IsPrintingAllowed  
-**Tipo de Dados**: Boolean  
+**Nome do parâmetro**: IsPrintingAllowed  
+**Tipo de dado**: Boolean  
 **Valores suportados**: True, False (default)  
 
-**Nome do Parâmetro**: IsContentsModifyingAllowed  
-**Tipo de Dados**: Boolean  
+**Nome do parâmetro**: IsContentsModifyingAllowed  
+**Tipo de dado**: Boolean  
 **Valores suportados**: True, False (default)  
 
-**Nome do Parâmetro**: IsFormFillingAllowed  
-**Tipo de Dados**: Boolean  
+**Nome do parâmetro**: IsFormFillingAllowed  
+**Tipo de dado**: Boolean  
 **Valores suportados**: True, False (default)  
 
 **Exemplo**
@@ -54,8 +54,8 @@ Atualmente, o renderizador Aspose.Pdf for Reporting Services suporta os seguinte
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
     <UserPassword>aspose</UserPassword>
-    <IsCopyingAllowed>False</IsCopyingAllowed>
-    <IsPrintingAllowed>False</IsPrintingAllowed>
+    <IsCopyingAllowed>Falso</IsCopyingAllowed>
+    <IsPrintingAllowed>Falso</IsPrintingAllowed>
     </Configuration>
     </Extension>
 </Render>
@@ -63,4 +63,3 @@ Atualmente, o renderizador Aspose.Pdf for Reporting Services suporta os seguinte
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
@@ -9,13 +9,13 @@ lastmod: "2021-06-05"
 
 {{% alert color="primary" %}}
 
-A segurança sempre foi a questão mais importante em todos os campos, seja na proteção de uma rede ou de um documento PDF. Os documentos são protegidos por vários motivos possíveis: o redator do documento pode querer manter o conteúdo do documento seguro e não querer permitir que outros o alterem, etc.
+A segurança sempre foi a questão mais importante em todos os campos, seja na proteção de uma rede ou de um documento PDF. Os documentos são protegidos por vários motivos possíveis: o autor do documento pode querer manter o conteúdo do documento seguro e não querer permitir que outros o alterem, etc.
 
 Aspose.PDF for Reporting Services cuidou muito desses aspectos de segurança, fornecendo esses recursos aos desenvolvedores que podem ser úteis para proteger seus documentos PDF. Portanto, contém uma série de parâmetros que permitem aos desenvolvedores aplicar diferentes medidas de segurança aos documentos PDF.
 
 Uma dessas medidas é proteger o documento PDF com senha durante a criptografia. Você também pode restringir ou permitir modificação de conteúdo, cópia de conteúdo, impressão de documentos ou permitir/desabilitar preenchimento de formulários. No momento, esses recursos não são suportados pelo SQL Reporting Services PDF Exporter padrão, mas você pode implementar esses recursos usando Aspose.PDF para Reporting Services. Basta adicionar parâmetros de segurança correspondentes a um relatório ou arquivo de configuração do servidor de relatório e você poderá criar documentos PDF seguros com privilégios limitados.
 
-Atualmente, o renderizador Aspose.PDF para Reporting Services dá suporte aos seguintes atributos de segurança:
+Atualmente, o renderizador Aspose.PDF para Reporting Services oferece suporte aos seguintes atributos de segurança:
 
 {{% /alert %}}
 

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
@@ -4,18 +4,18 @@ linktitle: Metadados XMP
 type: docs
 weight: 80
 url: /pt/reportingservices/xmp-metadata/
-description: Aprenda a gerenciar metadados XMP em relatórios PDF usando Aspose.PDF for Reporting Services. Aprimore o gerenciamento de metadados de documentos.
-lastmod: "2026-06-19"
+description: Aprenda a gerenciar metadados XMP em relatórios PDF usando Aspose.PDF for Reporting Services. Melhore o tratamento de metadados de documentos.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-O designer de relatórios do Reporting Services não oferece suporte à incorporação de metadados XMP no documento. Aspose.Pdf for Reporting Services fornece quatro parâmetros para definir os metadados XMP correspondentes, que são:
+O designer de relatórios do Reporting Services não suporta a incorporação de metadados XMP no documento. Aspose.PDF for Reporting Services fornece quatro parâmetros para definir os respectivos metadados XMP, são eles:
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Nome do parâmetro**: CreationDate  
+**Nome do Parâmetro**: CreationDate  
 **Tipo de Data**: String  
 **Valores suportados**: Data em um dos formatos de data
 
@@ -41,7 +41,7 @@ O designer de relatórios do Reporting Services não oferece suporte à incorpor
     <CreationDate>2017-12-10</CreationDate>
     <ModifyDate>2018-1-12</ModifyDate>
     <MetaDataDate>2018-3-7</MetaDataDate>
-    <CreatorTool>Aspose.Pdf for Reporting Services</CreatorTool>
+    <CreatorTool>Aspose.PDF for Reporting Services</CreatorTool>
     </Configuration>
     </Extension>
 </Render>
@@ -49,5 +49,4 @@ O designer de relatórios do Reporting Services não oferece suporte à incorpor
 {{< /highlight >}}
 
 {{% /alert %}}
-
 

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
@@ -1,39 +1,46 @@
 ---
 title: Metadados XMP
-linktitle: Metadados XMP
+linktitle: XMP Metadata
 type: docs
 weight: 80
-url: /pt/reportingservices/xmp-metadata/
-description: Aprenda a gerenciar metadados XMP em relatórios PDF usando Aspose.PDF for Reporting Services. Melhore o tratamento de metadados de documentos.
-lastmod: "2026-07-29"
+url: /reportingservices/xmp-metadata/
+description: Aprenda a gerenciar metadados XMP em relatórios PDF usando Aspose.PDF para Reporting Services. Aprimore o manuseio de metadados de documentos.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-O designer de relatórios do Reporting Services não suporta a incorporação de metadados XMP no documento. Aspose.PDF for Reporting Services fornece quatro parâmetros para definir os respectivos metadados XMP, são eles:
+O designer de relatórios do Reporting Services não dá suporte à incorporação de metadados XMP no documento. Aspose.PDF para Reporting Services fornece quatro parâmetros para definir os metadados XMP correspondentes, são eles:
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**Nome do Parâmetro**: CreationDate  
-**Tipo de Data**: String  
-**Valores suportados**: Data em um dos formatos de data
+```text
+**Parameter Name: CreationDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats
+```
 
-**Nome do Parâmetro**: ModifyDate  
-**Tipo de Data**: String  
-**Valores suportados**: Data em um dos formatos de data 
+```text
+**Parameter Name: ModifyDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats 
+```
 
-**Nome do Parâmetro**: MetaDataDate  
-**Tipo de Data**: String  
-**Valores suportados**: Data em um dos formatos de data 
+```text
+**Parameter Name: MetaDataDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats 
+```
 
-**Nome do Parâmetro**: CreatorTool  
-**Tipo de Data**: String  
-**Valores suportados**: Qualquer texto simples  
+```text
+**Parameter Name: CreatorTool  
+**Date Type: String  
+**Values supported: Any plain text  
+```
 
-**Exemplo**
-{{< highlight csharp >}}
+## Exemplo
 
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer, Aspose.Pdf.ReportingServices">
@@ -45,8 +52,6 @@ O designer de relatórios do Reporting Services não suporta a incorporação de
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
-
-{{% /alert %}}
 

--- a/pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
@@ -1,25 +1,25 @@
 ---
-title: Avaliar Aspose.Pdf
-linktitle: Avaliar Aspose.Pdf
+title: Avalie Aspose.Pdf
+linktitle: Evaluate Aspose.Pdf
 type: docs
 weight: 110
-url: /pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/
-description: Experimente o Aspose.PDF for Reporting Services gratuitamente. Saiba como avaliar seus recursos antes de tomar uma decisão de compra.
-lastmod: "2026-07-29"
+url: /reportingservices/evaluate-aspose-pdf-for-reporting-services/
+description: Experimente o Aspose.PDF para Reporting Services gratuitamente. Aprenda como avaliar suas características antes de tomar uma decisão de compra.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Esta página apresenta a diferença entre a versão licenciada e a versão de avaliação do Aspose.PDF for Reporting Services
+Esta página indica a diferença entre a versão licenciada e a versão de avaliação do Aspose.PDF para Reporting Services
 
 {{% /alert %}}
 
-Você pode baixar facilmente [Aspose.PDF for Reporting Services](https://downloads.aspose.com/pdf/reportingservices) para avaliação. O download de avaliação é o mesmo que o download adquirido. A versão de avaliação simplesmente se torna licenciada quando você coloca o arquivo de licença na pasta que contém Aspose.PDF.ReportingServices.dll ou algumas linhas de código para inicializar a licença ao usar o componente com o Report Viewer em modo local. A versão de avaliação do Aspose.PDF for Reporting Services (sem uma licença especificada) fornece funcionalidade completa do produto, mas insere uma marca d'água de avaliação no topo do documento ao renderizar o arquivo .RDL para o formato PDF. Você pode visitar a página a seguir para mais instruções sobre [como licenciar o Aspose.PDF for Reporting Services](/pdf/pt/reportingservices/license-aspose-pdf-for-reporting-services/)
+Você pode baixar facilmente [Aspose.PDF para serviços de relatórios](https://downloads.aspose.com/pdf/reportingservices) para avaliação. O download de avaliação é igual ao download adquirido. A versão de avaliação simplesmente se torna licenciada quando você coloca o arquivo de licença na pasta que contém Aspose.PDF.ReportingServices.dll ou algumas linhas de código para inicializar a licença ao usar o componente com Report Viewer em modo local. A versão de avaliação do Aspose.PDF para Reporting Services (sem licença especificada) fornece funcionalidade completa do produto, mas insere uma marca d'água de avaliação na parte superior do documento ao renderizar o arquivo .RDL para o formato PDF. Você pode visitar a página a seguir para obter mais instruções sobre [como licenciar Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/license-aspose-pdf-for-reporting-services/)
 
-![todo:image_alt_text](evaluate-aspose-pdf-for-reporting-services_1.png)
+![Avaliação](evaluate-aspose-pdf-for-reporting-services_1.png)
 
 {{% alert color="primary" %}}
 
-Se você quiser testar o Aspose.PDF for Reporting Services sem as limitações da versão de avaliação, também pode solicitar uma Licença Temporária de 30 dias. Por favor, consulte [Como obter uma Licença Temporária?](<https://about.aspose.com/>)
+Se quiser testar o Aspose.PDF para Reporting Services sem as limitações da versão de avaliação, você também pode solicitar uma licença temporária de 30 dias. Consulte [Como obter uma Licença Temporária?](<https://about.aspose.com/>)
 
 {{% /alert %}}

--- a/pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
@@ -1,26 +1,25 @@
 ---
-title: Avalie Aspose.Pdf
-linktitle: Avalie Aspose.Pdf
+title: Avaliar Aspose.Pdf
+linktitle: Avaliar Aspose.Pdf
 type: docs
 weight: 110
 url: /pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/
-description: Experimente Aspose.PDF for Reporting Services gratuitamente. Aprenda como avaliar seus recursos antes de tomar uma decisão de compra.
-lastmod: "2026-06-19"
+description: Experimente o Aspose.PDF for Reporting Services gratuitamente. Saiba como avaliar seus recursos antes de tomar uma decisão de compra.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Esta página indica a diferença entre a versão licenciada e a versão de avaliação do Aspose.PDF for Reporting Services
+Esta página apresenta a diferença entre a versão licenciada e a versão de avaliação do Aspose.PDF for Reporting Services
 
 {{% /alert %}}
 
-Você pode baixar facilmente [Aspose.PDF for Reporting Services](https://downloads.aspose.com/pdf/reportingservices) para avaliação. O download de avaliação é o mesmo que o download adquirido. A versão de avaliação simplesmente se torna licenciada quando você coloca o arquivo de licença na pasta que contém Aspose.PDF.ReportingServices.dll ou algumas linhas de código para inicializar a licença ao usar o componente com o Report Viewer no modo local. A versão de avaliação do Aspose.PDF for Reporting Services (sem uma licença especificada) fornece toda a funcionalidade do produto, mas insere uma marca d'água de avaliação no topo do documento ao renderizar o arquivo .RDL para o formato PDF. Você pode visitar a página a seguir para mais instruções sobre [Como licenciar Aspose.PDF for Reporting Services](/pdf/pt/reportingservices/license-aspose-pdf-for-reporting-services/)
+Você pode baixar facilmente [Aspose.PDF for Reporting Services](https://downloads.aspose.com/pdf/reportingservices) para avaliação. O download de avaliação é o mesmo que o download adquirido. A versão de avaliação simplesmente se torna licenciada quando você coloca o arquivo de licença na pasta que contém Aspose.PDF.ReportingServices.dll ou algumas linhas de código para inicializar a licença ao usar o componente com o Report Viewer em modo local. A versão de avaliação do Aspose.PDF for Reporting Services (sem uma licença especificada) fornece funcionalidade completa do produto, mas insere uma marca d'água de avaliação no topo do documento ao renderizar o arquivo .RDL para o formato PDF. Você pode visitar a página a seguir para mais instruções sobre [como licenciar o Aspose.PDF for Reporting Services](/pdf/pt/reportingservices/license-aspose-pdf-for-reporting-services/)
 
 ![todo:image_alt_text](evaluate-aspose-pdf-for-reporting-services_1.png)
 
 {{% alert color="primary" %}}
 
-Se você quiser testar o Aspose.PDF for Reporting Services sem as limitações da versão de avaliação, pode também solicitar uma Licença Temporária de 30 dias. Por favor, consulte [Como obter uma Licença Temporária?](<https://about.aspose.com/>)
+Se você quiser testar o Aspose.PDF for Reporting Services sem as limitações da versão de avaliação, também pode solicitar uma Licença Temporária de 30 dias. Por favor, consulte [Como obter uma Licença Temporária?](<https://about.aspose.com/>)
 
 {{% /alert %}}
-

--- a/pt/reportingservices/expand-report-items-properties/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/_index.md
@@ -1,14 +1,14 @@
 ---
-title: Expandir Propriedades dos Itens de Relatório
-linktitle: Expandir Propriedades dos Itens de Relatório
+title: Expandir propriedades de itens de relatório
+linktitle: Expand Report Items Props
 type: docs
 weight: 90
-url: /pt/reportingservices/expand-report-items-properties/
-description: Aprimore relatórios SSRS com Aspose.PDF. Saiba como expandir as propriedades dos itens de relatório para personalização detalhada de PDF.
-lastmod: "2026-07-29"
+url: /reportingservices/expand-report-items-properties/
+description: Aprimore os relatórios SSRS com Aspose.PDF. Saiba como expandir as propriedades do item de relatório para personalização detalhada do PDF.
+lastmod: "2021-06-05"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
-- [Adicionando Propriedades Personalizadas](/pdf/pt/reportingservices/adding-custom-properties/)
-- [Propriedades Personalizadas Suportadas](/pdf/pt/reportingservices/custom-properties-supported/)
+- [Adicionando propriedades personalizadas](/pdf/pt/reportingservices/adding-custom-properties/)
+- [Propriedades personalizadas suportadas](/pdf/pt/reportingservices/custom-properties-supported/)

--- a/pt/reportingservices/expand-report-items-properties/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/_index.md
@@ -1,15 +1,14 @@
 ---
-title: Expandir Propriedades dos Itens do Relatório
-linktitle: Expandir Propriedades dos Itens do Relatório
+title: Expandir Propriedades dos Itens de Relatório
+linktitle: Expandir Propriedades dos Itens de Relatório
 type: docs
 weight: 90
 url: /pt/reportingservices/expand-report-items-properties/
-description: Melhore relatórios SSRS com Aspose.PDF. Aprenda como expandir as propriedades dos itens do relatório para uma personalização detalhada de PDF.
-lastmod: "2026-06-19"
+description: Aprimore relatórios SSRS com Aspose.PDF. Saiba como expandir as propriedades dos itens de relatório para personalização detalhada de PDF.
+lastmod: "2026-07-29"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
 - [Adicionando Propriedades Personalizadas](/pdf/pt/reportingservices/adding-custom-properties/)
 - [Propriedades Personalizadas Suportadas](/pdf/pt/reportingservices/custom-properties-supported/)
-

--- a/pt/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
@@ -4,23 +4,23 @@ linktitle: Adicionando Propriedades Personalizadas
 type: docs
 weight: 10
 url: /pt/reportingservices/adding-custom-properties/
-description: Aprenda como adicionar propriedades personalizadas a relatórios PDF com Aspose.PDF for Reporting Services. Personalize seus documentos de forma eficiente.
-lastmod: "2026-06-19"
+description: Saiba como adicionar propriedades personalizadas a relatórios PDF com Aspose.PDF for Reporting Services. Personalize seus documentos de forma eficiente.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Você pode adicionar propriedades personalizadas para alguns itens de relatório para expandir seu uso, como ToC, setas de linha e assim por diante. Esta seção descreve esse processo.
+Você pode adicionar propriedades personalizadas a alguns itens de relatório para expandir seu uso, como ToC, setas de linha e assim por diante. Esta seção descreve esse processo.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Você pode adicionar propriedades personalizadas para alguns itens de relatório para expandir seu uso, como Índice, setas de linha e assim por diante. Esta seção descreve esse processo.
+Você pode adicionar propriedades personalizadas a alguns itens de relatório para expandir seu uso, como Índice, setas de linha e assim por diante. Esta seção descreve esse processo.
 
 Para adicionar propriedades personalizadas, você precisa editar o arquivo de código do documento RDL nas seguintes etapas:
 
-1. Conforme na figura a seguir, abra seu projeto, navegue até o Solution Explorer e clique com o botão direito no arquivo de relatório selecionado, então selecione o item de menu 'View Code'.
+1. Como na figura a seguir, abra seu projeto, navegue até o Solution Explorer e clique com o botão direito no arquivo de relatório selecionado, então selecione o item de menu 'View Code'.
 
 ![todo:image_alt_text](adding-custom-properties_1.png)
 
@@ -31,23 +31,22 @@ Para adicionar propriedades personalizadas, você precisa editar o arquivo de c�
 {{< highlight csharp >}}
 
 <chart Name="chart1">
-    <Left>5.5cm</Left>
-    <Top>0.5cm</Top>
+    <Left>5,5cm</Left>
+    <Top>0,5cm</Top>
       ......
     <Style>
       ......
     </style>     
     <CustomProperties>
       <CustomProperty>
-        <Name>IsInList</Name>
-        <Value>True</Value>
+        <Name>EstaNaLista</Name>
+        <Value>Verdadeiro</Value>
       </CustomProperty>
     </CustomProperties>
 </chart> 
 
 {{< /highlight >}}
 
-Neste exemplo de fragmento de código, o nome da propriedade personalizada é IsInList e o valor é 'True'.
+Neste exemplo de fragmento de código, o nome da propriedade personalizada é IsInList, e o valor é 'True'.
 
 {{% /alert %}}
-

--- a/pt/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
@@ -10,7 +10,7 @@ lastmod: "2021-06-05"
 
 {{% alert color="primary" %}}
 
-Você pode adicionar propriedades personalizadas a alguns itens de relatório para expandir seu uso, como ToC, setas de linha e assim por diante. Esta seção descreve esse processo.
+Você pode adicionar propriedades personalizadas para alguns itens de relatório para expandir seu uso, como ToC, setas de linha e assim por diante. Esta seção descreve esse processo.
 
 {{% /alert %}}
 
@@ -20,7 +20,7 @@ Para adicionar propriedades customizadas, você precisa editar o arquivo de cód
 
 1. Como na figura a seguir, abra seu projeto, navegue até o gerenciador de soluções, clique com o botão direito no arquivo de relatório selecionado e selecione o item de menu 'Exibir código'.
 
-![Adicionar propriedades personalizadas](adding-custom-properties_1.png)
+![Add Custom Properties](adding-custom-properties_1.png)
 
 2. Edite o arquivo de código XML. Por exemplo, se desejar adicionar uma propriedade customizada para o item de relatório gráfico, será necessário adicionar o código semelhante ao texto em vermelho no exemplo a seguir.
 

--- a/pt/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
@@ -1,11 +1,11 @@
 ---
-title: Adicionando Propriedades Personalizadas
-linktitle: Adicionando Propriedades Personalizadas
+title: Adicionando propriedades personalizadas
+linktitle: Adding Custom Properties
 type: docs
 weight: 10
-url: /pt/reportingservices/adding-custom-properties/
-description: Saiba como adicionar propriedades personalizadas a relatórios PDF com Aspose.PDF for Reporting Services. Personalize seus documentos de forma eficiente.
-lastmod: "2026-07-29"
+url: /reportingservices/adding-custom-properties/
+description: Aprenda como adicionar propriedades personalizadas a relatórios PDF com Aspose.PDF para Reporting Services. Personalize seus documentos com eficiência.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
@@ -14,39 +14,34 @@ Você pode adicionar propriedades personalizadas a alguns itens de relatório pa
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-
 Você pode adicionar propriedades personalizadas a alguns itens de relatório para expandir seu uso, como Índice, setas de linha e assim por diante. Esta seção descreve esse processo.
 
-Para adicionar propriedades personalizadas, você precisa editar o arquivo de código do documento RDL nas seguintes etapas:
+Para adicionar propriedades customizadas, você precisa editar o arquivo de código do documento RDL nas seguintes etapas:
 
-1. Como na figura a seguir, abra seu projeto, navegue até o Solution Explorer e clique com o botão direito no arquivo de relatório selecionado, então selecione o item de menu 'View Code'.
+1. Como na figura a seguir, abra seu projeto, navegue até o gerenciador de soluções, clique com o botão direito no arquivo de relatório selecionado e selecione o item de menu 'Exibir código'.
 
-![todo:image_alt_text](adding-custom-properties_1.png)
+![Adicionar propriedades personalizadas](adding-custom-properties_1.png)
 
-2. Edite o arquivo de código XML. Por exemplo, se você quiser adicionar uma propriedade personalizada para o item de relatório de gráfico, você precisa adicionar o código semelhante ao texto em vermelho no exemplo a seguir.
+2. Edite o arquivo de código XML. Por exemplo, se desejar adicionar uma propriedade customizada para o item de relatório gráfico, será necessário adicionar o código semelhante ao texto em vermelho no exemplo a seguir.
 
-**Exemplo**
+## Exemplo
 
-{{< highlight csharp >}}
-
+```xml
 <chart Name="chart1">
-    <Left>5,5cm</Left>
-    <Top>0,5cm</Top>
+    <Left>5.5cm</Left>
+    <Top>0.5cm</Top>
       ......
     <Style>
       ......
     </style>     
     <CustomProperties>
       <CustomProperty>
-        <Name>EstaNaLista</Name>
-        <Value>Verdadeiro</Value>
+        <Name>IsInList</Name>
+        <Value>True</Value>
       </CustomProperty>
     </CustomProperties>
 </chart> 
+```
 
-{{< /highlight >}}
+Neste exemplo de fragmento de código, o nome da propriedade customizada é IsInList e o valor é `True`.
 
-Neste exemplo de fragmento de código, o nome da propriedade personalizada é IsInList, e o valor é 'True'.
-
-{{% /alert %}}

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
@@ -1,16 +1,16 @@
 ---
-title: Propriedades Personalizadas Suportadas
-linktitle: Propriedades Personalizadas Suportadas
+title: Propriedades personalizadas suportadas
+linktitle: Custom Properties Supported
 type: docs
 weight: 20
-url: /pt/reportingservices/custom-properties-supported/
-description: Verifique as propriedades personalizadas suportadas no Aspose.PDF for Reporting Services. Maximize a flexibilidade nas suas saídas PDF.
-lastmod: "2026-07-29"
+url: /reportingservices/custom-properties-supported/
+description: Verifique as propriedades personalizadas suportadas em Aspose.PDF para Reporting Services. Maximize a flexibilidade em suas saídas de PDF.
+lastmod: "2021-06-05"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
-- [Sumário, Lista de Tabelas ou Figuras](/pdf/pt/reportingservices/table-of-contents-list-of-tables-or-figures/)
-- [Setas de Linha](/pdf/pt/reportingservices/line-arrows/)
-- [Nota de rodapé Nota de fim](/pdf/pt/reportingservices/footnote-endnote/)
-- [Justificar Alinhamento de Texto FullJustify](/pdf/pt/reportingservices/justify-fulljustify-text-alignment/)
+- [Índice Lista de tabelas ou figuras](/pdf/pt/reportingservices/table-of-contents-list-of-tables-or-figures/)
+- [Setas de linha](/pdf/pt/reportingservices/line-arrows/)
+- [Nota final](/pdf/pt/reportingservices/footnote-endnote/)
+- [Justificar FullJustify Alinhamento de Texto](/pdf/pt/reportingservices/justify-fulljustify-text-alignment/)

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
@@ -5,13 +5,12 @@ type: docs
 weight: 20
 url: /pt/reportingservices/custom-properties-supported/
 description: Verifique as propriedades personalizadas suportadas no Aspose.PDF for Reporting Services. Maximize a flexibilidade nas suas saídas PDF.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
-- [Sumário Lista de Tabelas ou Figuras](/pdf/pt/reportingservices/table-of-contents-list-of-tables-or-figures/)
+- [Sumário, Lista de Tabelas ou Figuras](/pdf/pt/reportingservices/table-of-contents-list-of-tables-or-figures/)
 - [Setas de Linha](/pdf/pt/reportingservices/line-arrows/)
-- [Nota de Rodapé Nota de Fim](/pdf/pt/reportingservices/footnote-endnote/)
+- [Nota de rodapé Nota de fim](/pdf/pt/reportingservices/footnote-endnote/)
 - [Justificar Alinhamento de Texto FullJustify](/pdf/pt/reportingservices/justify-fulljustify-text-alignment/)
-

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
@@ -1,33 +1,34 @@
 ---
-title: Nota de rodapé Nota final
-linktitle: Nota de rodapé Nota final
+title: Nota final
+linktitle: Footnote Endnote
 type: docs
 weight: 30
-url: /pt/reportingservices/footnote-endnote/
-description: Adicione notas de rodapé e notas finais aos seus relatórios PDF com Aspose.PDF for Reporting Services. Forneça referências detalhadas ao documento.
-lastmod: "2026-07-29"
+url: /reportingservices/footnote-endnote/
+description: Adicione notas de rodapé e notas finais aos seus relatórios PDF com Aspose.PDF for Reporting Services. Forneça referências detalhadas de documentos.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-O Report Builder não pode definir a nota de rodapé ou a nota final para caixas de texto. Com Aspose.PDF for Reporting Services, você pode fazer isso facilmente adicionando propriedades personalizadas.
+O Report Builder não pode definir notas de rodapé ou notas finais para caixas de texto. Com Aspose.PDF for Reporting Services, você pode fazer isso facilmente adicionando propriedades personalizadas.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-Nota de rodapé
-**Propriedade Personalizada** **Nome**: Nota de rodapé
-**Valor da Propriedade Personalizada**: *o* *valor* *deve* *ser* *um* *string*
+```text
+Footnote
+Custom Property `Name`: Footnote
+Custom Property Value: `the` `value` `should` `be` `a` `string`
+```
 
-Nota de fim
-**Propriedade Personalizada** **Nome**: Nota de fim
-**Valor da Propriedade Personalizada**: *o* *valor* *deve* *ser* *um* *string*
+```text
+Endnote
+Custom Property `Name`: Endnote
+Custom Property Value: `the` `value` `should` `be` `a` `string`
+```
 
-{{% alert color="primary" %}}
-No exemplo a seguir, o relatório contém uma Textbox com o valor 'AsposePdf4RS', e queremos adicionar uma descrição suplementar na forma de uma nota de rodapé com o texto "Um renderizador PDF opcional para SSRS da Aspose Pty. Ltd.".
-{{% /alert %}}
+No exemplo a seguir, o relatório contém uma caixa de texto com o valor `AsposePdf4RS`, e queremos adicionar uma descrição suplementar na forma de uma nota de rodapé com o texto "Um renderizador PDF opcional para SSRS da Aspose Pty. Ltd.".
 
-**Exemplo**
+## Exemplo
 
 ```cs
 <Textbox Name="Textbox1">
@@ -53,4 +54,3 @@ No exemplo a seguir, o relatório contém uma Textbox com o valor 'AsposePdf4RS'
 </Paragraphs>
 </Textbox>
 ```
-{{% /alert %}}

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
@@ -1,27 +1,27 @@
 ---
-title: Nota de rodapé Nota de fim
-linktitle: Nota de rodapé Nota de fim
+title: Nota de rodapé Nota final
+linktitle: Nota de rodapé Nota final
 type: docs
 weight: 30
 url: /pt/reportingservices/footnote-endnote/
-description: Adicione notas de rodapé e notas de fim aos seus relatórios PDF com Aspose.PDF for Reporting Services. Forneça referências detalhadas de documentos.
-lastmod: "2026-06-19"
+description: Adicione notas de rodapé e notas finais aos seus relatórios PDF com Aspose.PDF for Reporting Services. Forneça referências detalhadas ao documento.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-O Report Builder não pode definir a nota de rodapé ou a nota de fim para caixas de texto. Com Aspose.Pdf for Reporting Services, você pode fazer isso facilmente adicionando propriedades personalizadas.
+O Report Builder não pode definir a nota de rodapé ou a nota final para caixas de texto. Com Aspose.PDF for Reporting Services, você pode fazer isso facilmente adicionando propriedades personalizadas.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 Nota de rodapé
 **Propriedade Personalizada** **Nome**: Nota de rodapé
-**Valor da Propriedade Personalizada**: *o* *valor* *deve* *ser* *uma* *string*
+**Valor da Propriedade Personalizada**: *o* *valor* *deve* *ser* *um* *string*
 
 Nota de fim
 **Propriedade Personalizada** **Nome**: Nota de fim
-**Valor da Propriedade Personalizada**: *o* *valor* *deve* *ser* *uma* *string*
+**Valor da Propriedade Personalizada**: *o* *valor* *deve* *ser* *um* *string*
 
 {{% alert color="primary" %}}
 No exemplo a seguir, o relatório contém uma Textbox com o valor 'AsposePdf4RS', e queremos adicionar uma descrição suplementar na forma de uma nota de rodapé com o texto "Um renderizador PDF opcional para SSRS da Aspose Pty. Ltd.".
@@ -54,4 +54,3 @@ No exemplo a seguir, o relatório contém uma Textbox com o valor 'AsposePdf4RS'
 </Textbox>
 ```
 {{% /alert %}}
-

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
@@ -30,7 +30,7 @@ No exemplo a seguir, o relatório contém uma caixa de texto com o valor `Aspose
 
 ## Exemplo
 
-```cs
+```xml
 <Textbox Name="Textbox1">
 ...
 <Paragraphs>

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
@@ -1,37 +1,37 @@
 ---
-title: Alinhamento de Texto Justify FullJustify
-linktitle: Alinhamento de Texto Justify FullJustify
+title: Justificar FullJustify Alinhamento de Texto
+linktitle: Justify FullJustify Text Alignment
 type: docs
 weight: 40
-url: /pt/reportingservices/justify-fulljustify-text-alignment/
-description: Alcance o alinhamento de texto perfeito em relatórios PDF com Aspose.PDF for Reporting Services. Suporte para as opções de justificar e justificar totalmente.
-lastmod: "2026-07-29"
+url: /reportingservices/justify-fulljustify-text-alignment/
+description: Obtenha alinhamento de texto perfeito em relatórios PDF com Aspose.PDF for Reporting Services. Suporte para opções de justificação e justificação completa.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-O construtor de relatórios não oferece suporte à capacidade de especificar o alinhamento de texto para a caixa de texto “Justify” e “FullJustify”. Com Aspose.PDF for Reporting Services, você pode fazer isso facilmente adicionando propriedades personalizadas.
+O construtor de relatórios não suporta a capacidade de especificar o alinhamento de texto para caixa de texto `Justify` e `FullJustify`. Com Aspose.PDF for Reporting Services, você pode fazer isso facilmente adicionando propriedades personalizadas.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**Nome da Propriedade Personalizada** : TextAlignment  
-**Tipo de Propriedade Personalizada** : String  
-**Valores da Propriedade Personalizada** : Justify, FullJustify  
+```text
+Custom Property `Name`: TextAlignment  
+Custom Property `Type`: String  
+Custom Property `Values`: Justify, FullJustify  
+```
 
-No relatório, o código deve ser como o seguinte:
+No relatório o código deve ficar assim:
 
-**Exemplo**
+## Exemplo
 
-{{< highlight csharp >}}
+```xml
 <Textbox Name="textbox1">
 <value> AsposePdf4RS </value>     
   <CustomProperties>
    <CustomProperty>
-     <Name>AlinhamentoDeTexto</Name>
-     <Value>Justificar</Value>
+     <Name>TextAlignment</Name>
+     <Value>Justify</Value>
    </CustomProperty>
   </CustomProperties>
 </Textbox>
-{{< /highlight >}}
-{{% /alert %}}
+```

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
@@ -1,16 +1,16 @@
 ---
-title: Justify FullJustify Alinhamento de Texto
-linktitle: Justify FullJustify Alinhamento de Texto
+title: Alinhamento de Texto Justify FullJustify
+linktitle: Alinhamento de Texto Justify FullJustify
 type: docs
 weight: 40
 url: /pt/reportingservices/justify-fulljustify-text-alignment/
-description: Alcance um alinhamento de texto perfeito em relatórios PDF com Aspose.PDF for Reporting Services. Suporte para as opções justify e full justify.
-lastmod: "2026-06-19"
+description: Alcance o alinhamento de texto perfeito em relatórios PDF com Aspose.PDF for Reporting Services. Suporte para as opções de justificar e justificar totalmente.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-O construtor de relatórios não suporta a capacidade de especificar o alinhamento de texto para a caixa de texto “Justify” e “FullJustify”. Com Aspose.Pdf for Reporting Services, você pode fazer isso facilmente adicionando propriedades personalizadas.
+O construtor de relatórios não oferece suporte à capacidade de especificar o alinhamento de texto para a caixa de texto “Justify” e “FullJustify”. Com Aspose.PDF for Reporting Services, você pode fazer isso facilmente adicionando propriedades personalizadas.
 
 {{% /alert %}}
 
@@ -28,11 +28,10 @@ No relatório, o código deve ser como o seguinte:
 <value> AsposePdf4RS </value>     
   <CustomProperties>
    <CustomProperty>
-     <Name>TextAlignment</Name>
-     <Value>Justify</Value>
+     <Name>AlinhamentoDeTexto</Name>
+     <Value>Justificar</Value>
    </CustomProperty>
   </CustomProperties>
 </Textbox>
 {{< /highlight >}}
 {{% /alert %}}
-

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
@@ -5,28 +5,28 @@ type: docs
 weight: 20
 url: /pt/reportingservices/line-arrows/
 description: Aprenda a adicionar setas de linha em relatórios PDF usando Aspose.PDF for Reporting Services. Melhore os visuais dos relatórios sem esforço.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-A especificação RDL não especifica setas para o elemento de linha, portanto o report builder não oferece suporte à configuração de setas para linhas. Com Aspose.Pdf for Reporting Services você pode fazer isso facilmente.
+A especificação RDL não define as setas para o elemento de linha, portanto o construtor de relatórios não suporta a configuração de setas para linhas. Com o Aspose.PDF for Reporting Services você pode fazer isso facilmente.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Atualmente, o renderizador Aspose.PDF suporta a adição de setas no início ou no final de linhas adicionando propriedades personalizadas.
+Atualmente, o renderizador Aspose.PDF suporta a adição de setas no início ou no final das linhas, adicionando propriedades personalizadas.
 
-Adicionar seta inicial para a linha  
+Adicionar seta de início para a linha  
 **Propriedade Personalizada** **Nome**: HasArrowAtStart  
 **Valor da Propriedade Personalizada**: True  
 
-Adicionar seta final para a linha  
+Adicionar seta de fim para a linha  
 **Propriedade Personalizada** **Nome**: HasArrowAtEnd  
 **Valor da Propriedade Personalizada**: True  
 
-Por exemplo, há duas linhas chamadas ‘line1’ e ‘line2’ no arquivo de relatório atual, e a line1 tem a seta inicial, a line2 tem as setas inicial e final; para atender a esses requisitos, você pode adicionar propriedades personalizadas como no fragmento de código a seguir.
+Por exemplo, há duas linhas chamadas 'line1' e 'line2' no arquivo de relatório atual, e line1 tem a seta de início, line2 tem as setas de início e fim; para atender a esses requisitos, você pode adicionar propriedades personalizadas como no fragmento de código a seguir.
 
 **Exemplo**
 
@@ -37,8 +37,8 @@ Por exemplo, há duas linhas chamadas ‘line1’ e ‘line2’ no arquivo de re
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>HasArrowAtStart</Name>
-        <Value>True</Value>
+        <Name>TemSetaNoInício</Name>
+        <Value>Verdadeiro</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
@@ -49,16 +49,15 @@ Por exemplo, há duas linhas chamadas ‘line1’ e ‘line2’ no arquivo de re
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>HasArrowAtStart</Name>
-        <Value>True</Value>
+        <Name>TemSetaNoInício</Name>
+        <Value>Verdadeiro</Value>
       </CustomProperty>
 <CustomProperty>
-        <Name>HasArrowAtEnd</Name>
-        <Value>True</Value>
+        <Name>TemSetaNoFim</Name>
+        <Value>Verdadeiro</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
 
 {{< /highlight >}}
 {{% /alert %}}
-

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
@@ -1,44 +1,46 @@
 ---
-title: Setas de Linha
-linktitle: Setas de Linha
+title: Setas de linha
+linktitle: Line Arrows
 type: docs
 weight: 20
-url: /pt/reportingservices/line-arrows/
-description: Aprenda a adicionar setas de linha em relatórios PDF usando Aspose.PDF for Reporting Services. Melhore os visuais dos relatórios sem esforço.
-lastmod: "2026-07-29"
+url: /reportingservices/line-arrows/
+description: Aprenda a adicionar setas de linha em relatórios PDF usando Aspose.PDF para Reporting Services. Aprimore o visual do relatório sem esforço.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-A especificação RDL não define as setas para o elemento de linha, portanto o construtor de relatórios não suporta a configuração de setas para linhas. Com o Aspose.PDF for Reporting Services você pode fazer isso facilmente.
+A especificação RDL não especifica as setas sobre o elemento de linha, portanto, o construtor de relatórios não suporta a configuração de setas para linha. Com Aspose.PDF for Reporting Services você pode fazer isso facilmente.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+Atualmente, o renderizador Aspose.PDF oferece suporte à adição de setas no início ou no final das linhas, adicionando propriedades personalizadas.
 
-Atualmente, o renderizador Aspose.PDF suporta a adição de setas no início ou no final das linhas, adicionando propriedades personalizadas.
+```text
+Add Start Arrow for Line  
+Custom Property `Name`: HasArrowAtStart  
+Custom Property `Value`: True  
+```
 
-Adicionar seta de início para a linha  
-**Propriedade Personalizada** **Nome**: HasArrowAtStart  
-**Valor da Propriedade Personalizada**: True  
+```text
+Add End Arrow for Line  
+Custom Property `Name`: HasArrowAtEnd  
+Custom Property `Value`: True  
+```
 
-Adicionar seta de fim para a linha  
-**Propriedade Personalizada** **Nome**: HasArrowAtEnd  
-**Valor da Propriedade Personalizada**: True  
+Por exemplo, existem duas linhas nomeadas `line1` e `line2` no arquivo de relatório atual, e a linha1 possui a seta inicial, a linha2 possui as setas inicial e final. Para atender a esses requisitos, você pode adicionar propriedades customizadas como no fragmento de código a seguir.
 
-Por exemplo, há duas linhas chamadas 'line1' e 'line2' no arquivo de relatório atual, e line1 tem a seta de início, line2 tem as setas de início e fim; para atender a esses requisitos, você pode adicionar propriedades personalizadas como no fragmento de código a seguir.
+## Exemplo
 
-**Exemplo**
-
-{{< highlight csharp >}}
+```xml
  <Line Name="line1">
     <Style>
       ......
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>TemSetaNoInício</Name>
-        <Value>Verdadeiro</Value>
+        <Name>HasArrowAtStart</Name>
+        <Value>True</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
@@ -49,15 +51,14 @@ Por exemplo, há duas linhas chamadas 'line1' e 'line2' no arquivo de relatório
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>TemSetaNoInício</Name>
-        <Value>Verdadeiro</Value>
+        <Name>HasArrowAtStart</Name>
+        <Value>True</Value>
       </CustomProperty>
 <CustomProperty>
-        <Name>TemSetaNoFim</Name>
-        <Value>Verdadeiro</Value>
+        <Name>HasArrowAtEnd</Name>
+        <Value>True</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
+```
 
-{{< /highlight >}}
-{{% /alert %}}

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
@@ -1,25 +1,25 @@
 ---
-title: Sumário Lista de Tabelas ou Figuras
-linktitle: Sumário Lista de Tabelas ou Figuras
+title: Table of Contents List of Tables or Figures
+linktitle: Table of Contents List of Tables or Figures
 type: docs
 weight: 10
-url: /pt/reportingservices/table-of-contents-list-of-tables-or-figures/
-description: Aprenda como adicionar um Sumário, Lista de Tabelas ou Figuras em relatórios PDF usando Aspose.PDF for Reporting Services.
-lastmod: "2026-06-19"
+url: /reportingservices/table-of-contents-list-of-tables-or-figures/
+description: Learn how to add a Table of Contents, List of Tables, or Figures in PDF reports using Aspose.PDF for Reporting Services.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-O Report Designer não suporta a adição de sumário para documentos de relatório. Com Aspose.Pdf for Reporting Services você pode instruir facilmente o renderizador de PDF a gerar documentos PDF com Sumário, ou Lista de Tabelas ou Figuras. Você pode fazer isso nos passos a seguir:
+Report Designer does not support adding table of contents for report documents. With Aspose.PDF for Reporting Services you can easily instruct the PDF render to produce PDF documents with Table of Contents, or List of Tables or Figures. You can do it in the following steps:
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-Certifique-se de que o arquivo Aspose.Pdf.ListSectionStyle.xml existe em ```<Instance>```/bin, onde ```<Instance>``` é o diretório do Report Server. Se o arquivo não existir, crie-o em ```<Instance>```diretório /bin e coloque a marcação a seguir dentro.
+Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/bin, where ```<Instance>``` is the directory of the Report Server. If the file does not exist, create it in the ```<Instance>```/bin directory and place the following markup inside.
 
-## Sumário
+## Table of Contents
 
-**Exemplo**
+**Example**
 
 ```cs
 <ListSection ListType="TableOfContents">
@@ -41,9 +41,9 @@ Certifique-se de que o arquivo Aspose.Pdf.ListSectionStyle.xml existe em ```<Ins
 </ListSection>
 ```
 
-##  Lista de Tabelas
+##  List of TableS
 
-**Exemplo**
+**Example**
 
 ```cs
 <ListSection ListType="ListOfTables">
@@ -53,9 +53,9 @@ Certifique-se de que o arquivo Aspose.Pdf.ListSectionStyle.xml existe em ```<Ins
 </ListSection>
 ```
 
-## Lista de Figuras
+## List of Figures
 
-**Exemplo**
+**Example**
 
 ```cs
  <ListSection ListType="ListOfFigures">
@@ -66,41 +66,40 @@ Certifique-se de que o arquivo Aspose.Pdf.ListSectionStyle.xml existe em ```<Ins
 
 ```
 
-Consulte a seção 'Working with TOC' da documentação online do Aspose.Pdf.
+Please refer to 'Working with TOC' section of the Aspose.Pdf online documentation.
 
-**2-** Adicione o parâmetro de relatório 'IsListSectionSupported' e defina o valor como True, conforme mostrado no parágrafo 'List Section'.
-**3-** Adicione uma propriedade personalizada para o item de relatório que você deseja que seja listado no Sumário, na Lista de Tabelas ou na Lista de Figuras.
+**2-** Add report parameter 'IsListSectionSupported' and set the value to be True as shown in the 'List Section' paragraph.
+**3-** Add custom property for your report item you want to be listed in Table of Contents, List of Tables or Figures.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**Nome da Propriedade Personalizada** :IsInList
-**Valor da Propriedade** :Boolean
-**Valor da Propriedade Personalizada** : Verdadeiro ou Falso
+**Custom Property Name** :IsInList
+**Property Value** :Boolean
+**Custom Property Value** : True or False
 
 {{% alert color="primary" %}}
 
-Marca o item de relatório atual como listado por índice no sumário, ou na lista de tabelas ou figuras.
+Marks the current report item as listed by index in the table of contents, or the list of tables or figures.
 
 {{% /alert %}}
 
-**Nome da Propriedade Personalizada** : Title
-**Tipo da Propriedade Personalizada** : String
+**Custom Property Name** : Title
+**Custom Property Type** : String
 
 {{% alert color="primary" %}}
 
-O título do item exibido no sumário, lista de tabelas ou figuras.
+The item title displayed in the table of contents, list of tables or figures.
 {{% /alert %}}
 
-**Nome da Propriedade Personalizada** : ListLevel
-**Tipo de Propriedade Personalizada** : Inteiro
+**Custom Property Name** : ListLevel
+**Custom Property Type** : Integer
 
 {{% alert color="primary" %}}
 
-O nível dos itens listados exibidos no sumário.
+The level of listed items displayed in the table of contents.
 
 {{% /alert %}}
 
 {{% /alert %}}
-

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
@@ -1,25 +1,24 @@
 ---
-title: Table of Contents List of Tables or Figures
+title: Índice Lista de tabelas ou figuras
 linktitle: Table of Contents List of Tables or Figures
 type: docs
 weight: 10
 url: /reportingservices/table-of-contents-list-of-tables-or-figures/
-description: Learn how to add a Table of Contents, List of Tables, or Figures in PDF reports using Aspose.PDF for Reporting Services.
+description: Aprenda como adicionar um índice, uma lista de tabelas ou figuras em relatórios PDF usando Aspose.PDF para Reporting Services.
 lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Designer does not support adding table of contents for report documents. With Aspose.PDF for Reporting Services you can easily instruct the PDF render to produce PDF documents with Table of Contents, or List of Tables or Figures. You can do it in the following steps:
+O Designer de Relatórios não oferece suporte à adição de sumário para documentos de relatório. Com Aspose.PDF for Reporting Services você pode facilmente instruir o renderizador de PDF para produzir documentos PDF com Índice ou Lista de Tabelas ou Figuras. Você pode fazer isso nas seguintes etapas:
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/bin, where ```<Instance>``` is the directory of the Report Server. If the file does not exist, create it in the ```<Instance>```/bin directory and place the following markup inside.
+Certifique-se de que o arquivo Aspose.Pdf.ListSectionStyle.xml exista no diretório ```<Instance>```/bin, where ```<Instance>``` is the directory of the Report Server. If the file does not exist, create it in the ```<Instance>```/bin e coloque a seguinte marcação dentro dele.
 
-## Table of Contents
+## Índice
 
-**Example**
+### Exemplo
 
 ```cs
 <ListSection ListType="TableOfContents">
@@ -41,9 +40,9 @@ Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/b
 </ListSection>
 ```
 
-##  List of TableS
+##  Lista de Tabelas
 
-**Example**
+### Exemplo
 
 ```cs
 <ListSection ListType="ListOfTables">
@@ -53,9 +52,9 @@ Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/b
 </ListSection>
 ```
 
-## List of Figures
+## Lista de Figuras
 
-**Example**
+### Exemplo
 
 ```cs
  <ListSection ListType="ListOfFigures">
@@ -66,40 +65,29 @@ Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/b
 
 ```
 
-Please refer to 'Working with TOC' section of the Aspose.Pdf online documentation.
+Consulte a seção 'Trabalhando com TOC' da documentação online do Aspose.Pdf.
 
-**2-** Add report parameter 'IsListSectionSupported' and set the value to be True as shown in the 'List Section' paragraph.
-**3-** Add custom property for your report item you want to be listed in Table of Contents, List of Tables or Figures.
+**2-** Adicione o parâmetro de relatório `IsListSectionSupported` e defina o valor como True conforme mostrado no parágrafo `List Section`.
+**3-** Adicione uma propriedade personalizada para o item do relatório que você deseja que seja listado no Índice, Lista de Tabelas ou Figuras.
 
-{{% /alert %}}
+```text
+Custom Property Name: IsInList
+Property Value: Boolean
+Custom Property Value: True or False
+```
 
-{{% alert color="primary" %}}
+Marca o item do relatório atual como listado por índice no índice ou na lista de tabelas ou figuras.
 
-**Custom Property Name** :IsInList
-**Property Value** :Boolean
-**Custom Property Value** : True or False
+```text
+Custom Property Name: Title
+Custom Property Type: String
+```
 
-{{% alert color="primary" %}}
+O título do item exibido no índice, lista de tabelas ou figuras.
 
-Marks the current report item as listed by index in the table of contents, or the list of tables or figures.
+```text
+Custom Property Name: ListLevel
+Custom Property Type: Integer
+```
 
-{{% /alert %}}
-
-**Custom Property Name** : Title
-**Custom Property Type** : String
-
-{{% alert color="primary" %}}
-
-The item title displayed in the table of contents, list of tables or figures.
-{{% /alert %}}
-
-**Custom Property Name** : ListLevel
-**Custom Property Type** : Integer
-
-{{% alert color="primary" %}}
-
-The level of listed items displayed in the table of contents.
-
-{{% /alert %}}
-
-{{% /alert %}}
+O nível dos itens listados exibidos no índice.

--- a/pt/reportingservices/features/_index.md
+++ b/pt/reportingservices/features/_index.md
@@ -4,14 +4,14 @@ linktitle: Recursos
 type: docs
 weight: 30
 url: /pt/reportingservices/features/
-description: Descubra os principais recursos do Aspose.PDF for Reporting Services. Aprimore os relatórios SSRS com recursos avançados de renderização de PDF e personalização.
-lastmod: "2026-06-19"
+description: Descubra os principais recursos do Aspose.PDF for Reporting Services. Melhore os relatórios SSRS com recursos avançados de renderização de PDF e personalização.
+lastmod: "2026-07-29"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
-- [Suporte abrangente a RDL](/pdf/pt/reportingservices/comprehensive-rdl-support/)
-- [Suporte a Relatórios Parametrizados](/pdf/pt/reportingservices/parameterized-report-support/)
-- [Suporte a Itens de Relatório Personalizados](/pdf/pt/reportingservices/custom-report-item-support/)
-- [Implantação fácil e leve](/pdf/pt/reportingservices/easy-and-lightweight-deployment/)
-- [Suporte técnico gratuito de classe mundial](/pdf/pt/reportingservices/world-class-free-technical-support/)
 
+- [Suporte abrangente a RDL](/pdf/pt/reportingservices/comprehensive-rdl-support/)
+- [Suporte a relatórios parametrizados](/pdf/pt/reportingservices/parameterized-report-support/)
+- [Suporte a itens de relatório personalizados](/pdf/pt/reportingservices/custom-report-item-support/)
+- [Implantação Fácil e Leve](/pdf/pt/reportingservices/easy-and-lightweight-deployment/)
+- [Suporte Técnico Gratuito de Classe Mundial](/pdf/pt/reportingservices/world-class-free-technical-support/)

--- a/pt/reportingservices/features/_index.md
+++ b/pt/reportingservices/features/_index.md
@@ -1,17 +1,17 @@
 ---
-title: Recursos
-linktitle: Recursos
+title: Características
+linktitle: Features
 type: docs
 weight: 30
-url: /pt/reportingservices/features/
-description: Descubra os principais recursos do Aspose.PDF for Reporting Services. Melhore os relatórios SSRS com recursos avançados de renderização de PDF e personalização.
-lastmod: "2026-07-29"
+url: /reportingservices/features/
+description: Descubra os principais recursos do Aspose.PDF para Reporting Services. Aprimore os relatórios SSRS com recursos avançados de renderização e personalização de PDF.
+lastmod: "2021-06-05"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
-- [Suporte abrangente a RDL](/pdf/pt/reportingservices/comprehensive-rdl-support/)
+- [Suporte RDL abrangente](/pdf/pt/reportingservices/comprehensive-rdl-support/)
 - [Suporte a relatórios parametrizados](/pdf/pt/reportingservices/parameterized-report-support/)
-- [Suporte a itens de relatório personalizados](/pdf/pt/reportingservices/custom-report-item-support/)
-- [Implantação Fácil e Leve](/pdf/pt/reportingservices/easy-and-lightweight-deployment/)
+- [Suporte a item de relatório personalizado](/pdf/pt/reportingservices/custom-report-item-support/)
+- [Implantação fácil e leve](/pdf/pt/reportingservices/easy-and-lightweight-deployment/)
 - [Suporte Técnico Gratuito de Classe Mundial](/pdf/pt/reportingservices/world-class-free-technical-support/)

--- a/pt/reportingservices/features/comprehensive-rdl-support/_index.md
+++ b/pt/reportingservices/features/comprehensive-rdl-support/_index.md
@@ -1,24 +1,24 @@
 ---
-title: Suporte abrangente ao RDL
-linktitle: Suporte abrangente ao RDL
+title: Suporte RDL abrangente
+linktitle: Comprehensive RDL Support
 type: docs
 weight: 10
-url: /pt/reportingservices/comprehensive-rdl-support/
-description: Descubra o suporte abrangente a RDL no Aspose.PDF for Reporting Services. Renderize relatórios complexos do SQL Server em PDFs profissionais.
-lastmod: "2026-07-29"
+url: /reportingservices/comprehensive-rdl-support/
+description: Descubra suporte RDL abrangente em Aspose.PDF para Reporting Services. Renderize relatórios complexos do SQL Server em PDFs profissionais.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF for Reporting Services suporta a especificação RDL. Isso significa:
+Aspose.PDF para Reporting Services oferece suporte à especificação RDL. Isso significa:
 
-* Não é necessário redesenhar ou personalizar relatórios existentes.
-* Não é necessário usar um designer de relatórios específico. Você pode usar qualquer designer de relatórios RDL e o relatório será exportado exatamente da forma como você o projetou.
+* Não há necessidade de redesenhar ou personalizar relatórios existentes.
+* Não há necessidade de usar um designer de relatório específico. Você pode usar qualquer designer de relatório RDL e o relatório será exportado exatamente da maneira que você o projetou.
 
 {{% /alert %}}
 
-## **Elementos RDL suportados**
-Aspose.PDF for Reporting Services suporta os seguintes elementos RDL:
+## Elementos RDL Suportados
+Aspose.PDF para Reporting Services oferece suporte aos seguintes elementos RDL:
 
 - Seções
 - Cabeçalhos, rodapés
@@ -31,6 +31,6 @@ Aspose.PDF for Reporting Services suporta os seguintes elementos RDL:
 - Estilos
 - Retângulos
 - Linhas
-- Subrelatório
-- Painel de medidor (RS2008)
+- Sub-relatório
+- Painel de medição (RS2008)
 - Tablix (RS2008)

--- a/pt/reportingservices/features/comprehensive-rdl-support/_index.md
+++ b/pt/reportingservices/features/comprehensive-rdl-support/_index.md
@@ -1,19 +1,19 @@
 ---
-title: Suporte abrangente a RDL
-linktitle: Suporte abrangente a RDL
+title: Suporte abrangente ao RDL
+linktitle: Suporte abrangente ao RDL
 type: docs
 weight: 10
 url: /pt/reportingservices/comprehensive-rdl-support/
 description: Descubra o suporte abrangente a RDL no Aspose.PDF for Reporting Services. Renderize relatórios complexos do SQL Server em PDFs profissionais.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.Pdf for Reporting Services suporta a especificação RDL. Isso significa:
+Aspose.PDF for Reporting Services suporta a especificação RDL. Isso significa:
 
 * Não é necessário redesenhar ou personalizar relatórios existentes.
-* Não é necessário usar um designer de relatórios específico. Você pode usar qualquer designer de relatórios RDL e o relatório será exportado exatamente da maneira como você o projetou.
+* Não é necessário usar um designer de relatórios específico. Você pode usar qualquer designer de relatórios RDL e o relatório será exportado exatamente da forma como você o projetou.
 
 {{% /alert %}}
 
@@ -31,7 +31,6 @@ Aspose.PDF for Reporting Services suporta os seguintes elementos RDL:
 - Estilos
 - Retângulos
 - Linhas
-- Sub Relatório
+- Subrelatório
 - Painel de medidor (RS2008)
 - Tablix (RS2008)
-

--- a/pt/reportingservices/features/custom-report-item-support/_index.md
+++ b/pt/reportingservices/features/custom-report-item-support/_index.md
@@ -4,19 +4,18 @@ linktitle: Suporte a Itens de Relatório Personalizados
 type: docs
 weight: 30
 url: /pt/reportingservices/custom-report-item-support/
-description: Aproveite o suporte a itens de relatório personalizados no Aspose.PDF for Reporting Services. Produza PDFs sob medida e de alta qualidade sem esforço.
-lastmod: "2026-06-19"
+description: Aproveite o suporte a itens de relatório personalizados no Aspose.PDF for Reporting Services. Obtenha saídas PDF sob medida e de alta qualidade sem esforço.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Na especificação RDL para RS2016, RS2017, RS2019, RS2022 e Power BI, quase todo item de relatório pode ser estendido adicionando propriedades personalizadas. Atualmente, o Aspose.PDF for Reporting Services 2016, 2017, 2019, 2022 e Power BI suporta três dessas propriedades, nomeadamente:
+Na especificação RDL para RS2016, RS2017, RS2019, RS2022 e Power BI, quase todos os itens de relatório podem ser estendidos adicionando propriedades personalizadas. Atualmente, o Aspose.PDF for Reporting Services 2016, 2017, 2019, 2022 e Power BI oferece suporte a três dessas propriedades, a saber:
 
 - Sumário, lista de tabelas ou figuras.
 - Setas de linha.
-- Nota de rodapé/Fim de nota.
+- Nota de rodapé/nota de fim.
 
-Descubra como usá‑los no [Expandir Propriedades dos Itens de Relatório](/pdf/pt/reportingservices/expand-report-items-properties/) artigo.
+Descubra como usá-los no [Expandir Propriedades de Itens de Relatório](/pdf/pt/reportingservices/expand-report-items-properties/) artigo.
 
 {{% /alert %}}
-

--- a/pt/reportingservices/features/custom-report-item-support/_index.md
+++ b/pt/reportingservices/features/custom-report-item-support/_index.md
@@ -1,21 +1,21 @@
 ---
-title: Suporte a Itens de Relatório Personalizados
-linktitle: Suporte a Itens de Relatório Personalizados
+title: Suporte a item de relatório personalizado
+linktitle: Custom Report Item Support
 type: docs
 weight: 30
-url: /pt/reportingservices/custom-report-item-support/
-description: Aproveite o suporte a itens de relatório personalizados no Aspose.PDF for Reporting Services. Obtenha saídas PDF sob medida e de alta qualidade sem esforço.
-lastmod: "2026-07-29"
+url: /reportingservices/custom-report-item-support/
+description: Aproveite o suporte a itens de relatório personalizados no Aspose.PDF para Reporting Services. Obtenha saídas de PDF personalizadas e de alta qualidade sem esforço.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Na especificação RDL para RS2016, RS2017, RS2019, RS2022 e Power BI, quase todos os itens de relatório podem ser estendidos adicionando propriedades personalizadas. Atualmente, o Aspose.PDF for Reporting Services 2016, 2017, 2019, 2022 e Power BI oferece suporte a três dessas propriedades, a saber:
+Na especificação RDL para RS2016, RS2017, RS2019, RS2022 e Power BI, quase todos os itens de relatório podem ser estendidos adicionando propriedades personalizadas. Atualmente Aspose.PDF para Reporting Services 2016, 2017, 2019, 2022 e Power BI oferece suporte a três dessas propriedades, a saber:
 
-- Sumário, lista de tabelas ou figuras.
+- Índice, lista de tabelas ou figuras.
 - Setas de linha.
-- Nota de rodapé/nota de fim.
+- Nota de rodapé/nota final.
 
-Descubra como usá-los no [Expandir Propriedades de Itens de Relatório](/pdf/pt/reportingservices/expand-report-items-properties/) artigo.
+Saiba como usá-los no [Expanda Propriedades de Itens de Relatório](/pdf/pt/reportingservices/expand-report-items-properties/) artigo.
 
 {{% /alert %}}

--- a/pt/reportingservices/features/easy-and-lightweight-deployment/_index.md
+++ b/pt/reportingservices/features/easy-and-lightweight-deployment/_index.md
@@ -4,11 +4,11 @@ linktitle: Implantação Fácil e Leve
 type: docs
 weight: 40
 url: /pt/reportingservices/easy-and-lightweight-deployment/
-description: Aprenda como implantar o Aspose.PDF for Reporting Services com o mínimo esforço. A configuração leve garante rápida implementação e eficiência.
-lastmod: "2026-06-19"
+description: Aprenda como implantar o Aspose.PDF for Reporting Services com esforço mínimo. A configuração leve garante implementação rápida e eficiência.
+lastmod: "2026-07-29"
 ---
 
-**Aspose.Pdf for Reporting Services** é uma extensão de renderização personalizada para Microsoft SQL Server 2016/2017/2019/2022 Reporting Services e Power BI Report Server. O Aspose.Pdf for Reporting Services é fornecido como um único instalador MSI que pode ser instalado nos computadores que executam um dos seguintes:
+**Aspose.PDF for Reporting Services** é uma extensão de renderização personalizada para Microsoft SQL Server 2016/2017/2019/2022 Reporting Services e Power BI Report Server. O Aspose.PDF for Reporting Services é fornecido como um único instalador MSI que pode ser instalado nos computadores que executam um dos seguintes:
 
 - Microsoft SQL Server 2016 Reporting Services  
 - Microsoft SQL Server 2017 Reporting Services  
@@ -16,7 +16,6 @@ lastmod: "2026-06-19"
 - Microsoft SQL Server 2022 Reporting Services  
 - Microsoft Power BI Report Server
  
-Aspose.Pdf for Reporting Services é fácil de implantar e gerenciar, pois é composto por apenas um assembly .NET Aspose.Pdf.ReportingServices.dll, escrito completamente em C#, compatível com CLS e contendo apenas código gerenciado seguro. É necessário ter o .NET Framework 4.8.1 instalado no servidor.
+Aspose.PDF for Reporting Services é fácil de implantar e gerenciar, pois é composto por apenas um assembly .NET Aspose.Pdf.ReportingServices.dll, escrito completamente em C#, compatível com CLS e contendo apenas código gerenciado seguro. É necessário ter o .NET Framework 4.8.1 instalado no servidor.
 
-Aspose.Pdf.ReportingServices.dll deve ser copiado para o diretório ReportServer\\bin e o arquivo de configuração deve ser atualizado para que o Reporting Services reconheça a nova extensão de renderização. Essas etapas são realizadas pelo instalador do Aspose.Pdf for Reporting Services, mas você também pode executá‑las manualmente conforme descrito mais adiante nesta documentação.
-
+Aspose.Pdf.ReportingServices.dll deve ser copiado para o diretório ReportServer\\bin e o arquivo de configuração deve ser atualizado para que o Reporting Services reconheça a nova extensão de renderização. Essas etapas são realizadas pelo instalador do Aspose.PDF for Reporting Services, mas você também pode executá‑las manualmente conforme descrito mais adiante nesta documentação.

--- a/pt/reportingservices/features/easy-and-lightweight-deployment/_index.md
+++ b/pt/reportingservices/features/easy-and-lightweight-deployment/_index.md
@@ -1,21 +1,21 @@
 ---
-title: Implantação Fácil e Leve
-linktitle: Implantação Fácil e Leve
+title: Implantação fácil e leve
+linktitle: Easy and Lightweight Deployment
 type: docs
 weight: 40
-url: /pt/reportingservices/easy-and-lightweight-deployment/
-description: Aprenda como implantar o Aspose.PDF for Reporting Services com esforço mínimo. A configuração leve garante implementação rápida e eficiência.
-lastmod: "2026-07-29"
+url: /reportingservices/easy-and-lightweight-deployment/
+description: Aprenda como implantar Aspose.PDF para Reporting Services com esforço mínimo. A configuração leve garante implementação rápida e eficiência.
+lastmod: "2021-06-05"
 ---
 
-**Aspose.PDF for Reporting Services** é uma extensão de renderização personalizada para Microsoft SQL Server 2016/2017/2019/2022 Reporting Services e Power BI Report Server. O Aspose.PDF for Reporting Services é fornecido como um único instalador MSI que pode ser instalado nos computadores que executam um dos seguintes:
+**Aspose.PDF for Reporting Services** é uma extensão de renderização personalizada para Microsoft SQL Server 2016/2017/2019/2022 Reporting Services e Power BI Report Server. Aspose.PDF para Reporting Services é fornecido como um único instalador MSI que pode ser instalado nos computadores que executam um dos seguintes:
 
-- Microsoft SQL Server 2016 Reporting Services  
-- Microsoft SQL Server 2017 Reporting Services  
-- Microsoft SQL Server 2019 Reporting Services  
-- Microsoft SQL Server 2022 Reporting Services  
-- Microsoft Power BI Report Server
+- Serviços de relatórios do Microsoft SQL Server 2016  
+- Serviços de relatórios do Microsoft SQL Server 2017  
+- Serviços de relatórios do Microsoft SQL Server 2019  
+- Serviços de relatório do Microsoft SQL Server 2022  
+- Servidor de relatórios do Microsoft Power BI
  
-Aspose.PDF for Reporting Services é fácil de implantar e gerenciar, pois é composto por apenas um assembly .NET Aspose.Pdf.ReportingServices.dll, escrito completamente em C#, compatível com CLS e contendo apenas código gerenciado seguro. É necessário ter o .NET Framework 4.8.1 instalado no servidor.
+Aspose.PDF para Reporting Services é fácil de implantar e gerenciar, pois é composto por apenas um assembly .NET Aspose.Pdf.ReportingServices.dll, escrito completamente em C#, compatível com CLS e contendo apenas código gerenciado seguro. É necessário ter o .NET Framework 4.8.1 instalado no servidor.
 
-Aspose.Pdf.ReportingServices.dll deve ser copiado para o diretório ReportServer\\bin e o arquivo de configuração deve ser atualizado para que o Reporting Services reconheça a nova extensão de renderização. Essas etapas são realizadas pelo instalador do Aspose.PDF for Reporting Services, mas você também pode executá‑las manualmente conforme descrito mais adiante nesta documentação.
+Aspose.Pdf.ReportingServices.dll deve ser copiado para o diretório ReportServer\bin e o arquivo de configuração deve ser atualizado para que o Reporting Services esteja ciente da nova extensão de renderização. Essas etapas são executadas pelo instalador do Aspose.PDF for Reporting Services, mas você também pode executá-las manualmente, conforme descrito mais adiante nesta documentação.

--- a/pt/reportingservices/features/parameterized-report-support/_index.md
+++ b/pt/reportingservices/features/parameterized-report-support/_index.md
@@ -4,15 +4,15 @@ linktitle: Suporte a Relatórios Parametrizados
 type: docs
 weight: 20
 url: /pt/reportingservices/parameterized-report-support/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-Um relatório parametrizado é um relatório que aceita valores de entrada usados no processamento do relatório. Com um relatório parametrizado, você pode variar a saída de um relatório com base em valores que são definidos quando o relatório é executado. Aspose.Pdf for Reporting Services suporta dois tipos de parâmetros: parâmetros do servidor de relatórios e parâmetros de relatório. Os parâmetros do servidor de relatórios são usados para todos os relatórios no servidor de relatórios. Se você quiser tornar alguns parâmetros adequados para relatórios específicos, deve usar parâmetros de relatório.
+Um relatório parametrizado é um relatório que aceita valores de entrada usados no processamento do relatório. Com um relatório parametrizado, você pode variar a saída de um relatório com base nos valores definidos quando o relatório é executado. Aspose.PDF for Reporting Services oferece dois tipos de parâmetros: parâmetros do servidor de relatórios e parâmetros de relatório. Os parâmetros do servidor de relatórios são usados para todos os relatórios no servidor de relatórios. Se você quiser tornar alguns parâmetros adequados a relatórios específicos, deve usar parâmetros de relatório.
 
-Atualmente, o renderizador Aspose.Pdf suporta uma ampla variedade de parâmetros, como:
+Atualmente, o Aspose.Pdf renderer suporta uma ampla gama de parâmetros, como:
 
 ## **Parâmetros Suportados**
-Na versão atual, o Aspose.PDF render suporta diversos aspectos dos parâmetros, que são:
+Na versão atual, o Aspose.PDF render suporta muitos aspectos de parâmetros, que são:
 
 - Orientação da página
 - Formatação HTML
@@ -25,4 +25,3 @@ Na versão atual, o Aspose.PDF render suporta diversos aspectos dos parâmetros,
 - informações de depuração
 
 Saiba mais sobre os parâmetros a partir do [Configure Aspose.PDF for Reporting Services](/pdf/pt/reportingservices/configure-aspose-pdf-for-reporting-services/) artigo.
-

--- a/pt/reportingservices/features/parameterized-report-support/_index.md
+++ b/pt/reportingservices/features/parameterized-report-support/_index.md
@@ -1,27 +1,27 @@
 ---
-title: Suporte a Relatórios Parametrizados
-linktitle: Suporte a Relatórios Parametrizados
+title: Suporte a relatórios parametrizados
+linktitle: Parameterized Report Support
 type: docs
 weight: 20
-url: /pt/reportingservices/parameterized-report-support/
-lastmod: "2026-07-29"
+url: /reportingservices/parameterized-report-support/
+lastmod: "2021-06-05"
 ---
 
-Um relatório parametrizado é um relatório que aceita valores de entrada usados no processamento do relatório. Com um relatório parametrizado, você pode variar a saída de um relatório com base nos valores definidos quando o relatório é executado. Aspose.PDF for Reporting Services oferece dois tipos de parâmetros: parâmetros do servidor de relatórios e parâmetros de relatório. Os parâmetros do servidor de relatórios são usados para todos os relatórios no servidor de relatórios. Se você quiser tornar alguns parâmetros adequados a relatórios específicos, deve usar parâmetros de relatório.
+Um relatório parametrizado é um relatório que aceita valores de entrada usados ​​no processamento de relatórios. Com um relatório parametrizado, você pode variar a saída de um relatório com base nos valores definidos quando o relatório é executado. Aspose.PDF for Reporting Services oferece suporte a dois tipos de parâmetros: parâmetros do servidor de relatório e parâmetros de relatório. Os parâmetros do servidor de relatórios são usados ​​para todos os relatórios no servidor de relatórios. Se quiser tornar alguns parâmetros adequados para relatórios específicos, você deve usar parâmetros de relatório.
 
-Atualmente, o Aspose.Pdf renderer suporta uma ampla gama de parâmetros, como:
+Atualmente, o renderizador Aspose.Pdf oferece suporte a uma ampla gama de parâmetros, como:
 
-## **Parâmetros Suportados**
-Na versão atual, o Aspose.PDF render suporta muitos aspectos de parâmetros, que são:
+## Parâmetros suportados
+Na versão atual, a renderização Aspose.PDF suporta muitos aspectos de parâmetros, que são:
 
 - Orientação da página
 - Formatação HTML
 - Atributos de segurança
 - Tamanho da página
 - Tamanho das margens da página
-- Incorporação de fontes
-- Conformidade PDF/A
-- metadados XMP
-- informações de depuração
+- Incorporação de fonte
+- Conformidade com PDF/A
+- Metadados XMP
+- Informações de depuração
 
-Saiba mais sobre os parâmetros a partir do [Configure Aspose.PDF for Reporting Services](/pdf/pt/reportingservices/configure-aspose-pdf-for-reporting-services/) artigo.
+Saiba mais sobre os parâmetros do [Configurar Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/configure-aspose-pdf-for-reporting-services/) artigo.

--- a/pt/reportingservices/features/world-class-free-technical-support/_index.md
+++ b/pt/reportingservices/features/world-class-free-technical-support/_index.md
@@ -1,21 +1,21 @@
 ---
 title: Suporte Técnico Gratuito de Classe Mundial
-linktitle: Suporte Técnico Gratuito de Classe Mundial
+linktitle: World Class Free Technical Support
 type: docs
 weight: 50
-url: /pt/reportingservices/world-class-free-technical-support/
-description: Desfrute de suporte técnico gratuito de classe mundial para Aspose.PDF for Reporting Services. Receba assistência especializada sempre que precisar.
-lastmod: "2026-07-29"
+url: /reportingservices/world-class-free-technical-support/
+description: Aproveite suporte técnico gratuito de classe mundial para Aspose.PDF for Reporting Services. Obtenha assistência especializada sempre que precisar.
+lastmod: "2021-06-05"
 ---
 
-A Aspose é reconhecida por seu suporte técnico gratuito e ilimitado, que é complementado por artigos técnicos, manuais, fóruns e suporte sempre disponível dos desenvolvedores de produtos. Se uma nova versão ou um Hot Fix de um produto for lançado, todas as novas versões estão disponíveis gratuitamente se você possuir uma assinatura ativa.
+Aspose é conhecida por seu suporte técnico gratuito e ilimitado, que é apoiado por artigos técnicos, manuais, fóruns e suporte sempre pronto e desenvolvedores de produtos. Se houver uma nova versão ou um Hot Fix de um produto for lançado, todos os novos lançamentos estarão disponíveis gratuitamente se você tiver uma assinatura ativa.
 
-**Aspose.Support Forums** é o lugar não apenas para resolver problemas técnicos, mas também para participar de discussões de desenvolvimento com a vibrante e crescente comunidade de usuários da Aspose. Atualmente, há mais de 129,000 usuários registrados no site da Aspose.
+**Aspose.Support Forums** é o lugar não apenas para resolver problemas técnicos, mas também para participar de discussões de desenvolvimento com a comunidade vibrante e crescente de usuários do Aspose. Atualmente existem mais de 129.000 usuários registrados no site Aspose.
 
-Aspose.Blogs é o lugar para encontrar informações sobre os lançamentos mais recentes e sobre o que os desenvolvedores da Aspose têm a dizer.
+Aspose.Blogs é o lugar para procurar informações sobre os últimos lançamentos e sobre o que os desenvolvedores do Aspose têm a dizer.
 
-Há muita atividade nos Aspose.Support Forums:
+Há muita atividade nos Fóruns Aspose.Support:
 
-![todo:image_alt_text](world-class-free-technical-support.png)
+![Suporte Técnico Gratuito](world-class-free-technical-support.png)
 
  

--- a/pt/reportingservices/features/world-class-free-technical-support/_index.md
+++ b/pt/reportingservices/features/world-class-free-technical-support/_index.md
@@ -5,14 +5,14 @@ type: docs
 weight: 50
 url: /pt/reportingservices/world-class-free-technical-support/
 description: Desfrute de suporte técnico gratuito de classe mundial para Aspose.PDF for Reporting Services. Receba assistência especializada sempre que precisar.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-A Aspose é reconhecida por seu suporte técnico gratuito e ilimitado, que conta com artigos técnicos, manuais, fóruns e suporte sempre disponível, além dos desenvolvedores de produto. Se houver uma nova versão ou um Hot Fix de um produto lançada, todas as novas versões estão disponíveis gratuitamente se você tiver uma assinatura ativa.
+A Aspose é reconhecida por seu suporte técnico gratuito e ilimitado, que é complementado por artigos técnicos, manuais, fóruns e suporte sempre disponível dos desenvolvedores de produtos. Se uma nova versão ou um Hot Fix de um produto for lançado, todas as novas versões estão disponíveis gratuitamente se você possuir uma assinatura ativa.
 
-**Aspose.Support Forums** é o local não apenas para resolver problemas técnicos, mas também para participar de discussões de desenvolvimento com a comunidade vibrante e crescente de usuários da Aspose. Atualmente, há mais de 129.000 usuários registrados no site da Aspose.
+**Aspose.Support Forums** é o lugar não apenas para resolver problemas técnicos, mas também para participar de discussões de desenvolvimento com a vibrante e crescente comunidade de usuários da Aspose. Atualmente, há mais de 129,000 usuários registrados no site da Aspose.
 
-Aspose.Blogs é o local para procurar informações sobre os lançamentos mais recentes e o que os desenvolvedores da Aspose têm a dizer.
+Aspose.Blogs é o lugar para encontrar informações sobre os lançamentos mais recentes e sobre o que os desenvolvedores da Aspose têm a dizer.
 
 Há muita atividade nos Aspose.Support Forums:
 

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
@@ -10,8 +10,8 @@ lastmod: "2021-06-05"
 
 **Esta seção inclui os seguintes tópicos:**
 
-- [Install with MSI Installer](/pdf/reportingservices/install-with-msi-installer/)
-- [Install Manually](/pdf/reportingservices/install-manually/)
-- [Install with Configuring Tool](/pdf/reportingservices/install-with-configuring-tool/)
+- [Instalar com o instalador MSI](/pdf/reportingservices/install-with-msi-installer/)
+- [Instalar manualmente](/pdf/reportingservices/install-manually/)
+- [Instalar com ferramenta de configuração](/pdf/reportingservices/install-with-configuring-tool/)
 
 

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
@@ -1,19 +1,17 @@
 ---
-title: Instalar Aspose.PDF
-linktitle: Instalar Aspose.PDF
+title: Instale Aspose.PDF
+linktitle: Install Aspose.PDF
 type: docs
 weight: 50
-url: /pt/reportingservices/install-aspose-pdf-for-reporting-services/
-description: Aprenda como instalar o Aspose.PDF for Reporting Services. Siga este guia passo a passo para habilitar a funcionalidade de exportação de PDF no SSRS.
-lastmod: "2026-07-29"
+url: /reportingservices/install-aspose-pdf-for-reporting-services/
+description: Aprenda como instalar o Aspose.PDF para Reporting Services. Siga este guia passo a passo para ativar a funcionalidade de exportação de PDF no SSRS.
+lastmod: "2021-06-05"
 ---
-
-{{% alert color="primary" %}}
 
 **Esta seção inclui os seguintes tópicos:**
 
-- [Instalar com Instalador MSI](/pdf/pt/reportingservices/install-with-msi-installer/)
-- [Instalar Manualmente](/pdf/pt/reportingservices/install-manually/)
-- [Instalar com a Ferramenta de Configuração](/pdf/pt/reportingservices/install-with-configuring-tool/)
+- [Install with MSI Installer](/pdf/reportingservices/install-with-msi-installer/)
+- [Install Manually](/pdf/reportingservices/install-manually/)
+- [Install with Configuring Tool](/pdf/reportingservices/install-with-configuring-tool/)
 
-{{% /alert %}}
+

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
@@ -4,17 +4,16 @@ linktitle: Instalar Aspose.PDF
 type: docs
 weight: 50
 url: /pt/reportingservices/install-aspose-pdf-for-reporting-services/
-description: Saiba como instalar o Aspose.PDF para Reporting Services. Siga este guia passo a passo para habilitar a funcionalidade de exportação de PDF no SSRS.
-lastmod: "2026-06-19"
+description: Aprenda como instalar o Aspose.PDF for Reporting Services. Siga este guia passo a passo para habilitar a funcionalidade de exportação de PDF no SSRS.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
 **Esta seção inclui os seguintes tópicos:**
 
-- [Instalar com instalador MSI](/pdf/pt/reportingservices/install-with-msi-installer/)
-- [Instalar manualmente](/pdf/pt/reportingservices/install-manually/)
+- [Instalar com Instalador MSI](/pdf/pt/reportingservices/install-with-msi-installer/)
+- [Instalar Manualmente](/pdf/pt/reportingservices/install-manually/)
 - [Instalar com a Ferramenta de Configuração](/pdf/pt/reportingservices/install-with-configuring-tool/)
 
 {{% /alert %}}
-

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
@@ -4,11 +4,10 @@ linktitle: Instalar manualmente
 type: docs
 weight: 20
 url: /pt/reportingservices/install-manually/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
 - [Instalar no Report Server](/pdf/pt/reportingservices/install-to-report-server/)
-
 

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
@@ -1,13 +1,13 @@
 ---
 title: Instalar manualmente
-linktitle: Instalar manualmente
+linktitle: Install Manually
 type: docs
 weight: 20
-url: /pt/reportingservices/install-manually/
-lastmod: "2026-07-29"
+url: /reportingservices/install-manually/
+lastmod: "2021-06-05"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
-- [Instalar no Report Server](/pdf/pt/reportingservices/install-to-report-server/)
+- [Instalar no servidor de relatório](/pdf/pt/reportingservices/install-to-report-server/)
 

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Install to Report Server
+title: Instalar no servidor de relatório
 linktitle: Install to Report Server
 type: docs
 weight: 10
@@ -9,52 +9,38 @@ lastmod: "2021-06-05"
 
 {{% alert color="primary" %}}
 
-You only need to follow these steps if you install Aspose.PDF for Reporting Services manually, not using the MSI installer. MSI installer performs all necessary installation and registration actions automatically.
+Você só precisará seguir essas etapas se instalar o Aspose.PDF para Reporting Services manualmente, sem usar o instalador MSI. O instalador MSI executa todas as ações necessárias de instalação e registro automaticamente.
 
 {{% /alert %}}
 
-In the following steps, you will need to copy and modify files in the directory where Microsoft SQL Server Reporting Services is installed. The SSRS 2016 assembly is located in the \Bin\SSRS2016 directory of the zip package; the SSRS 2017 assembly is located in the \Bin\SSRS2017 directory; the SSRS 2019 assembly is located in the \Bin\SSRS2019 directory; the SSRS 2022 assembly is located in the \Bin\SSRS2022 directory; the Power BI Report Server assembly is located in the \Bin\PowerBI directory. 
+Nas etapas a seguir, você precisará copiar e modificar arquivos no diretório onde o Microsoft SQL Server Reporting Services está instalado. O assembly do SSRS 2016 está localizado no diretório \Bin\SSRS2016 do pacote zip; o assembly SSRS 2017 está localizado no diretório \Bin\SSRS2017; o assembly SSRS 2019 está localizado no diretório \Bin\SSRS2019; o assembly SSRS 2022 está localizado no diretório \Bin\SSRS2022; o assembly do Servidor de Relatórios do Power BI está localizado no diretório \Bin\PowerBI.
 
-{{% alert color="primary" %}}
+**Etapa 1.** Localize o diretório de instalação do Report Server. O diretório raiz do Microsoft SQL Server geralmente é C:\Program Files\Microsoft SQL Server. O processo adicional é um pouco diferente para o Reporting Services 2016, o Reporting Services 2017 e posterior e o Power BI Report Server:
 
-**Step 1.** Locate the Report Server installation directory. The root directory for Microsoft SQL Server is usually C:\Program Files\Microsoft SQL Server. Further process is slightly different for Reporting Services 2016, Reporting Services 2017 and later, and Power BI Report Server:
+- O Report Server 2016, por padrão, é instalado no diretório C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer. Se você estiver usando instâncias nomeadas personalizadas em vez da padrão, o caminho padrão será C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
+- O Report Server 2017 e posterior, por padrão, é instalado no diretório C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer.
+- Por padrão, o Power BI Report Server é instalado no diretório C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer.
 
-- Report Server 2016 by default is installed in the C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer directory. If you are using custom named instances instead of the default one, the default path will be C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
-- Report Server 2017 and later by default is installed in the C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer directory.
-- Power BI Report Server by default is installed in the C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer directory.
+No texto a seguir, o diretório de instalação do Reporting Services (um dos caminhos mencionados acima) será referenciado como `<Instance>`.
 
-In the following text the installation directory of the Reporting Services (one of the aforementioned paths) will be referenced to as ```<Instance>```.
-{{% /alert %}}
+**Etapa 2.** Copie Aspose.Pdf.ReportingServices.dll da versão SSRS correspondente para a pasta `<Instance>\bin`.
 
-{{% alert color="primary" %}}
-**Step 2.** Copy Aspose.Pdf.ReportingServices.dll for the corresponding SSRS version to the ```<Instance>```\bin folder.
-{{% /alert %}}
+**Etapa 3.** Registre Aspose.PDF para Reporting Services como uma extensão de renderização. Abra o arquivo `<Instance>\rsreportserver.config` e adicione as seguintes linhas ao elemento `<Render>`:
 
-{{% alert color="primary" %}}
-**Step 3.** Register Aspose.PDF for Reporting Services as a rendering extension. Open the ```<Instance>```\rsreportserver.config file and add the following lines into the ```<Render>``` element:
-{{% /alert %}}
+## Exemplo
 
-**Example**
-
-{{< highlight csharp >}}
-
- <Render>
+```xml
+<Render>
 ...
-<!--Start here.-->
-
 <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices"/>
-
 </Render>
+```
 
-{{< /highlight >}}
+**Etapa 4.** Forneça ao Aspose.PDF para Reporting Services permissões de execução. Abra o arquivo `<Instance>\rssrvpolicy.config` e adicione o seguinte texto como o último item no segundo elemento externo `<CodeGroup>` que deve ser `<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):`
 
-{{% alert color="primary" %}}
-**Step 4.** Provide Aspose.PDF for Reporting Services with permissions to execute. Open the ```<Instance>```\rssrvpolicy.config file and add the following text as the last item in the second to outer ```<CodeGroup>``` element (which should be ```<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):```
-{{% /alert %}}
+## Exemplo
 
-**Example**
-
-{{< highlight csharp >}}
+```xml
 
  <CodeGroup>
 ...
@@ -77,20 +63,14 @@ Name="Aspose.Pdf_for_Reporting_Services" Description="This code group grants ful
 </CodeGroup>
 
 </CodeGroup>
+```
 
-{{< /highlight >}}
+**Etapa 5.** Verifique se o Aspose.PDF para Reporting Services foi instalado com êxito. Abra o portal da Web Reporting Services e verifique a lista de formatos de exportação disponíveis para um relatório. Você pode iniciar o portal da web iniciando um navegador da web e digitando o URL do portal da web do Reporting Services na barra de endereço (por padrão é http://`<Reporting_Services_server_name>`/reports/). Selecione um dos relatórios disponíveis em seu portal da web e abra a lista suspensa Exportar. Você deverá ver a lista de formatos de exportação, incluindo aqueles fornecidos pela extensão Aspose.PDF para Reporting Services. Selecione PDF por meio do item Aspose.PDF.
 
-{{% alert color="primary" %}}
-**Step 5.** Verify that Aspose.PDF for Reporting Services was installed successfully. Open the Reporting Services web portal and check the list of available export formats for a report. You can launch the web portal by starting a web browser and typing the Reporting Services web portal URL in the address bar (by default it is http://```<Reporting_Services_server_name>```/reports/). Select one of the reports available in your web portal and pull the Export dropdown list. You should see the list of export formats including the ones provided by the Aspose.PDF for Reporting Services extension. Select PDF via Aspose.PDF item.
+![Install to report server](install-to-report-server_1.png)
 
- 
-{{% /alert %}}
+Clique no item selecionado. Ele irá gerar o relatório no formato selecionado, enviá-lo ao cliente e, dependendo das configurações do seu navegador, mostrar a caixa de diálogo Salvar arquivo para escolher onde salvar o relatório exportado ou baixar automaticamente o arquivo para sua pasta Downloads.
 
-![todo:image_alt_text](install-to-report-server_1.png)
+Parabéns, você instalou com sucesso o Aspose.PDF for Reporting Services e exportou um relatório como um documento PDF!
 
-Click the selected item. It will generate the report in the selected format, send it to the client, and, depending on your web browser settings, either show you the Save File dialog to choose where to save the exported report, or automatically download the file to the your Downloads folder.
-
-{{% alert color="primary" %}}
-Congratulations, you’ve successfully installed Aspose.PDF for Reporting Services and exported a report as a PDF document!
-{{% /alert %}}
 

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
@@ -1,40 +1,40 @@
 ---
-title: Instalar no Report Server
-linktitle: Instalar no Report Server
+title: Install to Report Server
+linktitle: Install to Report Server
 type: docs
 weight: 10
-url: /pt/reportingservices/install-to-report-server/
-lastmod: "2026-06-19"
+url: /reportingservices/install-to-report-server/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Você só precisa seguir estas etapas se instalar o Aspose.PDF for Reporting Services manualmente, não usando o instalador MSI. O instalador MSI executa todas as ações necessárias de instalação e registro automaticamente.
+You only need to follow these steps if you install Aspose.PDF for Reporting Services manually, not using the MSI installer. MSI installer performs all necessary installation and registration actions automatically.
 
 {{% /alert %}}
 
-Nas etapas seguintes, você precisará copiar e modificar arquivos no diretório onde o Microsoft SQL Server Reporting Services está instalado. O assembly do SSRS 2016 está localizado no diretório \Bin\SSRS2016 do pacote zip; o assembly do SSRS 2017 está localizado no diretório \Bin\SSRS2017; o assembly do SSRS 2019 está localizado no diretório \Bin\SSRS2019; o assembly do SSRS 2022 está localizado no diretório \Bin\SSRS2022; o assembly do Power BI Report Server está localizado no diretório \Bin\PowerBI. 
+In the following steps, you will need to copy and modify files in the directory where Microsoft SQL Server Reporting Services is installed. The SSRS 2016 assembly is located in the \Bin\SSRS2016 directory of the zip package; the SSRS 2017 assembly is located in the \Bin\SSRS2017 directory; the SSRS 2019 assembly is located in the \Bin\SSRS2019 directory; the SSRS 2022 assembly is located in the \Bin\SSRS2022 directory; the Power BI Report Server assembly is located in the \Bin\PowerBI directory. 
 
 {{% alert color="primary" %}}
 
-**Etapa 1.** Localize o diretório de instalação do Report Server. O diretório raiz do Microsoft SQL Server geralmente é C:\Program Files\Microsoft SQL Server. O processo posterior é um pouco diferente para Reporting Services 2016, Reporting Services 2017 e posteriores, e para o Power BI Report Server:
+**Step 1.** Locate the Report Server installation directory. The root directory for Microsoft SQL Server is usually C:\Program Files\Microsoft SQL Server. Further process is slightly different for Reporting Services 2016, Reporting Services 2017 and later, and Power BI Report Server:
 
-- O Report Server 2016, por padrão, é instalado no diretório C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer. Se você estiver usando instâncias com nomes personalizados em vez da padrão, o caminho padrão será C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
-- O Report Server 2017 e versões posteriores, por padrão, são instalados no diretório C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer.
-- O Power BI Report Server, por padrão, é instalado no diretório C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer.
+- Report Server 2016 by default is installed in the C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer directory. If you are using custom named instances instead of the default one, the default path will be C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
+- Report Server 2017 and later by default is installed in the C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer directory.
+- Power BI Report Server by default is installed in the C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer directory.
 
-No texto a seguir, o diretório de instalação do Reporting Services (um dos caminhos mencionados) será referenciado como ```<Instance>```.
+In the following text the installation directory of the Reporting Services (one of the aforementioned paths) will be referenced to as ```<Instance>```.
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Etapa 2.** Copie Aspose.Pdf.ReportingServices.dll para a versão correspondente do SSRS para ```<Instance>```pasta \bin.
+**Step 2.** Copy Aspose.Pdf.ReportingServices.dll for the corresponding SSRS version to the ```<Instance>```\bin folder.
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Etapa 3.** Registre o Aspose.Pdf for Reporting Services como uma extensão de renderização. Abra o ```<Instance>```\rsreportserver.config file e adicione as linhas a seguir no ```<Render>``` elemento:
+**Step 3.** Register Aspose.PDF for Reporting Services as a rendering extension. Open the ```<Instance>```\rsreportserver.config file and add the following lines into the ```<Render>``` element:
 {{% /alert %}}
 
-**Exemplo**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -49,10 +49,10 @@ No texto a seguir, o diretório de instalação do Reporting Services (um dos ca
 {{< /highlight >}}
 
 {{% alert color="primary" %}}
-**Etapa 4.** Forneça o Aspose.Pdf for Reporting Services com permissões para executar. Abra o ```<Instance>```arquivo \\rssrvpolicy.config e adicione o texto a seguir como o último item no segundo ao externo ```<CodeGroup>``` elemento (que deve ser ```<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):```
+**Step 4.** Provide Aspose.PDF for Reporting Services with permissions to execute. Open the ```<Instance>```\rssrvpolicy.config file and add the following text as the last item in the second to outer ```<CodeGroup>``` element (which should be ```<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):```
 {{% /alert %}}
 
-**Exemplo**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -81,19 +81,16 @@ Name="Aspose.Pdf_for_Reporting_Services" Description="This code group grants ful
 {{< /highlight >}}
 
 {{% alert color="primary" %}}
-**Etapa 5.** Verifique se o Aspose.Pdf for Reporting Services foi instalado com sucesso. Abra o portal web do Reporting Services e verifique a lista de formatos de exportação disponíveis para um relatório. Você pode iniciar o portal web iniciando um navegador e digitando a URL do portal web do Reporting Services na barra de endereço (por padrão, ela é http://```<Reporting_Services_server_name>```/reports/). Selecione um dos relatórios disponíveis em seu portal da Web e abra a lista suspensa Exportar. Você deve ver a lista de formatos de exportação, incluindo os fornecidos pela extensão Aspose.Pdf for Reporting Services. Selecione o item PDF via Aspose.PDF.
+**Step 5.** Verify that Aspose.PDF for Reporting Services was installed successfully. Open the Reporting Services web portal and check the list of available export formats for a report. You can launch the web portal by starting a web browser and typing the Reporting Services web portal URL in the address bar (by default it is http://```<Reporting_Services_server_name>```/reports/). Select one of the reports available in your web portal and pull the Export dropdown list. You should see the list of export formats including the ones provided by the Aspose.PDF for Reporting Services extension. Select PDF via Aspose.PDF item.
 
  
 {{% /alert %}}
 
 ![todo:image_alt_text](install-to-report-server_1.png)
 
-Clique no item selecionado. Ele gerará o relatório no formato selecionado, enviará ao cliente e, dependendo das configurações do seu navegador, exibirá a caixa de diálogo Salvar arquivo para escolher onde salvar o relatório exportado ou baixará automaticamente o arquivo para a sua pasta Downloads.
+Click the selected item. It will generate the report in the selected format, send it to the client, and, depending on your web browser settings, either show you the Save File dialog to choose where to save the exported report, or automatically download the file to the your Downloads folder.
 
 {{% alert color="primary" %}}
-Parabéns, você instalou o Aspose.Pdf for Reporting Services com sucesso e exportou um relatório como documento PDF!
+Congratulations, you’ve successfully installed Aspose.PDF for Reporting Services and exported a report as a PDF document!
 {{% /alert %}}
-
-
-
 

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
@@ -1,24 +1,23 @@
 ---
-title: Instalar com a Ferramenta de Configuração
-linktitle: Instalar com a Ferramenta de Configuração
+title: Instalar com ferramenta de configuração
+linktitle: Install with Configuring Tool
 type: docs
 weight: 30
-url: /pt/reportingservices/install-with-configuring-tool/
-description: Guia passo a passo para instalar o Aspose.PDF for Reporting Services usando a ferramenta de configuração para integração perfeita.
-lastmod: "2026-07-29"
+url: /reportingservices/install-with-configuring-tool/
+description: Guia passo a passo para instalar o Aspose.PDF para Reporting Services usando a ferramenta de configuração para integração perfeita.
+lastmod: "2021-06-05"
 ---
 
-Aspose.PDF for Reporting Services Configuring Tool pode ajudá-lo a configurar a extensão Aspose.PDF for Reporting Services para qualquer uma das versões suportadas do Report Server (RS). Atualmente, ele suporta RS2016, RS2017, RS2019, RS2022 e Power BI Report Server. A Ferramenta de Configuração requer .NET Framework 4.8.
+A ferramenta de configuração Aspose.PDF for Reporting Services pode ajudá-lo a configurar a extensão Aspose.PDF for Reporting Services para qualquer uma das versões suportadas do Report Server (RS). Atualmente ele oferece suporte a RS2016, RS2017, RS2019, RS2022 e Power BI Report Server. A ferramenta de configuração requer o .NET Framework 4.8.
 
-Se quiser instalar a extensão e registrá-la no Report Server, selecione o tipo de ação 'Register'. Para cancelar o registro e desinstalar a extensão, selecione o tipo de ação 'Unregister'.
+Se desejar instalar a extensão e registrá-la no Report Server, selecione a opção `Register` tipo de ação. Para cancelar o registro e desinstalar a extensão, selecione o `Unregister` tipo de ação.
 
-![todo:image_alt_text](install-with-configuring-tool_1.png)
+![Instalar com ferramenta de configuração](install-with-configuring-tool_1.png)
 
-**Os passos a seguir descrevem como usá-lo em detalhes:**
+**As etapas a seguir descrevem como usá-lo em detalhes:**
 
-1. Insira ou procure o caminho do arquivo DLL para a extensão Aspose.PDF for Reporting Services;
-1. Selecione o tipo de ação correspondente: Register ou Unregister;
-1. Selecione a guia correspondente à versão do Report Server que você deseja configurar. Por favor, certifique‑se de que você selecionou o arquivo DLL destinado à sua versão do RS. Se a versão solicitada do produto não estiver instalada na máquina, a ferramenta de configuração informará com dicas. Se você estiver configurando a extensão para a instância nomeada RS2016 (não a padrão \u0027MSSQLSERVER\u0027), insira o nome da instância personalizada e, em seguida, pressione o botão \u0027Refresh\u0027.
-1. Certifique‑se de que os caminhos e nomes dos arquivos de configuração exibidos nas caixas de texto inferiores estejam corretos. Se não estiverem, você pode pressionar o botão \u0027Refresh\u0027 para tentar encontrar a instância do RS novamente, ou pode procurá‑los manualmente.
-1. Pressione o botão \u0027Config\u0027. A ferramenta agora tentará fazer a configuração solicitada e informará se a configuração foi bem‑sucedida ou não.
- 
+1. Insira ou procure o caminho do arquivo DLL para a extensão Aspose.PDF para Reporting Services;
+1. Selecione o tipo de ação correspondente: Cadastrar ou Descadastrar;
+1. Selecione a guia correspondente à versão do Report Server que você deseja configurar. Certifique-se de ter selecionado o arquivo DLL destinado à sua versão RS. Caso a versão solicitada do produto não esteja instalada na máquina, a ferramenta de configuração informará com dicas. Se você estiver configurando a extensão para a instância RS2016 nomeada (não a padrão 'MSSQLSERVER'), insira o nome da instância personalizada e pressione o botão 'Atualizar'.
+1. Certifique-se de que os caminhos e nomes dos arquivos de configuração mostrados nas caixas de texto inferiores estejam corretos. Se não estiverem, você pode pressionar o botão 'Atualizar' para tentar encontrar a instância RS novamente ou pode procurá-los manualmente.
+1. Pressione o botão 'Configurar'. A ferramenta agora tentará fazer a configuração solicitada e informará se a configuração foi bem-sucedida ou não.

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
@@ -5,21 +5,20 @@ type: docs
 weight: 30
 url: /pt/reportingservices/install-with-configuring-tool/
 description: Guia passo a passo para instalar o Aspose.PDF for Reporting Services usando a ferramenta de configuração para integração perfeita.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-O Aspose.Pdf for Reporting Services Configuring Tool pode ajudá-lo a configurar a extensão Aspose.Pdf for Reporting Services para qualquer uma das versões suportadas do Report Server (RS). Atualmente, ele suporta RS2016, RS2017, RS2019, RS2022 e Power BI Report Server. O Configuring Tool requer .NET Framework 4.8.
+Aspose.PDF for Reporting Services Configuring Tool pode ajudá-lo a configurar a extensão Aspose.PDF for Reporting Services para qualquer uma das versões suportadas do Report Server (RS). Atualmente, ele suporta RS2016, RS2017, RS2019, RS2022 e Power BI Report Server. A Ferramenta de Configuração requer .NET Framework 4.8.
 
-Se você quiser instalar a extensão e registrá‑la no Report Server, selecione o tipo de ação 'Register'. Para cancelar o registro e desinstalar a extensão, selecione o tipo de ação 'Unregister'.
+Se quiser instalar a extensão e registrá-la no Report Server, selecione o tipo de ação 'Register'. Para cancelar o registro e desinstalar a extensão, selecione o tipo de ação 'Unregister'.
 
 ![todo:image_alt_text](install-with-configuring-tool_1.png)
 
-**Os passos a seguir descrevem como usá‑lo em detalhes:**
+**Os passos a seguir descrevem como usá-lo em detalhes:**
 
-1. Insira ou procure o caminho do arquivo DLL para a extensão Aspose.Pdf for Reporting Services;
+1. Insira ou procure o caminho do arquivo DLL para a extensão Aspose.PDF for Reporting Services;
 1. Selecione o tipo de ação correspondente: Register ou Unregister;
-1. Selecione a aba correspondente à versão do Report Server que você deseja configurar. Certifique‑se de que selecionou o arquivo DLL destinado à sua versão do RS. Se a versão solicitada do produto não estiver instalada na máquina, a ferramenta de configuração lhe informará com dicas. Se estiver configurando a extensão para a instância nomeada RS2016 (não a padrão 'MSSQLSERVER'), insira o nome da instância personalizada e, em seguida, pressione o botão 'Refresh'.
-1. Certifique‑se de que os caminhos e nomes dos arquivos de configuração exibidos nas caixas de texto inferiores estejam corretos. Se não estiverem, você pode pressionar o botão 'Refresh' para tentar localizar a instância do RS novamente, ou pode procurá‑los manualmente.
-1. Pressione o botão 'Config'. A ferramenta agora tentará aplicar a configuração solicitada e informará se a configuração foi bem‑sucedida ou não.
+1. Selecione a guia correspondente à versão do Report Server que você deseja configurar. Por favor, certifique‑se de que você selecionou o arquivo DLL destinado à sua versão do RS. Se a versão solicitada do produto não estiver instalada na máquina, a ferramenta de configuração informará com dicas. Se você estiver configurando a extensão para a instância nomeada RS2016 (não a padrão \u0027MSSQLSERVER\u0027), insira o nome da instância personalizada e, em seguida, pressione o botão \u0027Refresh\u0027.
+1. Certifique‑se de que os caminhos e nomes dos arquivos de configuração exibidos nas caixas de texto inferiores estejam corretos. Se não estiverem, você pode pressionar o botão \u0027Refresh\u0027 para tentar encontrar a instância do RS novamente, ou pode procurá‑los manualmente.
+1. Pressione o botão \u0027Config\u0027. A ferramenta agora tentará fazer a configuração solicitada e informará se a configuração foi bem‑sucedida ou não.
  
-

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
@@ -4,21 +4,20 @@ linktitle: Instalar com Instalador MSI
 type: docs
 weight: 10
 url: /pt/reportingservices/install-with-msi-installer/
-description: Aprenda como instalar o Aspose.PDF for Reporting Services usando o instalador MSI. Um guia simples para uma configuração rápida.
-lastmod: "2026-06-19"
+description: Saiba como instalar Aspose.PDF for Reporting Services usando o instalador MSI. Um guia direto para configuração rápida.
+lastmod: "2026-07-29"
 ---
 
-Você pode instalar o Aspose.Pdf for Reporting Services usando um instalador MSI. Execute Aspose.Pdf.ReportingServices.msi e siga as etapas oferecidas pelo instalador. O instalador copiará o assembly e outros arquivos para o diretório especificado e instalará o produto na instância padrão do Reporting Services. Você não precisa copiar ou modificar nenhum arquivo manualmente, a menos que deseje adicionar parâmetros de configuração especiais conforme descrito na seção ‘Configure Aspose.Pdf for Reporting Services’.
+Você pode instalar Aspose.PDF for Reporting Services usando um instalador MSI. Execute Aspose.Pdf.ReportingServices.msi e siga as etapas oferecidas pelo instalador. O instalador copiará o assembly e outros arquivos para o diretório especificado e instalará o produto na instância padrão do Reporting Services. Você não precisa copiar ou modificar nenhum arquivo manualmente, a menos que queira adicionar parâmetros de configuração especiais conforme descrito na seção 'Configure Aspose.PDF for Reporting Services'.
 
-A instalação automática é a melhor opção, que funciona na maioria dos casos. Contudo, pode ser necessário instalar o produto manualmente em algumas situações, como:
+A instalação automática é a melhor opção que funciona na maioria dos casos. No entanto, pode ser necessário instalar o produto manualmente em algumas situações, como:
  
 - A instalação automática falha devido a problemas de segurança de I/O.
-- Você precisa instalar o produto em uma instância nomeada (não padrão) do Reporting Services 2016 ou em várias instâncias.
-- Você atualiza para a versão mais recente e deseja apenas substituir o assembly em vez de desinstalar a versão antiga e instalar a nova usando o instalador MSI.
+- Você precisa instalar o produto em uma instância nomeada (não padrão) do Reporting Services 2016 ou em múltiplas instâncias.
+- Você atualiza para a versão mais recente e só quer substituir o assembly em vez de desinstalar a versão antiga e instalar a nova usando o instalador MSI.
  
 {{% alert color="primary" %}}
 
-Observação: Note que, no último caso, você pode acabar com outros componentes (como a documentação offline) que não foram atualizados para a versão correspondente.
+Nota: Observe que, no último caso, você pode acabar com outros componentes (como a documentação offline) que não foram atualizados para a versão correspondente.
 
 {{% /alert %}}
-

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
@@ -1,23 +1,23 @@
 ---
-title: Instalar com Instalador MSI
-linktitle: Instalar com Instalador MSI
+title: Instalar com o instalador MSI
+linktitle: Install with MSI Installer
 type: docs
 weight: 10
-url: /pt/reportingservices/install-with-msi-installer/
-description: Saiba como instalar Aspose.PDF for Reporting Services usando o instalador MSI. Um guia direto para configuração rápida.
-lastmod: "2026-07-29"
+url: /reportingservices/install-with-msi-installer/
+description: Aprenda como instalar o Aspose.PDF para Reporting Services usando o instalador MSI. Um guia simples para configuração rápida.
+lastmod: "2021-06-05"
 ---
 
-Você pode instalar Aspose.PDF for Reporting Services usando um instalador MSI. Execute Aspose.Pdf.ReportingServices.msi e siga as etapas oferecidas pelo instalador. O instalador copiará o assembly e outros arquivos para o diretório especificado e instalará o produto na instância padrão do Reporting Services. Você não precisa copiar ou modificar nenhum arquivo manualmente, a menos que queira adicionar parâmetros de configuração especiais conforme descrito na seção 'Configure Aspose.PDF for Reporting Services'.
+Você pode instalar o Aspose.PDF para Reporting Services usando um instalador MSI. Execute Aspose.Pdf.ReportingServices.msi e siga as etapas oferecidas pelo instalador. O instalador copiará o assembly e outros arquivos para o diretório especificado e instalará o produto na instância padrão do Reporting Services. Você não precisa copiar ou modificar nenhum arquivo manualmente, a menos que queira adicionar parâmetros de configuração especiais, conforme descrito na seção 'Configurar Aspose.PDF para Reporting Services'.
 
-A instalação automática é a melhor opção que funciona na maioria dos casos. No entanto, pode ser necessário instalar o produto manualmente em algumas situações, como:
- 
-- A instalação automática falha devido a problemas de segurança de I/O.
-- Você precisa instalar o produto em uma instância nomeada (não padrão) do Reporting Services 2016 ou em múltiplas instâncias.
-- Você atualiza para a versão mais recente e só quer substituir o assembly em vez de desinstalar a versão antiga e instalar a nova usando o instalador MSI.
+A instalação automática é a melhor opção que funciona na maioria dos casos. No entanto, pode ser necessário instalar o produto manualmente em algumas situações como:
+
+- A instalação automática falha devido a problemas de segurança de E/S.
+- Você precisa instalar o produto em uma instância nomeada (não padrão) do Reporting Services 2016 ou em várias instâncias.
+- Você atualiza para a versão mais recente e deseja apenas substituir a montagem em vez de desinstalar a versão antiga e instalar a nova usando o instalador MSI.
  
 {{% alert color="primary" %}}
 
-Nota: Observe que, no último caso, você pode acabar com outros componentes (como a documentação offline) que não foram atualizados para a versão correspondente.
+Nota: Observe que neste último caso você pode acabar com outros componentes (como a documentação offline) não atualizados para a versão correspondente.
 
 {{% /alert %}}

--- a/pt/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
@@ -1,23 +1,23 @@
 ---
-title: Licença
-linktitle: Licença
+title: License
+linktitle: License
 
 type: docs
 weight: 70
-url: /pt/reportingservices/license-aspose-pdf-for-reporting-services/
-description: Entenda as opções de licenciamento para Aspose.PDF for Reporting Services. Descubra como ativar sua licença e desbloquear todas as funcionalidades.
-lastmod: "2026-06-19"
+url: /reportingservices/license-aspose-pdf-for-reporting-services/
+description: Understand licensing options for Aspose.PDF for Reporting Services. Find out how to activate your license and unlock full functionality.
+lastmod: "2021-06-05"
 ---
 
-**Aspose.Pdf for Reporting Services** versão de avaliação fornece o mesmo conjunto de recursos presente na versão Licenciada, exceto pela marca d'água de avaliação no PDF resultante ao usar a versão de avaliação. Por favor, visite nosso site e faça o download da versão do produto e comece a explorar nosso produto com o conjunto completo de recursos em modo de avaliação.
+**Aspose.PDF for Reporting Services** evaluation version provide the same set of features as present in Licensed version, except for the evaluation watermark in resultant PDF when using evaluation version. Please visit our website and download the product version and start exploring our product with complete set of features in an evaluation mode.
 
-Quando estiver satisfeito com sua avaliação, [compre uma licença](https://purchase.aspose.com/buy). Antes de comprar, certifique-se de que entende e concorda com os termos da assinatura da licença.
+When you are happy with your evaluation, [buy a license](https://purchase.aspose.com/buy). Before purchasing, make sure you understand and agree to the license subscription terms.
 
-A licença estará disponível para download na página de pedido após o pagamento do pedido. A licença é um arquivo XML em texto simples, assinado digitalmente. A licença contém informações como o nome do cliente, o produto adquirido e o tipo da licença. Não modifique o conteúdo do arquivo de licença, pois isso invalidará a licença.
+The license will be available for download from the order page after the order is paid. The license is a clear text, digitally signed XML file. The license contains information such as the client's name, the purchased product and the type of the license. Do not modify the content of the license file as it will invalidate the license.
 
-## Licenciando um Servidor
+## Licensing a Server
 
-Baixe o arquivo de licença e copie-o para C:\Program Files\Microsoft SQL Server\```<Instance>``\Reporting Services\ReportServer\bin, or C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin, or C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin folder on the server (the same folder where the Aspose.Pdf.ReportingServices.dll is placed).
+Download the license file and copy it to the C:\Program Files\Microsoft SQL Server\```<Instance>``\Reporting Services\ReportServer\bin, or C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin, or C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin folder on the server (the same folder where the Aspose.Pdf.ReportingServices.dll is placed).
 
 ```<Instance>``` is the subdirectory name that corresponds to the Microsoft SQL Server 2016 instance you want to license.
 
@@ -50,4 +50,3 @@ Please note that that supported license file names are Aspose.PDF.ReportingServi
 You may also request a 30 days temporary license to test the product. Please visit the following link for more information on how to get Temporary license. [Get a Temporary License](https://purchase.aspose.com/temporary-license).
 
 {{% /alert %}}
-

--- a/pt/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
@@ -1,52 +1,50 @@
 ---
-title: License
+title: Licença
 linktitle: License
 
 type: docs
 weight: 70
 url: /reportingservices/license-aspose-pdf-for-reporting-services/
-description: Understand licensing options for Aspose.PDF for Reporting Services. Find out how to activate your license and unlock full functionality.
+description: Entenda as opções de licenciamento do Aspose.PDF para Reporting Services. Descubra como ativar sua licença e desbloquear todas as funcionalidades.
 lastmod: "2021-06-05"
 ---
 
-**Aspose.PDF for Reporting Services** evaluation version provide the same set of features as present in Licensed version, except for the evaluation watermark in resultant PDF when using evaluation version. Please visit our website and download the product version and start exploring our product with complete set of features in an evaluation mode.
+A versão de avaliação **Aspose.PDF for Reporting Services** fornece o mesmo conjunto de recursos presente na versão licenciada, exceto pela marca d'água de avaliação no PDF resultante ao usar a versão de avaliação. Visite nosso site e baixe a versão do produto e comece a explorar nosso produto com um conjunto completo de recursos em modo de avaliação.
 
-When you are happy with your evaluation, [buy a license](https://purchase.aspose.com/buy). Before purchasing, make sure you understand and agree to the license subscription terms.
+Quando você estiver satisfeito com sua avaliação, [buy a license](https://purchase.aspose.com/buy). Antes de comprar, certifique-se de compreender e concordar com os termos de assinatura da licença.
 
-The license will be available for download from the order page after the order is paid. The license is a clear text, digitally signed XML file. The license contains information such as the client's name, the purchased product and the type of the license. Do not modify the content of the license file as it will invalidate the license.
+A licença estará disponível para download na página do pedido após o pagamento do pedido. A licença é um arquivo XML de texto não criptografado e assinado digitalmente. A licença contém informações como o nome do cliente, o produto adquirido e o tipo de licença. Não modifique o conteúdo do arquivo de licença, pois isso invalidará a licença.
 
-## Licensing a Server
+## Licenciamento de um servidor
 
-Download the license file and copy it to the C:\Program Files\Microsoft SQL Server\```<Instance>``\Reporting Services\ReportServer\bin, or C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin, or C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin folder on the server (the same folder where the Aspose.Pdf.ReportingServices.dll is placed).
+Baixe o arquivo de licença e copie-o para a pasta C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\bin ou C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin ou C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin no servidor (a mesma pasta onde está o Aspose.Pdf.ReportingServices.dll é colocado).
 
-```<Instance>``` is the subdirectory name that corresponds to the Microsoft SQL Server 2016 instance you want to license.
+`<Instance>` é o nome do subdiretório que corresponde à instância do Microsoft SQL Server 2016 que você deseja licenciar.
 
-The default instance directory for Microsoft SQL Server 2016 is MSRS13.MSSQLSERVER.
-For the Microsoft SQL Server 2017 and later the default instance path is C:\Program Files\Microsoft SQL Server\SSRS.
-For the Power BI Report Server the default instance path is C:\Program Files\Microsoft Power BI Report Server\PBIRS.
+O diretório de instância padrão do Microsoft SQL Server 2016 é MSRS13.MSSQLSERVER.
+Para o Microsoft SQL Server 2017 e posterior, o caminho da instância padrão é C:\Program Files\Microsoft SQL Server\SSRS.
+Para o Servidor de Relatórios do Power BI, o caminho da instância padrão é C:\Arquivos de Programas\Microsoft Power BI Report Server\PBIRS.
 
-**PDF generated using “Territory sales drilldown” report**
+**PDF gerado usando o relatório "Detalhamento de vendas por território"**
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_1.png)
+![License-Territory sales drilldown](license-aspose-pdf-for-reporting-services_1.png)
 
+**PDF gerado usando o relatório "Detalhes do pedido de vendas"**
 
-**PDF generated using “Sales Order details” report**
+![License-Sales Order details](license-aspose-pdf-for-reporting-services_2.png)
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_2.png)
+Se houver algum problema ao inicializar a licença, uma marca d’água de avaliação será exibida no documento PDF resultante, conforme especificado abaixo.
 
-If there is a problem while initializing the license, an evaluation watermark is displayed in the resultant PDF document as specified below.
+**Documento PDF gerado usando "Detalhamento de Vendas por Território" com marca d'água**
 
-**PDF document generated using “Territory Sales Drilldown” with watermark**
+![License-Territory Sales Drilldown](license-aspose-pdf-for-reporting-services_3.png)
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_3.png)
+Observe que os nomes dos arquivos de licença suportados são Aspose.PDF.ReportingServices.lic, Aspose.Total.ReportingServices.lic e Aspose.Total.Product.Family.lic. Se o arquivo tiver outro nome, renomeie-o.
 
-Please note that that supported license file names are Aspose.PDF.ReportingServices.lic, Aspose.Total.ReportingServices.lic and Aspose.Total.Product.Family.lic. If the file has any other name, please rename it.
-
-
-## Temporary License
+## Licença Temporária
 
 {{% alert color="primary" %}}
 
-You may also request a 30 days temporary license to test the product. Please visit the following link for more information on how to get Temporary license. [Get a Temporary License](https://purchase.aspose.com/temporary-license).
+Você também pode solicitar uma licença temporária de 30 dias para testar o produto. Visite o link a seguir para obter mais informações sobre como obter licença temporária. [Get a Temporary License](https://purchase.aspose.com/temporary-license).
 
 {{% /alert %}}

--- a/pt/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
@@ -11,19 +11,19 @@ lastmod: "2021-06-05"
 
 A versão de avaliação **Aspose.PDF for Reporting Services** fornece o mesmo conjunto de recursos presente na versão licenciada, exceto pela marca d'água de avaliação no PDF resultante ao usar a versão de avaliação. Visite nosso site e baixe a versão do produto e comece a explorar nosso produto com um conjunto completo de recursos em modo de avaliação.
 
-Quando você estiver satisfeito com sua avaliação, [buy a license](https://purchase.aspose.com/buy). Antes de comprar, certifique-se de compreender e concordar com os termos de assinatura da licença.
+Quando estiver satisfeito com sua avaliação, [compre uma licença](https://purchase.aspose.com/buy). Antes de comprar, certifique-se de compreender e concordar com os termos de assinatura da licença.
 
 A licença estará disponível para download na página do pedido após o pagamento do pedido. A licença é um arquivo XML de texto não criptografado e assinado digitalmente. A licença contém informações como o nome do cliente, o produto adquirido e o tipo de licença. Não modifique o conteúdo do arquivo de licença, pois isso invalidará a licença.
 
 ## Licenciamento de um servidor
 
-Baixe o arquivo de licença e copie-o para a pasta C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\bin ou C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin ou C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin no servidor (a mesma pasta onde está o Aspose.Pdf.ReportingServices.dll é colocado).
+Baixe o arquivo de licença e copie-o para a pasta C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\bin ou C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin ou C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin no servidor (a mesma pasta onde o Aspose.Pdf.ReportingServices.dll é colocado).
 
 `<Instance>` é o nome do subdiretório que corresponde à instância do Microsoft SQL Server 2016 que você deseja licenciar.
 
 O diretório de instância padrão do Microsoft SQL Server 2016 é MSRS13.MSSQLSERVER.
 Para o Microsoft SQL Server 2017 e posterior, o caminho da instância padrão é C:\Program Files\Microsoft SQL Server\SSRS.
-Para o Servidor de Relatórios do Power BI, o caminho da instância padrão é C:\Arquivos de Programas\Microsoft Power BI Report Server\PBIRS.
+Para o Servidor de Relatórios do Power BI, o caminho da instância padrão é C:\Program Files\Microsoft Power BI Report Server\PBIRS.
 
 **PDF gerado usando o relatório "Detalhamento de vendas por território"**
 
@@ -45,6 +45,6 @@ Observe que os nomes dos arquivos de licença suportados são Aspose.PDF.Reporti
 
 {{% alert color="primary" %}}
 
-Você também pode solicitar uma licença temporária de 30 dias para testar o produto. Visite o link a seguir para obter mais informações sobre como obter licença temporária. [Get a Temporary License](https://purchase.aspose.com/temporary-license).
+Você também pode solicitar uma licença temporária de 30 dias para testar o produto. Visite o link a seguir para obter mais informações sobre como obter licença temporária. [Obtenha uma licença temporária](https://purchase.aspose.com/temporary-license).
 
 {{% /alert %}}

--- a/pt/reportingservices/product-overview/_index.md
+++ b/pt/reportingservices/product-overview/_index.md
@@ -1,11 +1,11 @@
 ---
 title: Visão geral do produto
-linktitle: Visão geral do produto
+linktitle: Product Overview
 type: docs
 weight: 10
-url: /pt/reportingservices/product-overview/
+url: /reportingservices/product-overview/
 description: Uma visão geral do Aspose.PDF for Reporting Services – uma solução abrangente para renderizar relatórios SSRS em PDF com recursos avançados de layout.
-lastmod: "2026-07-29"
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
@@ -14,17 +14,17 @@ lastmod: "2026-07-29"
 
 {{% /alert %}}
 
-## Bem-vindo ao Aspose.PDF for Reporting Services!
+## Bem-vindo ao Aspose.PDF para Reporting Services!
 
-Microsoft SQL Server Reporting Services atende a uma necessidade que muitas organizações enfrentam - a necessidade de criar soluções de inteligência de negócios e relatórios. Até agora, os desenvolvedores precisavam incorporar relatórios em seus aplicativos, ou as organizações precisavam adquirir soluções de relatório de terceiros caras e, às vezes, problemáticas. Agora, Microsoft SQL Server Reporting Services oferece uma solução completa para distribuir relatórios em toda a empresa; permitindo que os negócios tomem decisões de forma melhor e mais rápida.
+O Microsoft SQL Server Reporting Services atende a uma necessidade que muitas organizações enfrentam: a necessidade de criar soluções de business intelligence e relatórios. Até agora, os desenvolvedores eram obrigados a incorporar relatórios em seus aplicativos ou as organizações eram obrigadas a adquirir soluções de relatórios de terceiros caras e às vezes problemáticas. Agora, o Microsoft SQL Server Reporting Services oferece uma solução completa para distribuição de relatórios em toda a empresa; permitindo que as empresas tomem decisões melhores e mais rápidas.
 
-**Aspose.PDF for Reporting Services** é outra solução única da Aspose, que possibilita a geração de relatórios PDF no Microsoft SQL Server 2016/2017/2019/2022 Reporting Services e no Power BI Report Server. Todos os recursos de relatório RDL, incluindo tabelas, matrizes, gráficos e imagens, são convertidos com o mais alto grau de precisão para PDF.
+**Aspose.PDF for Reporting Services** é outra solução exclusiva da Aspose, que possibilita a geração de relatórios em PDF no Microsoft SQL Server 2016/2017/2019/2022 Reporting Services e no Power BI Report Server. Todos os recursos do relatório RDL, incluindo tabelas, matrizes, gráficos e imagens, são convertidos para PDF com o mais alto grau de precisão.
 
-Microsoft SQL Server Reporting Services possui recursos internos para exportar relatórios como documentos PDF, mas não oferece o suporte técnico necessário ao usuário final. Aspose.Pdf se empenha em fornecer um suporte técnico supremo e eficiente.
+O Microsoft SQL Server Reporting Services possui recursos integrados para exportar relatórios como documentos PDF, mas não fornece o suporte técnico necessário para o usuário final. Aspose.Pdf se esforça para fornecer um suporte técnico supremo e eficiente.
 
-Aspose.PDF for Reporting Services cria documentos no servidor sem utilizar o Adobe.Pdf SDK. Aspose.PDF for Reporting Services usa internamente o Aspose.PDF for .NET – o componente de classe mundial para processamento e conversões de documentos no lado do servidor.
+Aspose.PDF para Reporting Services cria documentos no servidor sem utilizar Adobe.Pdf SDK. O Aspose.PDF for Reporting Services usa internamente o Aspose.PDF for .NET – o componente de classe mundial para processamento e conversões de documentos no servidor.
 
-## Aspose.PDF for Reporting Services torna possível exportar qualquer relatório em formato PDF
+## Aspose.PDF for Reporting Services permite exportar qualquer relatório em formato PDF
 
-![todo:image_alt_text](product-overview_2.png)
+![Product Overview](product-overview_2.png)
 

--- a/pt/reportingservices/product-overview/_index.md
+++ b/pt/reportingservices/product-overview/_index.md
@@ -5,7 +5,7 @@ type: docs
 weight: 10
 url: /pt/reportingservices/product-overview/
 description: Uma visão geral do Aspose.PDF for Reporting Services – uma solução abrangente para renderizar relatórios SSRS em PDF com recursos avançados de layout.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
@@ -16,16 +16,15 @@ lastmod: "2026-06-19"
 
 ## Bem-vindo ao Aspose.PDF for Reporting Services!
 
-Microsoft SQL Server Reporting Services atende a uma necessidade que muitas organizações enfrentam - a necessidade de construir soluções de inteligência de negócios e de relatórios. Até agora, os desenvolvedores precisavam incorporar relatórios em suas aplicações, ou as organizações precisavam adquirir soluções de relatórios de terceiros caras e às vezes problemáticas. Agora, Microsoft SQL Server Reporting Services oferece uma solução completa para distribuir relatórios em toda a empresa; permitindo que os negócios tomem decisões melhor e mais rapidamente.
+Microsoft SQL Server Reporting Services atende a uma necessidade que muitas organizações enfrentam - a necessidade de criar soluções de inteligência de negócios e relatórios. Até agora, os desenvolvedores precisavam incorporar relatórios em seus aplicativos, ou as organizações precisavam adquirir soluções de relatório de terceiros caras e, às vezes, problemáticas. Agora, Microsoft SQL Server Reporting Services oferece uma solução completa para distribuir relatórios em toda a empresa; permitindo que os negócios tomem decisões de forma melhor e mais rápida.
 
-**Aspose.Pdf for Reporting Services** é outra solução única da Aspose, que torna possível a geração de relatórios PDF no Microsoft SQL Server 2016/2017/2019/2022 Reporting Services e no Power BI Report Server. Todos os recursos de relatório RDL, incluindo tabelas, matrizes, gráficos e imagens, são convertidos com o mais alto grau de precisão para PDF.
+**Aspose.PDF for Reporting Services** é outra solução única da Aspose, que possibilita a geração de relatórios PDF no Microsoft SQL Server 2016/2017/2019/2022 Reporting Services e no Power BI Report Server. Todos os recursos de relatório RDL, incluindo tabelas, matrizes, gráficos e imagens, são convertidos com o mais alto grau de precisão para PDF.
 
-Microsoft SQL Server Reporting Services tem habilidades integradas para exportar relatórios como documentos PDF, mas carece de oferecer o suporte técnico necessário para o usuário final. Aspose.Pdf se esforça para fornecer um suporte técnico supremo e eficiente.
+Microsoft SQL Server Reporting Services possui recursos internos para exportar relatórios como documentos PDF, mas não oferece o suporte técnico necessário ao usuário final. Aspose.Pdf se empenha em fornecer um suporte técnico supremo e eficiente.
 
-Aspose.Pdf for Reporting Services cria documentos no servidor sem utilizar o Adobe.Pdf SDK. Aspose.Pdf for Reporting Services usa internamente o Aspose.Pdf for .NET – o componente de classe mundial para processamento e conversões de documentos no lado do servidor.
+Aspose.PDF for Reporting Services cria documentos no servidor sem utilizar o Adobe.Pdf SDK. Aspose.PDF for Reporting Services usa internamente o Aspose.PDF for .NET – o componente de classe mundial para processamento e conversões de documentos no lado do servidor.
 
-## Aspose.PDF for Reporting Services torna possível exportar qualquer relatório no formato PDF
+## Aspose.PDF for Reporting Services torna possível exportar qualquer relatório em formato PDF
 
 ![todo:image_alt_text](product-overview_2.png)
-
 

--- a/pt/reportingservices/sample-reports-gallery/_index.md
+++ b/pt/reportingservices/sample-reports-gallery/_index.md
@@ -1,37 +1,37 @@
 ---
-title: Galeria de Relatórios de Exemplo
-linktitle: Galeria de Relatórios de Exemplo
+title: Galeria de exemplos de relatórios
+linktitle: Sample Reports Gallery
 type: docs
 weight: 40
-url: /pt/reportingservices/sample-reports-gallery/
-description: Explore relatórios de exemplo gerados usando Aspose.PDF for Reporting Services. Veja como seus relatórios SSRS podem se transformar em saídas PDF refinadas.
-lastmod: "2026-07-29"
+url: /reportingservices/sample-reports-gallery/
+description: Explore exemplos de relatórios gerados usando Aspose.PDF para Reporting Services. Veja como seus relatórios SSRS podem se transformar em saídas de PDF sofisticadas.
+lastmod: "2024-05-05"
 ---
 
 {{% alert color="primary" %}}
 
-Esta galeria demonstra relatórios PDF exportados pelo Aspose.PDF for Reporting Services.
+Esta galeria demonstra relatórios em PDF exportados por Aspose.PDF para Reporting Services.
 
 {{% /alert %}}
 
-A maioria dos relatórios mostrados aqui vem do banco de dados Adventure Works. Adventure Works é um banco de dados de exemplo para o Microsoft SQL Server, disponível para download da Microsoft. [aqui](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
+A maioria dos relatórios mostrados aqui vem do banco de dados Adventure Works. Adventure Works é um banco de dados de exemplo para Microsoft SQL Server, disponível para download na Microsoft [aqui](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
 
-## Vendas da Empresa
+## Vendas da empresa
 
-![Vendas da Empresa  relatório em PDF](sample-reports-gallery_1.png)
+![Relatório de vendas da empresa em PDF](sample-reports-gallery_1.png)
 
-## Resumo de Vendas de Empregado
+## Resumo de vendas de funcionários
 
-![Resumo de Vendas de Empregado relatório em PDF](sample-reports-gallery_2.png)
+![Relatório de resumo de vendas de funcionários em PDF](sample-reports-gallery_2.png)
 
 ## Catálogo de Produtos
 
-![Relatório de Catálogo de Produtos em PDF](sample-reports-gallery_3.png)
+![Relatório de catálogo de produtos em PDF](sample-reports-gallery_3.png)
 
-## Vendas da Linha de Produtos
+## Vendas de linha de produtos
 
-![Relatório de Vendas da Linha de Produtos em PDF](sample-reports-gallery_4.png)
+![Relatório de vendas da linha de produtos em PDF](sample-reports-gallery_4.png)
 
-## Detalhe do Pedido de Venda
+## Detalhe do pedido de vendas
 
-![Relatório de Detalhe do Pedido de Venda em PDF](sample-reports-gallery_5.png)
+![Relatório de detalhes do pedido de vendas em PDF](sample-reports-gallery_5.png)

--- a/pt/reportingservices/sample-reports-gallery/_index.md
+++ b/pt/reportingservices/sample-reports-gallery/_index.md
@@ -5,34 +5,33 @@ type: docs
 weight: 40
 url: /pt/reportingservices/sample-reports-gallery/
 description: Explore relatórios de exemplo gerados usando Aspose.PDF for Reporting Services. Veja como seus relatórios SSRS podem se transformar em saídas PDF refinadas.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Esta galeria demonstra relatórios PDF exportados pelo Aspose.Pdf for Reporting Services.
+Esta galeria demonstra relatórios PDF exportados pelo Aspose.PDF for Reporting Services.
 
 {{% /alert %}}
 
-A maioria dos relatórios mostrados aqui vem do banco de dados Adventure Works. Adventure Works é um banco de dados de exemplo para o Microsoft SQL Server, disponível para download da Microsoft [aqui](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
+A maioria dos relatórios mostrados aqui vem do banco de dados Adventure Works. Adventure Works é um banco de dados de exemplo para o Microsoft SQL Server, disponível para download da Microsoft. [aqui](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
 
 ## Vendas da Empresa
 
 ![Vendas da Empresa  relatório em PDF](sample-reports-gallery_1.png)
 
-## Resumo de Vendas do Empregado
+## Resumo de Vendas de Empregado
 
-![Relatório de Resumo de Vendas do Empregado em PDF](sample-reports-gallery_2.png)
+![Resumo de Vendas de Empregado relatório em PDF](sample-reports-gallery_2.png)
 
 ## Catálogo de Produtos
 
 ![Relatório de Catálogo de Produtos em PDF](sample-reports-gallery_3.png)
 
-## Vendas da Linha de Produto
+## Vendas da Linha de Produtos
 
-![Relatório de Vendas da Linha de Produto em PDF](sample-reports-gallery_4.png)
+![Relatório de Vendas da Linha de Produtos em PDF](sample-reports-gallery_4.png)
 
 ## Detalhe do Pedido de Venda
 
 ![Relatório de Detalhe do Pedido de Venda em PDF](sample-reports-gallery_5.png)
-

--- a/pt/reportingservices/supported-file-formats/_index.md
+++ b/pt/reportingservices/supported-file-formats/_index.md
@@ -1,29 +1,29 @@
 ---
-title: Formatos de Arquivo Compatíveis
-linktitle: Formatos de Arquivo Compatíveis
+title: Formatos de arquivo suportados
+linktitle: Supported File Formats
 type: docs
 weight: 20
-url: /pt/reportingservices/supported-file-formats/
-description: Confira os formatos de arquivo compatíveis do Aspose.PDF for Reporting Services. Converta seus relatórios SSRS para PDF, DOC, XLS e muito mais com facilidade.
-lastmod: "2026-07-29"
+url: /reportingservices/supported-file-formats/
+description: Confira os formatos de arquivo suportados pelo Aspose.PDF para Reporting Services. Renderize seus relatórios SSRS em PDF, DOC, XLS e muito mais com facilidade.
+lastmod: "2021-06-05"
 ---
 
-## Formatos de Carregamento Compatíveis
+## Formatos de carregamento suportados
 
-A tabela a seguir indica os formatos de arquivo que o Aspose.PDF for Reporting Services pode carregar.
+A tabela a seguir indica os formatos de arquivo que Aspose.PDF para Reporting Services pode carregar.
 
-|**Formato**|**Descrição**|
+|**Formatar**|**Descrição**|
 | :- | :- |
-|RDL|Linguagem de Definição de Relatório|
-|[HTML](https://docs.fileformat.com/web/html/)|Linguagem de Marcação de Hipertexto|
+|RDL|Linguagem de definição de relatório|
+|[HTML](https://docs.fileformat.com/web/html/)|Linguagem de marcação de hipertexto|
 
-## Formatos de Salvamento Suportados
+## Formatos de salvamento suportados
 
-A tabela a seguir indica os formatos de arquivo nos quais o documento pode ser salvo ao usar o Aspose.PDF for Reporting Services. 
+A tabela a seguir indica os formatos de arquivo nos quais o documento pode ser salvo usando Aspose.PDF para Reporting Services. 
 
-|**Formato**|**Descrição**|
+|**Formatar**|**Descrição**|
 | :- | :- |
-|[PDF](https://docs.fileformat.com/pdf/)|Salva o documento no formato PDF|
+|[PDF](https://docs.fileformat.com/pdf/)|Salva o documento em formato PDF|
 |PDF/A |Salva o documento no formato PDF/A|
 |[XPS](https://docs.fileformat.com/page-description-language/xps/)|Salva o documento no formato XML Paper Specification|
-|EPUB|Salva o documento no formato de arquivo E-Book|
+|EPUB|Salva o documento em formato de arquivo de e-book|

--- a/pt/reportingservices/supported-file-formats/_index.md
+++ b/pt/reportingservices/supported-file-formats/_index.md
@@ -4,8 +4,8 @@ linktitle: Formatos de Arquivo Compatíveis
 type: docs
 weight: 20
 url: /pt/reportingservices/supported-file-formats/
-description: Confira os formatos de arquivo compatíveis do Aspose.PDF for Reporting Services. Renderize seus relatórios SSRS para PDF, DOC, XLS e muito mais com facilidade.
-lastmod: "2026-06-19"
+description: Confira os formatos de arquivo compatíveis do Aspose.PDF for Reporting Services. Converta seus relatórios SSRS para PDF, DOC, XLS e muito mais com facilidade.
+lastmod: "2026-07-29"
 ---
 
 ## Formatos de Carregamento Compatíveis
@@ -17,14 +17,13 @@ A tabela a seguir indica os formatos de arquivo que o Aspose.PDF for Reporting S
 |RDL|Linguagem de Definição de Relatório|
 |[HTML](https://docs.fileformat.com/web/html/)|Linguagem de Marcação de Hipertexto|
 
-## Formatos de Salvar Compatíveis
+## Formatos de Salvamento Suportados
 
-A tabela a seguir indica os formatos de arquivo nos quais o documento pode ser salvo usando o Aspose.PDF for Reporting Services. 
+A tabela a seguir indica os formatos de arquivo nos quais o documento pode ser salvo ao usar o Aspose.PDF for Reporting Services. 
 
 |**Formato**|**Descrição**|
 | :- | :- |
 |[PDF](https://docs.fileformat.com/pdf/)|Salva o documento no formato PDF|
 |PDF/A |Salva o documento no formato PDF/A|
 |[XPS](https://docs.fileformat.com/page-description-language/xps/)|Salva o documento no formato XML Paper Specification|
-|EPUB|Salva o documento no formato de arquivo de e‑book|
-
+|EPUB|Salva o documento no formato de arquivo E-Book|

--- a/pt/reportingservices/technical-articles/_index.md
+++ b/pt/reportingservices/technical-articles/_index.md
@@ -5,10 +5,9 @@ type: docs
 weight: 120
 url: /pt/reportingservices/technical-articles/
 description: Explore artigos técnicos para Aspose.PDF for Reporting Services. Obtenha insights aprofundados e dicas práticas para renderização eficaz de PDF.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
-- [Migração do SQL Reporting Services para Aspose.Pdf for Reporting Services](/pdf/pt/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
+- [Migração do SQL Reporting Services para Aspose.PDF for Reporting Services](/pdf/pt/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
 - [Integração do SQL Reporting Services com MS SharePoint](/pdf/pt/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/)
-

--- a/pt/reportingservices/technical-articles/_index.md
+++ b/pt/reportingservices/technical-articles/_index.md
@@ -1,13 +1,14 @@
 ---
 title: Artigos Técnicos
-linktitle: Artigos Técnicos
+linktitle: Technical Articles
 type: docs
 weight: 120
-url: /pt/reportingservices/technical-articles/
-description: Explore artigos técnicos para Aspose.PDF for Reporting Services. Obtenha insights aprofundados e dicas práticas para renderização eficaz de PDF.
-lastmod: "2026-07-29"
+url: /reportingservices/technical-articles/
+description: Explore artigos técnicos do Aspose.PDF para Reporting Services. Obtenha insights detalhados e dicas práticas para uma renderização eficaz de PDF.
+lastmod: "2021-06-05"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
-- [Migração do SQL Reporting Services para Aspose.PDF for Reporting Services](/pdf/pt/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
+
+- [Migração do SQL Reporting Services para Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
 - [Integração do SQL Reporting Services com MS SharePoint](/pdf/pt/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/)

--- a/pt/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
@@ -1,14 +1,13 @@
 ---
-title: Migração do SQL Reporting Services para Aspose.Pdf for Reporting Services
-linktitle: Migração do SQL Reporting Services para Aspose.Pdf for Reporting Services
+title: Migração do SQL Reporting Services para Aspose.PDF for Reporting Services
+linktitle: Migração do SQL Reporting Services para Aspose.PDF for Reporting Services
 type: docs
 weight: 10
 url: /pt/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/
-description: Saiba como migrar do SQL Reporting Services para Aspose.PDF for Reporting Services. Atualize seu processo de geração de PDF.
-lastmod: "2026-06-19"
+description: Aprenda como migrar do SQL Reporting Services para Aspose.PDF for Reporting Services. Atualize seu processo de geração de PDF.
+lastmod: "2026-07-29"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
 - [Por que escolher Aspose.PDF for Reporting Services](/pdf/pt/reportingservices/why-choose-aspose-pdf-for-reporting-services/)
-

--- a/pt/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
@@ -1,13 +1,13 @@
 ---
-title: Migração do SQL Reporting Services para Aspose.PDF for Reporting Services
-linktitle: Migração do SQL Reporting Services para Aspose.PDF for Reporting Services
+title: Migração do SQL Reporting Services para Aspose.PDF para Reporting Services
+linktitle: Migration from SQL Reporting Services to Aspose.PDF for Reporting Services
 type: docs
 weight: 10
-url: /pt/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/
-description: Aprenda como migrar do SQL Reporting Services para Aspose.PDF for Reporting Services. Atualize seu processo de geração de PDF.
-lastmod: "2026-07-29"
+url: /reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/
+description: Saiba como migrar do SQL Reporting Services para Aspose.PDF for Reporting Services. Atualize seu processo de geração de PDF.
+lastmod: "2024-05-05"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
-- [Por que escolher Aspose.PDF for Reporting Services](/pdf/pt/reportingservices/why-choose-aspose-pdf-for-reporting-services/)
+- [Por que escolher Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/why-choose-aspose-pdf-for-reporting-services/)

--- a/pt/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
@@ -1,36 +1,36 @@
 ---
-title: Por que escolher Aspose.Pdf para Reporting Services
-linktitle: Por que escolher Aspose.Pdf para Reporting Services
+title: Por que escolher Aspose.PDF for Reporting Services
+linktitle: Por que escolher Aspose.PDF for Reporting Services
 type: docs
 weight: 10
 url: /pt/reportingservices/why-choose-aspose-pdf-for-reporting-services/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-**Aspose.Pdf for Reporting Services** é uma solução .NET robusta que permite produzir relatórios PDF usando o Microsoft SQL Server 2016, 2017, 2019 e 2022 Reporting Services, e o Microsoft Power BI Report Server. Aspose.Pdf for Reporting Services não opera de forma independente, mas é uma extensão de renderização para o SQL Reporting Services. Não só suporta os elementos básicos de relatório, como tabelas, gráficos, imagens, Cabeçalhos/Rodapés, linhas etc., como também fornece a capacidade de adicionar propriedades personalizadas que lhe dão uma alavancagem extra sobre o SQL Reporting Services. Ao usar essas propriedades, você pode gerar Lista de Conteúdos, que não é suportada pelo Report Designer. Você pode ter Notas de Rodapé/Notas de Fim no documento PDF resultante, que nativamente não são suportadas pelo Report Builder. Outra funcionalidade interessante é ter Setas de Linha, que também não são suportadas pelo SQL Reporting Services, mas Aspose.Pdf for Reporting Services pode fornecer a capacidade de adicionar setas no início ou no final do elemento de linha. Além disso, Aspose.Pdf for Reporting Services fornece a funcionalidade de especificar o alinhamento de texto (Justify ou FullJustify) que não é suportado pelo Report Designer. Esses modos de texto tornam o documento resultante melhor formatado e de fácil leitura.
+**Aspose.PDF for Reporting Services** é uma solução .NET robusta que permite produzir relatórios PDF usando o Microsoft SQL Server 2016, 2017, 2019 e 2022 Reporting Services, e o Microsoft Power BI Report Server. Aspose.PDF for Reporting Services não opera de forma independente, mas é uma extensão de renderização para o SQL Reporting Services. Não apenas suporta os elementos básicos de relatório, como tabelas, gráficos, imagens, Headers/Footers, linhas etc., mas também oferece a capacidade de adicionar propriedades personalizadas que lhe conferem uma vantagem extra sobre o SQL Reporting Services. Ao usar essas propriedades, você pode gerar List of Contents, que não é suportada pelo Report Designer. Você pode ter Footnotes/Endnotes no documento PDF resultante, que não são suportadas nativamente pelo Report Builder. Outro recurso interessante é ter Line Arrows, que também não são suportadas pelo SQL Reporting Services, mas Aspose.PDF for Reporting Services pode fornecer a capacidade de adicionar setas no início ou no final do elemento de linha. Além disso, Aspose.PDF for Reporting Services fornece a funcionalidade de especificar o alinhamento de texto (Justify ou FullJustify), informação que não é suportada pelo Report Designer. Esses modos de texto tornam o documento resultante melhor formatado e de fácil leitura.
 
-Juntamente com os recursos mencionados anteriormente, você também pode definir alguns outros parâmetros de configuração para os relatórios, para obter recursos que não são nativamente suportados pelo SQL Reporting Services. A seguir, uma breve descrição desses recursos oferecidos pelo Aspose.Pdf for Reporting Services
+Além dos recursos mencionados anteriormente, você também pode definir alguns outros parâmetros de configuração para os relatórios, a fim de obter recursos que não são suportados nativamente pelo SQL Reporting Services. A seguir, uma breve descrição desses recursos oferecidos pelo Aspose.PDF for Reporting Services
 
-## Configurações de Segurança
+## Configurações de segurança
 
-Às vezes você pode desejar exportar um documento PDF protegido com uma senha, com privilégios limitados de cópia de texto e impressão. Infelizmente, o Reporting Services não oferece suporte a essa possibilidade. No entanto, você ainda pode implementá-la usando o Aspose.Pdf for Reporting Services. Basta adicionar os parâmetros de segurança correspondentes ao relatório ou ao servidor de relatórios para obter um documento PDF seguro com privilégios limitados. Para mais informações, consulte a seção 'Security Setting'.
+Às vezes você pode desejar exportar um documento PDF protegido com uma senha, com privilégios limitados de cópia de texto e impressão. Infelizmente, o Reporting Services não oferece suporte a essa possibilidade. No entanto, você ainda pode implementá-la usando o Aspose.PDF for Reporting Services. Basta adicionar os parâmetros de segurança correspondentes ao relatório ou ao servidor de relatórios para obter um documento PDF seguro com privilégios limitados. Para obter mais informações, consulte a seção \u0027Security Setting\u0027.
 
-## Incorporação de Fonte Personalizada
+## Incorporação de fonte personalizada
 
-O designer do Reporting Services não suporta a incorporação de fonte para texto; com o Aspose.Pdf for Reporting Services você pode facilmente incorporar informações de fonte ao seu documento PDF. Para mais informações, consulte a seção 'IsFontEmbedded'.
+O designer do Reporting Services não oferece suporte à incorporação de fontes para texto; com o Aspose.PDF for Reporting Services, você pode facilmente incorporar informações de fonte ao seu documento PDF. Para obter mais informações, consulte a seção \u0027IsFontEmbedded\u0027.
 
 ## Metadados XMP
 
-O designer do Reporting Services não suporta a incorporação dos metadados XMP. Aspose.Pdf for Reporting Services fornece quatro parâmetros (CreationDate, ModifyDate, MetaDataDate e CreatorTool) para definir os metadados XMP correspondentes. Para mais informações, consulte a seção 'XMP Metadata'.
+O designer do Reporting Services não oferece suporte à incorporação dos metadados XMP. Aspose.PDF for Reporting Services fornece quatro parâmetros (CreationDate, ModifyDate, MetaDataDate e CreatorTool) para definir os correspondentes Metadados XMP. Para obter mais informações, consulte a seção 'XMP Metadata'.
 
 ## PDF/A
 
-Ao usar o SQL Server Reporting Services, você pode gerar o documento PDF apenas em formato simples, enquanto a geração de documentos PDF/A não é suportada. Mas o Aspose.Pdf for Reporting Services oferece o recurso de criar documentos compatíveis com PDF/A com a adição de um único parâmetro de configuração. Para mais informações, consulte a seção 'PDF Conformance'.
+Ao usar o SQL Server Reporting Services, você só pode gerar o documento PDF em formato simples, enquanto a criação de documentos PDF/A não é suportada. Mas Aspose.PDF for Reporting Services fornece o recurso de criar documentos compatíveis com PDF/A com a adição de um único parâmetro de configuração. Para obter mais informações, consulte a seção 'PDF Conformance'.
 
 ## Ângulo de Rotação da Página
 
-Ao usar o Aspose.Pdf for Reporting Services, você pode definir o número de graus pelos quais a página deve ser girada no sentido horário ao ser exibida ou impressa. Para mais informações, consulte a seção 'Page Rotating Angle'.
+Ao usar o Aspose.PDF for Reporting Services, você pode definir o número de graus pelos quais a página deve ser girada no sentido horário quando exibida ou impressa. Para obter mais informações, consulte a seção 'Page Rotating Angle'.
 
 ## Tamanho da Margem da Página
 
-O designer do Reporting Services não suporta a definição do tamanho das margens da página. O Aspose.Pdf for Reporting Services, por outro lado, fornece quatro parâmetros para definir o tamanho correspondente da margem da página. Eles são PageMarginLeft, PageMarginRight, PageMarginTop e PageMarginBottom. Para mais informações, consulte a seção 'Page Margin Size'.
+O designer do Reporting Services não oferece suporte à definição do tamanho das margens da página. O Aspose.PDF for Reporting Services, por outro lado, fornece quatro parâmetros para definir o tamanho correspondente da margem da página. Eles são PageMarginLeft, PageMarginRight, PageMarginTop e PageMarginBottom. Para mais informações, consulte a seção ‘Page Margin Size’.

--- a/pt/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
@@ -1,36 +1,36 @@
 ---
-title: Por que escolher Aspose.PDF for Reporting Services
-linktitle: Por que escolher Aspose.PDF for Reporting Services
+title: Por que escolher Aspose.PDF para Reporting Services
+linktitle: Why choose Aspose.PDF for Reporting Services
 type: docs
 weight: 10
-url: /pt/reportingservices/why-choose-aspose-pdf-for-reporting-services/
-lastmod: "2026-07-29"
+url: /reportingservices/why-choose-aspose-pdf-for-reporting-services/
+lastmod: "2021-06-05"
 ---
 
-**Aspose.PDF for Reporting Services** é uma solução .NET robusta que permite produzir relatórios PDF usando o Microsoft SQL Server 2016, 2017, 2019 e 2022 Reporting Services, e o Microsoft Power BI Report Server. Aspose.PDF for Reporting Services não opera de forma independente, mas é uma extensão de renderização para o SQL Reporting Services. Não apenas suporta os elementos básicos de relatório, como tabelas, gráficos, imagens, Headers/Footers, linhas etc., mas também oferece a capacidade de adicionar propriedades personalizadas que lhe conferem uma vantagem extra sobre o SQL Reporting Services. Ao usar essas propriedades, você pode gerar List of Contents, que não é suportada pelo Report Designer. Você pode ter Footnotes/Endnotes no documento PDF resultante, que não são suportadas nativamente pelo Report Builder. Outro recurso interessante é ter Line Arrows, que também não são suportadas pelo SQL Reporting Services, mas Aspose.PDF for Reporting Services pode fornecer a capacidade de adicionar setas no início ou no final do elemento de linha. Além disso, Aspose.PDF for Reporting Services fornece a funcionalidade de especificar o alinhamento de texto (Justify ou FullJustify), informação que não é suportada pelo Report Designer. Esses modos de texto tornam o documento resultante melhor formatado e de fácil leitura.
+**Aspose.PDF for Reporting Services** é uma solução .NET robusta que permite produzir relatórios em PDF usando o Microsoft SQL Server 2016, 2017, 2019 e 2022 Reporting Services e o Microsoft Power BI Report Server. Aspose.PDF for Reporting Services não opera de forma independente, mas é uma extensão de renderização para o SQL Reporting Services. Ele não apenas oferece suporte aos elementos básicos do relatório, como tabelas, gráficos, imagens, cabeçalhos/rodapés, linhas, etc., mas também fornece a capacidade de adicionar propriedades personalizadas, o que proporciona uma vantagem extra no SQL Reporting Services. Ao usar essas propriedades, você pode gerar uma Lista de Conteúdo que não é suportada pelo Designer de Relatórios. Você pode ter notas de rodapé/notas finais no documento PDF resultante que não são nativamente suportadas pelo Report Builder. Outro recurso interessante é ter setas de linha, que também não são suportadas pelo SQL Reporting Services, mas o Aspose.PDF para Reporting Services pode fornecer a capacidade de adicionar setas no início ou no final do elemento de linha. Além disso, Aspose.PDF para Reporting Services fornece a funcionalidade para especificar as informações de alinhamento de texto (Justify ou FullJustify) que não são suportadas pelo Report Designer. Esses modos de texto tornam o documento resultante melhor formatado e de fácil leitura.
 
-Além dos recursos mencionados anteriormente, você também pode definir alguns outros parâmetros de configuração para os relatórios, a fim de obter recursos que não são suportados nativamente pelo SQL Reporting Services. A seguir, uma breve descrição desses recursos oferecidos pelo Aspose.PDF for Reporting Services
+Juntamente com os recursos mencionados anteriormente, você também pode definir outros parâmetros de configuração para os relatórios, para obter recursos que não são suportados nativamente pelo SQL Reporting Services. A seguir está um breve resumo desses recursos oferecidos pelo Aspose.PDF para Reporting Services
 
 ## Configurações de segurança
 
-Às vezes você pode desejar exportar um documento PDF protegido com uma senha, com privilégios limitados de cópia de texto e impressão. Infelizmente, o Reporting Services não oferece suporte a essa possibilidade. No entanto, você ainda pode implementá-la usando o Aspose.PDF for Reporting Services. Basta adicionar os parâmetros de segurança correspondentes ao relatório ou ao servidor de relatórios para obter um documento PDF seguro com privilégios limitados. Para obter mais informações, consulte a seção \u0027Security Setting\u0027.
+Às vezes você pode querer exportar documentos PDF protegidos por senha, com privilégios limitados de cópia e impressão de texto. Infelizmente, o Reporting Services não oferece suporte a essa possibilidade. No entanto, você ainda pode implementá-lo usando Aspose.PDF para Reporting Services. Basta adicionar parâmetros de segurança correspondentes ao relatório ou servidor de relatório para obter um documento PDF seguro com privilégios limitados. Para obter mais informações, consulte a seção 'Configuração de segurança'.
 
 ## Incorporação de fonte personalizada
 
-O designer do Reporting Services não oferece suporte à incorporação de fontes para texto; com o Aspose.PDF for Reporting Services, você pode facilmente incorporar informações de fonte ao seu documento PDF. Para obter mais informações, consulte a seção \u0027IsFontEmbedded\u0027.
+O designer do Reporting Services não dá suporte à fonte incorporada para texto; com Aspose.PDF for Reporting Services você pode incorporar facilmente informações de fonte em seu documento PDF. Para obter mais informações, consulte a seção 'IsFontEmbedded'.
 
 ## Metadados XMP
 
-O designer do Reporting Services não oferece suporte à incorporação dos metadados XMP. Aspose.PDF for Reporting Services fornece quatro parâmetros (CreationDate, ModifyDate, MetaDataDate e CreatorTool) para definir os correspondentes Metadados XMP. Para obter mais informações, consulte a seção 'XMP Metadata'.
+O designer do Reporting Services não oferece suporte à incorporação de metadados XMP. Aspose.PDF para Reporting Services fornece quatro parâmetros (CreationDate, ModifyDate, MetaDataDate e CreatorTool) para definir os metadados XMP correspondentes. Para obter mais informações, consulte a seção 'Metadados XMP'.
 
 ## PDF/A
 
-Ao usar o SQL Server Reporting Services, você só pode gerar o documento PDF em formato simples, enquanto a criação de documentos PDF/A não é suportada. Mas Aspose.PDF for Reporting Services fornece o recurso de criar documentos compatíveis com PDF/A com a adição de um único parâmetro de configuração. Para obter mais informações, consulte a seção 'PDF Conformance'.
+Ao usar o SQL Server Reporting Services, você só pode gerar o documento PDF em formato simples, enquanto a geração de documentos PDF/A não é suportada. Mas Aspose.PDF for Reporting Services fornece o recurso para criar documentos compatíveis com PDF/A com a adição de um único parâmetro de configuração. Para obter mais informações, consulte a seção 'Conformidade com PDF'.
 
-## Ângulo de Rotação da Página
+## Ângulo de rotação da página
 
-Ao usar o Aspose.PDF for Reporting Services, você pode definir o número de graus pelos quais a página deve ser girada no sentido horário quando exibida ou impressa. Para obter mais informações, consulte a seção 'Page Rotating Angle'.
+Ao usar Aspose.PDF para Reporting Services, você pode definir o número de graus em que a página deve ser girada no sentido horário quando exibida ou impressa. Para obter mais informações, consulte a seção 'Ângulo de rotação da página'.
 
-## Tamanho da Margem da Página
+## Tamanho da margem da página
 
-O designer do Reporting Services não oferece suporte à definição do tamanho das margens da página. O Aspose.PDF for Reporting Services, por outro lado, fornece quatro parâmetros para definir o tamanho correspondente da margem da página. Eles são PageMarginLeft, PageMarginRight, PageMarginTop e PageMarginBottom. Para mais informações, consulte a seção ‘Page Margin Size’.
+O designer do Reporting Services não dá suporte à configuração do tamanho das margens da página. Aspose.PDF for Reporting Services, por outro lado, fornece quatro parâmetros para definir o tamanho da margem da página correspondente. Eles são PageMarginLeft, PageMarginRight, PageMarginTop e PageMarginBottom. Para obter mais informações, consulte a seção 'Tamanho da margem da página'.

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
@@ -4,7 +4,7 @@ linktitle: Integração do SQL Reporting Services com MS SharePoint
 type: docs
 weight: 20
 url: /pt/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
@@ -13,4 +13,3 @@ lastmod: "2026-06-19"
 - [Configurando o Reporting Services](/pdf/pt/reportingservices/setting-up-reporting-services/)
 - [Configurando o SharePoint no servidor Reporting Services](/pdf/pt/reportingservices/setting-up-sharepoint-on-reporting-services-server/)
 - [Configuração do Reporting Services e SharePoint](/pdf/pt/reportingservices/reporting-services-and-sharepoint-configuration/)
-

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
@@ -1,15 +1,15 @@
 ---
 title: Integração do SQL Reporting Services com MS SharePoint
-linktitle: Integração do SQL Reporting Services com MS SharePoint
+linktitle: SQL Reporting Services Integration with MS SharePoint
 type: docs
 weight: 20
-url: /pt/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/
-lastmod: "2026-07-29"
+url: /reportingservices/sql-reporting-services-integration-with-ms-sharepoint/
+lastmod: "2021-06-05"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
 - [Introdução](/pdf/pt/reportingservices/introduction/)
 - [Configurando o Reporting Services](/pdf/pt/reportingservices/setting-up-reporting-services/)
-- [Configurando o SharePoint no servidor Reporting Services](/pdf/pt/reportingservices/setting-up-sharepoint-on-reporting-services-server/)
-- [Configuração do Reporting Services e SharePoint](/pdf/pt/reportingservices/reporting-services-and-sharepoint-configuration/)
+- [Configurando o SharePoint no Reporting Services Server](/pdf/pt/reportingservices/setting-up-sharepoint-on-reporting-services-server/)
+- [Configuração do Reporting Services e do SharePoint](/pdf/pt/reportingservices/reporting-services-and-sharepoint-configuration/)

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
@@ -1,15 +1,15 @@
 ---
 title: Introdução
-linktitle: Introdução
+linktitle: Introduction
 type: docs
 weight: 10
-url: /pt/reportingservices/introduction/
-lastmod: "2026-07-29"
+url: /reportingservices/introduction/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF for Reporting Services tem sido muito notável para a geração de PDF através do SQL Reporting Services há muitos anos e oferece diversas opções de configuração e parametrização que não são suportadas por padrão no SQL Reporting Services. Recentemente, recebemos algumas solicitações relacionadas à Integração do Aspose.PDF for Reporting Services com o SharePoint. Para este artigo, vamos nos concentrar no MS SharePoint 2010. Antes de prosseguir, assumimos que você já possui uma farm do SharePoint configurada. Neste exemplo, utilizaremos o SharePoint Cloud completo. No entanto, os passos são semelhantes para o SharePoint Foundation Server.
+Aspose.PDF para Reporting Services tem sido notável na geração de PDF por meio do SQL Reporting Services há muitos anos e fornece diversas opções de configuração e parametrização que não são suportadas por padrão no SQL Reporting Services. Recentemente, recebemos algumas solicitações relacionadas ao Aspose.PDF para integração do Reporting Services com o SharePoint. Neste artigo, vamos nos concentrar no MS SharePoint 2010. Antes de prosseguirmos, presumimos que você já tenha uma configuração do Farm do SharePoint. Neste exemplo, usaremos o SharePoint Cloud completo. No entanto, as etapas são semelhantes para o SharePoint Foundation Server.
 
 {{% /alert %}}
 
@@ -17,37 +17,37 @@ Aspose.PDF for Reporting Services tem sido muito notável para a geração de PD
 
 Antes de prosseguirmos, vamos dar uma olhada nos tópicos de referência que consultamos durante a preparação deste artigo.
 
-- [Visão geral da integração de Reporting Services e SharePoint](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
-- [Topologias de Implantação para Reporting Services no Modo Integrado do SharePoint](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
-- [Configurando Reporting Services para Integração com SharePoint 2010](http://msdn.microsoft.com/en-us/library/bb326356.aspx)
+- [Overview of Reporting Services and SharePoint Technology Integration](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
+- [Deployment Topologies for Reporting Services in SharePoint Integrated Mode](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
+- [Configuring Reporting Services for SharePoint 2010 Integration](http://msdn.microsoft.com/en-us/library/bb326356.aspx)
 
 {{% /alert %}}
 
-## Configuração do Ambiente
+## Configuração do ambiente
 
-Nossa configuração consiste em 4 servidores. Inclui um Controlador de Domínio, um SQL Server, um Servidor SharePoint e um servidor para Reporting Services. Você pode optar por ter o SharePoint e o Reporting Services no mesmo equipamento, o que simplificará um pouco e eu apontarei algumas das diferenças.
+A configuração externa consiste em 4 servidores. Inclui um Controlador de Domínio, um SQL Server, um SharePoint Server e um servidor para Reporting Services. Você pode optar por ter o SharePoint e o Reporting Services na mesma caixa, o que simplificará um pouco isso e apontarei algumas das diferenças.
 
-## Pré-requisitos de Instalação
+## Pré-requisitos de instalação
 
 {{% alert color="primary" %}}
 
-O Add-In Reporting Services para SharePoint é um dos componentes essenciais para que a Integração funcione corretamente. O Add-In precisa ser instalado em qualquer um dos Web Front Ends (WFE) que estejam na sua fazenda SharePoint, junto com o servidor Central Admin. Uma das novas mudanças com o SQL 2008 R2 & SharePoint 2010 é que o Add-In 2008 R2 agora é um pré-requisito para a instalação do SharePoint. Isso significa que o Add-In RS será instalado quando você for instalar o SharePoint. Isso foi mostrado e destacado na figura abaixo. Na prática, isso evita muitos dos problemas que vimos com o SP 2007 e RS 2008 ao instalar o Add-In.
+O suplemento Reporting Services para SharePoint é um dos principais componentes para que a integração funcione corretamente. O suplemento precisa ser instalado em qualquer Web Front Ends (WFE) que esteja em seu farm do SharePoint junto com o servidor Central Admin. Uma das novas mudanças no SQL 2008 R2 e no SharePoint 2010 é que o complemento 2008 R2 agora é um pré-requisito para a instalação do SharePoint. Isso significa que o suplemento RS será instalado quando você instalar o SharePoint. Ele foi mostrado e destacado na figura abaixo. Na verdade, isso evita muitos problemas que vimos com o SP 2007 e o RS 2008 ao instalar o complemento.
 
-![todo:image_alt_text](introduction_1.png)
+![Introduction](introduction_1.png)
 
-**Image1 :- Complemento do Reporting Services para Share Point**
+**Imagem1: - Suplemento Reporting Services para Share Point**
 {{% /alert %}}
 
 ## Autenticação do SharePoint
 
-**Antes de mergulharmos nas partes de Integração do RS, uma coisa que quero destacar sobre o Farm do SharePoint é como você configura o Site. Mais especificamente, como você configura a autenticação para o site. Se será Classic ou Claims. Essa escolha é importante no início. Não acredito que você possa mudar essa opção depois que ela for feita. Se você puder mudá-la, não seria um processo simples.**
+**Antes de entrarmos nas partes da Integração RS, uma coisa que quero destacar sobre o Farm do SharePoint é como você configura o Site. Mais especificamente como você configura a autenticação do site. Seja Clássico ou Claims. Essa escolha é importante no começo. Não acredito que você possa alterar essa opção depois de concluída. Se você pudesse mudar isso, não seria um processo simples.
 
-NOTA: ***Reporting Services 2008 R2 não tem suporte a Claims***
+NOTA: ***O Reporting Services 2008 R2 NÃO tem reconhecimento de reivindicações***
 
-Mesmo que você escolha seu site SharePoint para usar Claims, o Reporting Services em si não tem consciência de Claims. Dito isso, isso afeta como a autenticação funciona com o Reporting Services. Então, qual é a diferença do ponto de vista do Reporting Services? Tudo se resume a se você deseja encaminhar as Credenciais do Usuário para a fonte de dados. Classic:- Pode usar Kerberos e encaminhar as credenciais do usuário para sua fonte de dados backend (será necessário usar Kerberos para isso). Claims:- Um token Claims é usado e não um token do Windows. O RS sempre usará Trusted Authentication neste cenário e terá acesso apenas ao token SPUser. Você precisará armazenar suas credenciais na sua fonte de dados.
+Mesmo que você escolha seu site do SharePoint para usar Declarações, o Reporting Services em si não reconhece as Declarações. Dito isto, isso afeta o modo como a autenticação funciona com o Reporting Services. Então, qual é a diferença da perspectiva do Reporting Services? A questão é se você deseja encaminhar as credenciais do usuário para a fonte de dados. Clássico: - Pode usar Kerberos e encaminhar as credenciais do usuário para sua fonte de dados back-end (será necessário usar Kerberos para isso). Reivindicações: - Um token de reivindicações é usado e não um token do Windows. O RS sempre usará autenticação confiável neste cenário e terá acesso apenas ao token SPUser. Você precisará armazenar suas credenciais em sua fonte de dados.
 
-Classic :- Pode usar Kerberos e encaminhar as credenciais do usuário para sua fonte de dados back end (será necessário usar Kerberos para isso.
+Clássico: - Pode usar Kerberos e encaminhar as credenciais do usuário para sua fonte de dados de back-end (será necessário usar Kerberos para isso.
 
-Claims :- Um token Claims é usado e não um token do Windows. O RS sempre usará Trusted Authentication neste cenário e terá acesso apenas ao token SPUser. Você precisará armazenar suas credenciais na sua fonte de dados.
+Reivindicações: - Um token de reivindicações é usado e não um token do Windows. O RS sempre usará autenticação confiável neste cenário e terá acesso apenas ao token SPUser. Você precisará armazenar suas credenciais em sua fonte de dados.
 
-Por enquanto, queremos apenas nos concentrar na configuração do RS. Neste ponto, o SharePoint está instalado na minha caixa SharePoint e configurado com um site Classic Auth na porta 80. No servidor RS, acabei de instalar o Reporting Services e é isso.
+Por enquanto, queremos apenas nos concentrar na configuração do RS. Neste ponto, o SharePoint está instalado em meu SharePoint Box e configurado com um Classic Auth Site na porta 80. No servidor RS, acabei de instalar o Reporting Services e pronto.

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
@@ -17,9 +17,9 @@ Aspose.PDF para Reporting Services tem sido notável na geração de PDF por mei
 
 Antes de prosseguirmos, vamos dar uma olhada nos tópicos de referência que consultamos durante a preparação deste artigo.
 
-- [Overview of Reporting Services and SharePoint Technology Integration](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
-- [Deployment Topologies for Reporting Services in SharePoint Integrated Mode](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
-- [Configuring Reporting Services for SharePoint 2010 Integration](http://msdn.microsoft.com/en-us/library/bb326356.aspx)
+- [Visão geral do Reporting Services e da integração de tecnologia do SharePoint](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
+- [Topologias de implantação para Reporting Services no modo integrado do SharePoint](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
+- [Configurando o Reporting Services para integração com o SharePoint 2010](http://msdn.microsoft.com/en-us/library/bb326356.aspx)
 
 {{% /alert %}}
 

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
@@ -4,12 +4,12 @@ linktitle: Introdução
 type: docs
 weight: 10
 url: /pt/reportingservices/introduction/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF for Reporting Services tem sido muito notável para a geração de PDF através do SQL Reporting Services há muitos anos e fornece diversas opções de configuração e parametrização que não são suportadas por padrão no SQL Reporting Services. Recentemente recebemos algumas solicitações sobre a Integração do Aspose.PDF for Reporting Services com o SharePoint. Neste artigo, vamos nos concentrar no MS SharePoint 2010. Antes de prosseguirmos, assumimos que você já tem um SharePoint Farm configurado. Neste exemplo, usaremos o SharePoint Cloud completo. Contudo, as etapas são semelhantes para o SharePoint Foundation Server.
+Aspose.PDF for Reporting Services tem sido muito notável para a geração de PDF através do SQL Reporting Services há muitos anos e oferece diversas opções de configuração e parametrização que não são suportadas por padrão no SQL Reporting Services. Recentemente, recebemos algumas solicitações relacionadas à Integração do Aspose.PDF for Reporting Services com o SharePoint. Para este artigo, vamos nos concentrar no MS SharePoint 2010. Antes de prosseguir, assumimos que você já possui uma farm do SharePoint configurada. Neste exemplo, utilizaremos o SharePoint Cloud completo. No entanto, os passos são semelhantes para o SharePoint Foundation Server.
 
 {{% /alert %}}
 
@@ -17,7 +17,7 @@ Aspose.PDF for Reporting Services tem sido muito notável para a geração de PD
 
 Antes de prosseguirmos, vamos dar uma olhada nos tópicos de referência que consultamos durante a preparação deste artigo.
 
-- [Visão geral da integração das tecnologias Reporting Services e SharePoint](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
+- [Visão geral da integração de Reporting Services e SharePoint](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
 - [Topologias de Implantação para Reporting Services no Modo Integrado do SharePoint](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
 - [Configurando Reporting Services para Integração com SharePoint 2010](http://msdn.microsoft.com/en-us/library/bb326356.aspx)
 
@@ -25,13 +25,13 @@ Antes de prosseguirmos, vamos dar uma olhada nos tópicos de referência que con
 
 ## Configuração do Ambiente
 
-Nossa configuração consiste em 4 servidores. Inclui um Controlador de Domínio, um SQL Server, um Servidor SharePoint e um servidor para Reporting Services. Você pode optar por ter SharePoint e Reporting Services na mesma máquina, o que simplificará um pouco e eu apontarei algumas das diferenças.
+Nossa configuração consiste em 4 servidores. Inclui um Controlador de Domínio, um SQL Server, um Servidor SharePoint e um servidor para Reporting Services. Você pode optar por ter o SharePoint e o Reporting Services no mesmo equipamento, o que simplificará um pouco e eu apontarei algumas das diferenças.
 
 ## Pré-requisitos de Instalação
 
 {{% alert color="primary" %}}
 
-O Add-In Reporting Services para SharePoint é um dos componentes principais para que a Integração funcione corretamente. O Add-In precisa ser instalado em qualquer um dos Web Front Ends (WFE) que estejam na sua fazenda SharePoint, juntamente com o servidor Central Admin. Uma das novas mudanças com SQL 2008 R2 & SharePoint 2010 é que o Add-In 2008 R2 agora é um pré-requisito para a Instalação do SharePoint. Isso significa que o Add-In RS será instalado quando você for instalar o SharePoint. Isso foi mostrado e destacado na figura abaixo. Isso realmente evita muitos problemas que vimos com SP 2007 e RS 2008 ao instalar o Add-In.
+O Add-In Reporting Services para SharePoint é um dos componentes essenciais para que a Integração funcione corretamente. O Add-In precisa ser instalado em qualquer um dos Web Front Ends (WFE) que estejam na sua fazenda SharePoint, junto com o servidor Central Admin. Uma das novas mudanças com o SQL 2008 R2 & SharePoint 2010 é que o Add-In 2008 R2 agora é um pré-requisito para a instalação do SharePoint. Isso significa que o Add-In RS será instalado quando você for instalar o SharePoint. Isso foi mostrado e destacado na figura abaixo. Na prática, isso evita muitos dos problemas que vimos com o SP 2007 e RS 2008 ao instalar o Add-In.
 
 ![todo:image_alt_text](introduction_1.png)
 
@@ -40,15 +40,14 @@ O Add-In Reporting Services para SharePoint é um dos componentes principais par
 
 ## Autenticação do SharePoint
 
-**Antes de mergulharmos nas partes de Integração do RS, uma coisa que quero destacar sobre o Farm do SharePoint é como você configura o Site. Mais especificamente, como você configura a autenticação para o site. Se será Classic ou Claims. Essa escolha é importante no início. Não acredito que você possa mudar essa opção depois de concluída. Se você puder mudá-la, não será um processo simples.**
+**Antes de mergulharmos nas partes de Integração do RS, uma coisa que quero destacar sobre o Farm do SharePoint é como você configura o Site. Mais especificamente, como você configura a autenticação para o site. Se será Classic ou Claims. Essa escolha é importante no início. Não acredito que você possa mudar essa opção depois que ela for feita. Se você puder mudá-la, não seria um processo simples.**
 
-NOTE: ***Reporting Services 2008 R2 NÃO é compatível com Claims***
+NOTA: ***Reporting Services 2008 R2 não tem suporte a Claims***
 
-Mesmo se você escolher seu site SharePoint para usar Claims, o Reporting Services em si não tem consciência de Claims. Dito isso, ele afeta como a autenticação funciona com o Reporting Services. Então, qual é a diferença do ponto de vista do Reporting Services? Tudo se resume a se você deseja encaminhar Credenciais de Usuário para a fonte de dados. Classic:- Pode usar Kerberos e encaminhar as credenciais do usuário para sua fonte de dados de back end (será necessário usar Kerberos para isso). Claims:- Um token Claims é usado e não um token do Windows. O RS sempre usará Trusted Authentication neste cenário e terá acesso apenas ao token SPUser. Você precisará armazenar suas credenciais dentro da sua fonte de dados.
+Mesmo que você escolha seu site SharePoint para usar Claims, o Reporting Services em si não tem consciência de Claims. Dito isso, isso afeta como a autenticação funciona com o Reporting Services. Então, qual é a diferença do ponto de vista do Reporting Services? Tudo se resume a se você deseja encaminhar as Credenciais do Usuário para a fonte de dados. Classic:- Pode usar Kerberos e encaminhar as credenciais do usuário para sua fonte de dados backend (será necessário usar Kerberos para isso). Claims:- Um token Claims é usado e não um token do Windows. O RS sempre usará Trusted Authentication neste cenário e terá acesso apenas ao token SPUser. Você precisará armazenar suas credenciais na sua fonte de dados.
 
-Classic :- Pode usar Kerberos e encaminhar as credenciais do usuário para sua fonte de dados de back end (será necessário usar Kerberos para isso.
+Classic :- Pode usar Kerberos e encaminhar as credenciais do usuário para sua fonte de dados back end (será necessário usar Kerberos para isso.
 
-Claims :- Um token Claims é usado e não um token do Windows. O RS sempre usará Trusted Authentication neste cenário e terá acesso apenas ao token SPUser. Você precisará armazenar suas credenciais dentro da sua fonte de dados.
+Claims :- Um token Claims é usado e não um token do Windows. O RS sempre usará Trusted Authentication neste cenário e terá acesso apenas ao token SPUser. Você precisará armazenar suas credenciais na sua fonte de dados.
 
-Por enquanto, queremos apenas nos concentrar na configuração do RS. Neste ponto, o SharePoint está instalado na minha SharePoint Box e configurado com um site Classic Auth na porta 80. No servidor RS, acabei de instalar o Reporting Services e é só.
-
+Por enquanto, queremos apenas nos concentrar na configuração do RS. Neste ponto, o SharePoint está instalado na minha caixa SharePoint e configurado com um site Classic Auth na porta 80. No servidor RS, acabei de instalar o Reporting Services e é isso.

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
@@ -1,44 +1,44 @@
 ---
 title: Configuração do Reporting Services e do SharePoint
-linktitle: Configuração do Reporting Services e do SharePoint
+linktitle: Reporting Services and SharePoint configuration
 type: docs
 weight: 40
-url: /pt/reportingservices/reporting-services-and-sharepoint-configuration/
-lastmod: "2026-07-29"
+url: /reportingservices/reporting-services-and-sharepoint-configuration/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Agora que o SharePoint está instalado e configurado no servidor RS e o RS está configurado através do Reporting Services Configuration Manager, podemos passar para a configuração dentro do Central Admin. O RS 2008 R2 realmente simplificou esse processo. Antes, tínhamos um processo de 3 etapas que era necessário executar para que isso funcionasse. Agora temos apenas uma etapa.
+Agora que o SharePoint está instalado e configurado no servidor RS e o RS está instalado e configurado por meio do Reporting Services Configuration Manager, podemos passar para a configuração no Central Admin. O RS 2008 R2 realmente simplificou esse processo. Costumávamos ter um processo de três etapas que você precisava executar para que isso funcionasse. Agora só temos um passo.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Queremos ir ao site do Administrador Central e depois às Configurações Gerais de Aplicação. Na parte inferior, veremos Reporting Services.
+Queremos ir para o site do Administrador Central e depois para Configurações Gerais do Aplicativo. Na parte inferior, veremos Reporting Services.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_1.png)
-**Image1**:- diálogo de configuração do SharePoint
+![Configuration-step1](reporting-services-and-sharepoint-configuration_1.png)
+**Imagem1**: - Caixa de diálogo de configuração do SharePoint
 
-Selecione o link "Reporting Services Integration". A tela a seguir será exibida.
+Selecione o link "Integração do Reporting Services". A tela a seguir será exibida.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_2.png)
-**Image2**:- Especifique as credenciais de integração do Reporting Services
+![Configuration-step2](reporting-services-and-sharepoint-configuration_2.png)
+**Imagem2**: - Especifique as credenciais de integração do Reporting Services
 
 {{% /alert %}}
 
-## URL do Serviço Web:
+## URL do serviço web:
 
-**Forneceremos a URL para o Report Server que encontramos no Reporting Services Configuration Manager.**
+**Forneceremos a URL do Servidor de Relatórios que encontramos no Reporting Services Configuration Manager.**
 
-## Modo de Autenticação:
+## Modo de autenticação:
 
-**Também selecionaremos um modo de autenticação. O link da MSDN a seguir detalha o que são esses modos.
-Visão geral de segurança para Reporting Services em modo integrado do SharePoint**
+**Também selecionaremos um modo de autenticação. O link do MSDN a seguir explica detalhadamente o que são.
+Visão geral de segurança do Reporting Services no modo integrado do SharePoint**
 
 {{% alert color="primary" %}}
 
-**Em resumo, se seu site estiver usando Autenticação de Claims, você sempre usará Autenticação Confiável independentemente do que escolher aqui. Se quiser passar credenciais do Windows, deverá escolher Autenticação do Windows. Para Autenticação Confiável, passaremos o token SPUser e não dependeremos da credencial do Windows. Você também deverá usar Autenticação Confiável se configurou seus sites em Modo Clássico para NTLM e o RS está configurado para NTLM. Kerberos seria necessário para usar Autenticação do Windows e repassá‑la para sua fonte de dados.**
+**Resumindo, se o seu site estiver usando autenticação de declarações, você sempre usará autenticação confiável, independentemente do que escolher aqui. Se quiser passar credenciais do Windows, você deverá escolher Autenticação do Windows. Para autenticação confiável, passaremos o token SPUser e não dependeremos da credencial do Windows. Você também desejará usar a autenticação confiável se tiver configurado seus sites no modo clássico para NTLM e o RS estiver configurado para NTLM. O Kerberos seria necessário para usar a autenticação do Windows e transmiti-la para sua fonte de dados.**
 
 {{% /alert %}}
 
@@ -46,54 +46,54 @@ Visão geral de segurança para Reporting Services em modo integrado do SharePoi
 
 {{% alert color="primary" %}}
 
-**Isso dá a você a opção de ativar o Reporting Services em todas as coleções de sites, ou você pode escolher em quais deseja ativá-lo. Isso realmente significa quais sites poderão usar o Reporting Services. Quando terminar, você deverá ver os seguintes resultados**
+**Isso oferece a opção de ativar o Reporting Services em todos os conjuntos de sites ou você pode escolher em quais deseja ativá-lo. Na verdade, isso significa quais sites poderão usar o Reporting Services. Quando terminar, você deverá ver os seguintes resultados **
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_3.png)
+![Configuration-step3](reporting-services-and-sharepoint-configuration_3.png)
 
-**Image3:**- Integração bem‑sucedida do Reporting Services com o ambiente SharePoint
+**Imagem3:**- Integração bem-sucedida do Reporting Services com o ambiente SharePoint
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Voltando ao URL do ReportServer, devemos ver algo semelhante ao seguinte
+Voltando ao URL ReportServer, devemos ver algo semelhante ao seguinte
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_4.png)
+![Configuration-step4](reporting-services-and-sharepoint-configuration_4.png)
 
-**Image4:**- O Reporting Services está conectado com sucesso ao ambiente SharePoint
+**Imagem4:**- Reporting Services foi conectado com sucesso ao ambiente SharePoint
 
-**NOTE:** ***Se o seu site SharePoint estiver configurado para SSL, ele não aparecerá nesta lista. É um problema conhecido e não significa que haja um problema. Seus relatórios ainda devem funcionar.***
+**NOTA:** ***Se o seu site SharePoint estiver configurado para SSL, ele não aparecerá nesta lista. É um problema conhecido e não significa que haja um problema. Seus relatórios ainda devem funcionar.***
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Agora que integrámos com sucesso ambos os produtos, estamos prontos para usar Reporting Services no SharePoint 2010. Assim como na versão anterior, temos um recurso (ativado quando configuramos a Integração do Reporting Services) na “Site Collection Feature”. Também a instalação adicionou 3 tipos de conteúdo ao nosso site. Na Imagem 7 podemos ver 2 desses tipos de conteúdo adicionados a uma biblioteca de documentos para criar um relatório personalizado usando o, como podemos ver na Image5 abaixo.
+Agora que integramos ambos os produtos com sucesso, estamos prontos para usar o Reporting Services no SharePoint 2010. Assim como na versão anterior, temos um recurso (ativado quando configuramos a Integração do Reporting Services) no “Site Collection Feature”. Além disso, a instalação adicionou 3 tipos de conteúdo para adicionar ao nosso site. Na Imagem 7 podemos ver 2 deles tipos de conteúdo adicionados em uma biblioteca de documentos para criar um relatório personalizado usando o, como podemos ver na Imagem 5 abaixo.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_5.png)
+![Configuration-step5](reporting-services-and-sharepoint-configuration_5.png)
 
-**Image5:**- Report Builder
+**Imagem5:**- Construtor de Relatórios
 
-O “Reporter Builder” é um controle ActiveX, portanto precisamos baixá‑lo no servidor, como podemos ver na Imagem 6 abaixo.
+O “Reporter Builder” é um controle ActiveX então precisamos baixá-lo através do servidor, como podemos ver na Imagem 6 abaixo.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_6.png)
+![Configuration-step6](reporting-services-and-sharepoint-configuration_6.png)
 
-**Image6:**- Baixe e instale o Report Builder
+**Imagem6:**- Baixe e instale o Report Builder
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Depois que o processo de download for concluído, carregue o controle “Report Builder”. Agora estamos prontos para criar nosso primeiro relatório, como mostrado na Image7 abaixo.
+Assim que o processo de download for concluído, carregue o controle “Report Builder”. Agora estamos prontos para desenhar nosso primeiro relatório, conforme mostrado na Imagem7 abaixo.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_7.png)
+![Configuration-step7](reporting-services-and-sharepoint-configuration_7.png)
 
-**Image7:**- Report Builder – Assistente de criação de novo relatório
+**Imagem7:**- Report Builder – Novo assistente de geração de relatórios
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Após criar nosso relatório, podemos salvá‑lo na biblioteca de documentos criada para armazenar os relatórios no nosso SharePoint 2010. O outro tipo de conteúdo deve ser usado para criar conexões compartilhadas como fonte de dados e salvá‑las em uma biblioteca de documentos no SharePoint. Podemos criar uma biblioteca de documentos, adicionar esse tipo de conteúdo e, então, ter nossas conexões disponíveis para alterar a fonte de dados dos relatórios.
+Após criar nosso relatório poderíamos salvá-lo na biblioteca de documentos criada para colocar os relatórios em nosso SharePoint 2010. O outro tipo de conteúdo deve ser usado para criar conexão compartilhada como fonte de dados e salvá-los em uma biblioteca de documentos no SharePoint. Podemos criar uma biblioteca de documentos, adicionar este tipo de conteúdo e depois termos nossas conexões disponíveis para alterar a fonte de dados dos relatórios.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_8.png)
+![Configuration-step8](reporting-services-and-sharepoint-configuration_8.png)
 
-**Image8:**- Integração bem-sucedida do Aspose.PDF for Reporting Services com o MS SharePoint
+**Image8:**- Integração bem-sucedida de Aspose.PDF para Reporting Services com MS SharePoint
 {{% /alert %}}
 

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
@@ -1,26 +1,26 @@
 ---
-title: Configuração do Reporting Services e SharePoint
-linktitle: Configuração do Reporting Services e SharePoint
+title: Configuração do Reporting Services e do SharePoint
+linktitle: Configuração do Reporting Services e do SharePoint
 type: docs
 weight: 40
 url: /pt/reportingservices/reporting-services-and-sharepoint-configuration/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Agora que o SharePoint está instalado e configurado no servidor RS e o RS está configurado através do Reporting Services Configuration Manager, podemos passar para a configuração no Central Admin. O RS 2008 R2 simplificou muito esse processo. Antes tínhamos um processo de 3 etapas que precisávamos executar para que isso funcionasse. Agora temos apenas uma etapa.
+Agora que o SharePoint está instalado e configurado no servidor RS e o RS está configurado através do Reporting Services Configuration Manager, podemos passar para a configuração dentro do Central Admin. O RS 2008 R2 realmente simplificou esse processo. Antes, tínhamos um processo de 3 etapas que era necessário executar para que isso funcionasse. Agora temos apenas uma etapa.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Queremos acessar o site Central Administrator e, em seguida, entrar em Configurações Gerais do Aplicativo. Mais para baixo, veremos Reporting Services.
+Queremos ir ao site do Administrador Central e depois às Configurações Gerais de Aplicação. Na parte inferior, veremos Reporting Services.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_1.png)
 **Image1**:- diálogo de configuração do SharePoint
 
-Selecione "Reporting Services Integration" link. A tela a seguir será exibida.
+Selecione o link "Reporting Services Integration". A tela a seguir será exibida.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_2.png)
 **Image2**:- Especifique as credenciais de integração do Reporting Services
@@ -29,16 +29,16 @@ Selecione "Reporting Services Integration" link. A tela a seguir será exibida.
 
 ## URL do Serviço Web:
 
-**Forneceremos a URL do Report Server que encontramos no Reporting Services Configuration Manager.**
+**Forneceremos a URL para o Report Server que encontramos no Reporting Services Configuration Manager.**
 
 ## Modo de Autenticação:
 
-**Também selecionaremos um modo de autenticação. O link MSDN a seguir detalha o que são esses modos.
-Visão geral de segurança para Reporting Services no modo SharePoint Integrated**
+**Também selecionaremos um modo de autenticação. O link da MSDN a seguir detalha o que são esses modos.
+Visão geral de segurança para Reporting Services em modo integrado do SharePoint**
 
 {{% alert color="primary" %}}
 
-**Em resumo, se o seu site usa Claims Authentication, você sempre usará Trusted Authentication independentemente da escolha aqui. Se você quiser passar credenciais do Windows, deverá escolher Windows Authentication. Para Trusted Authentication, passaremos o token SPUser e não dependeremos da credencial do Windows. Você também desejará usar Trusted Authentication se configurou seus sites Classic Mode para NTLM e o RS está configurado para NTLM. Kerberos seria necessário para usar Windows Authentication e passar isso para sua fonte de dados.**
+**Em resumo, se seu site estiver usando Autenticação de Claims, você sempre usará Autenticação Confiável independentemente do que escolher aqui. Se quiser passar credenciais do Windows, deverá escolher Autenticação do Windows. Para Autenticação Confiável, passaremos o token SPUser e não dependeremos da credencial do Windows. Você também deverá usar Autenticação Confiável se configurou seus sites em Modo Clássico para NTLM e o RS está configurado para NTLM. Kerberos seria necessário para usar Autenticação do Windows e repassá‑la para sua fonte de dados.**
 
 {{% /alert %}}
 
@@ -46,11 +46,11 @@ Visão geral de segurança para Reporting Services no modo SharePoint Integrated
 
 {{% alert color="primary" %}}
 
-**Isso lhe dá a opção de ativar o Reporting Services em todas as coleções de sites, ou você pode escolher em quais deseja ativá-lo. Isso realmente significa quais sites poderão usar o Reporting Services. Quando concluído, você deverá ver os seguintes resultados**
+**Isso dá a você a opção de ativar o Reporting Services em todas as coleções de sites, ou você pode escolher em quais deseja ativá-lo. Isso realmente significa quais sites poderão usar o Reporting Services. Quando terminar, você deverá ver os seguintes resultados**
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_3.png)
 
-**Image3:**- Integração bem-sucedida do Reporting Services com o ambiente SharePoint
+**Image3:**- Integração bem‑sucedida do Reporting Services com o ambiente SharePoint
 {{% /alert %}}
 
 {{% alert color="primary" %}}
@@ -59,20 +59,20 @@ Voltando ao URL do ReportServer, devemos ver algo semelhante ao seguinte
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_4.png)
 
-**Image4:**- Reporting Services está conectado com sucesso ao ambiente SharePoint
+**Image4:**- O Reporting Services está conectado com sucesso ao ambiente SharePoint
 
 **NOTE:** ***Se o seu site SharePoint estiver configurado para SSL, ele não aparecerá nesta lista. É um problema conhecido e não significa que haja um problema. Seus relatórios ainda devem funcionar.***
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Agora que integrámos com sucesso ambos os produtos, estamos prontos para usar o Reporting Services no SharePoint 2010. Assim como na versão anterior, temos um recurso (ativado quando configuramos a Integração do Reporting Services) na "Site Collection Feature". Também a instalação adicionou 3 tipos de conteúdo ao nosso site. Na Imagem 7 podemos ver 2 desses tipos de conteúdo adicionados a uma biblioteca de documentos para criar um relatório personalizado usando o, como podemos ver na Image5 abaixo.
+Agora que integrámos com sucesso ambos os produtos, estamos prontos para usar Reporting Services no SharePoint 2010. Assim como na versão anterior, temos um recurso (ativado quando configuramos a Integração do Reporting Services) na “Site Collection Feature”. Também a instalação adicionou 3 tipos de conteúdo ao nosso site. Na Imagem 7 podemos ver 2 desses tipos de conteúdo adicionados a uma biblioteca de documentos para criar um relatório personalizado usando o, como podemos ver na Image5 abaixo.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_5.png)
 
 **Image5:**- Report Builder
 
-O “Reporter Builder” é um controle ActiveX, portanto precisamos baixá-lo no servidor, como podemos ver na Imagem 6 abaixo.
+O “Reporter Builder” é um controle ActiveX, portanto precisamos baixá‑lo no servidor, como podemos ver na Imagem 6 abaixo.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_6.png)
 
@@ -81,20 +81,19 @@ O “Reporter Builder” é um controle ActiveX, portanto precisamos baixá-lo n
 
 {{% alert color="primary" %}}
 
-Depois que o processo de download for concluído, carregue o controle “Report Builder”. Agora estamos prontos para projetar nosso primeiro relatório, como mostrado na Image7 abaixo.
+Depois que o processo de download for concluído, carregue o controle “Report Builder”. Agora estamos prontos para criar nosso primeiro relatório, como mostrado na Image7 abaixo.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_7.png)
 
-**Image7:**- Report Builder – Assistente de geração de novo relatório
+**Image7:**- Report Builder – Assistente de criação de novo relatório
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Depois de criar nosso relatório, podemos salvá‑lo na biblioteca de documentos criada para armazenar os relatórios no nosso SharePoint 2010. O outro tipo de conteúdo deve ser usado para criar conexões compartilhadas como fonte de dados e salvá‑las em uma biblioteca de documentos no SharePoint. Podemos criar uma biblioteca de documentos, adicionar esse tipo de conteúdo e, depois, ter nossas conexões disponíveis para alterar a fonte de dados dos relatórios.
+Após criar nosso relatório, podemos salvá‑lo na biblioteca de documentos criada para armazenar os relatórios no nosso SharePoint 2010. O outro tipo de conteúdo deve ser usado para criar conexões compartilhadas como fonte de dados e salvá‑las em uma biblioteca de documentos no SharePoint. Podemos criar uma biblioteca de documentos, adicionar esse tipo de conteúdo e, então, ter nossas conexões disponíveis para alterar a fonte de dados dos relatórios.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_8.png)
 
-**Image8:**- Integração bem-sucedida do Aspose.PDF para Reporting Services com o MS SharePoint
+**Image8:**- Integração bem-sucedida do Aspose.PDF for Reporting Services com o MS SharePoint
 {{% /alert %}}
-
 

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
@@ -4,47 +4,47 @@ linktitle: Configurando o Reporting Services
 type: docs
 weight: 20
 url: /pt/reportingservices/setting-up-reporting-services/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Nossa primeira parada no Servidor Reporting Services é o Gerenciador de Configuração do Reporting Services.
+Nossa primeira parada no Reporting Services Server é o Reporting Services Configuration Manager.
 
 {{% /alert %}}
 
-## Conta de Serviço:
+## Conta de serviço:
 
-**Certifique‑se de entender qual conta de serviço você está usando para o Reporting Services. Se encontrarmos problemas, eles podem estar relacionados à conta de serviço que você está usando. O padrão é Network Service. Quando implantamos novas versões, sempre usamos Contas de Domínio, pois é onde provavelmente encontraremos problemas. Para esta instância do servidor, usamos uma Conta de Domínio chamada RSService.**
+**Certifique‑se de entender qual conta de serviço você está usando para o Reporting Services. Se encontrarmos problemas, eles podem estar relacionados à conta de serviço que você está usando. O padrão é Network Service. Quando vamos implantar novas compilações, sempre usamos contas de domínio, porque é aí que provavelmente encontraremos problemas. Para esta instância do servidor, usamos uma conta de domínio chamada RSService.**
 
 ![todo:image_alt_text](setting-up-reporting-services_1.png)
 
-**Image1:- Configurando a conta de serviço**
+**Image1:- Configurando conta de serviço**
 
 ## URL do Serviço Web:
 
 {{% alert color="primary" %}}
 
-**Precisaremos configurar a URL do Serviço Web. Este é o diretório virtual (vdir) do ReportServer que hospeda os Serviços Web usados pelo Reporting Services, e com o qual o SharePoint se comunicará. A menos que você queira personalizar as propriedades do vdir (ou seja, SSL, portas, cabeçalhos de host, etc… ), você deve simplesmente clicar em Aplicar aqui e estará pronto para usar.**
+**Precisaremos configurar a URL do Serviço Web. Este é o diretório virtual (vdir) do ReportServer que hospeda os Serviços Web usados pelo Reporting Services, e com o qual o SharePoint se comunicará. A menos que você queira personalizar as propriedades do vdir (ou seja, SSL, portas, cabeçalhos de host, etc…), você deve simplesmente clicar em Aplicar aqui e estará pronto para usar.**
 ![todo:image_alt_text](setting-up-reporting-services_2.png)
 
-**Image2:- Configurando a URL do Serviço Web Uma vez que a URL do Serviço Web tenha sido configurada, você deve ser capaz de ver os seguintes resultados**
+**Imagem2:- Configurando a URL do Serviço Web Uma vez que a URL do serviço Web tenha sido configurada, você deverá ser capaz de ver os seguintes resultados**
 
 ![todo:image_alt_text](setting-up-reporting-services_3.png)
 
-**Image3:- Configuração bem-sucedida da URL do Serviço Web**
+**Imagem3:- Configuração bem-sucedida da URL do serviço Web**
 {{% /alert %}}
 
 ## Banco de dados:
 
-**Precisamos criar o Banco de Dados do Catálogo do Reporting Services. Isso pode ser colocado em qualquer mecanismo de banco de dados SQL 2008 ou SQL 2008 R2. O SQL11 também funcionaria bem, mas ainda está em BETA. Esta ação criará dois bancos de dados, ReportServer e ReportServerTempDB, por padrão.**
+**Precisamos criar o Banco de Dados do Catálogo do Reporting Services. Ele pode ser colocado em qualquer mecanismo de banco de dados SQL 2008 ou SQL 2008 R2. O SQL11 também funcionaria bem, mas ainda está em BETA. Essa ação criará dois bancos de dados, ReportServer e ReportServerTempDB, por padrão.**
 
 {{% alert color="primary" %}}
-**A outra etapa importante nisso é garantir que você escolha SharePoint Integrated para o tipo de banco de dados. Uma vez feita essa escolha, ela não pode ser alterada.**
+**A outra etapa importante aqui é garantir que você escolha SharePoint Integrated para o tipo de banco de dados. Depois que essa escolha for feita, não poderá ser alterada.**
 
 ![todo:image_alt_text](setting-up-reporting-services_4.png)
 
-**Image4:- Criando o banco de dados do servidor de relatórios**
+**Image4:- Criando banco de dados do servidor de relatórios**
 
 ![todo:image_alt_text](setting-up-reporting-services_5.png)
 
@@ -55,7 +55,7 @@ Nossa primeira parada no Servidor Reporting Services é o Gerenciador de Configu
 **Image6:- Configurando o nome do banco de dados e o Modo**
 {{% /alert %}}
 
-**Para as credenciais, é assim que o Report Server se comunicará com o SQL Server. Qualquer conta que você selecionar receberá certos direitos dentro do banco de dados Catalog, bem como alguns dos bancos de dados do sistema via RSExecRole. MSDB é um desses bancos de dados para uso de assinaturas, pois utilizamos o SQL Agent.**
+**Para as credenciais, é assim que o Report Server se comunicará com o SQL Server. Qualquer conta que você selecionar receberá certos direitos dentro do banco de dados Catalog, bem como em alguns dos bancos de dados do sistema via RSExecRole. MSDB é um desses bancos de dados para uso de Assinaturas, pois utilizamos o SQL Agent.**
 
 ![todo:image_alt_text](setting-up-reporting-services_7.png)
 
@@ -63,7 +63,7 @@ Nossa primeira parada no Servidor Reporting Services é o Gerenciador de Configu
 
 {{% alert color="primary" %}}
 
-**Depois que as credenciais do banco de dados forem especificadas, deveríamos ser capazes de obter os resultados conforme especificado abaixo.**
+**Depois que as credenciais do banco de dados forem especificadas, devemos ser capazes de obter os resultados conforme especificado abaixo.**
 
 ![todo:image_alt_text](setting-up-reporting-services_8.png)
 
@@ -74,28 +74,27 @@ Nossa primeira parada no Servidor Reporting Services é o Gerenciador de Configu
 **Image9:- Resumo da conclusão do banco de dados do Report Server**
 {{% /alert %}}
 
-## URL do Report Manager:
+## URL do Gerenciador de Relatórios:
 
-**Podemos ignorar a URL do Report Manager, pois não é usada quando estamos no modo Integrado ao SharePoint. O SharePoint é nossa interface. O Report Manager não funciona.**
+**Podemos ignorar o URL do Report Manager, pois ele não é usado quando estamos no modo SharePoint Integrated. O SharePoint é nossa interface frontal. O Report Manager não funciona.**
 
 ## Chaves de Criptografia:
 
 {{% alert color="primary" %}}
-**Faça backup das suas Chaves de Criptografia e certifique-se de saber onde as guarda. Se você se deparar com uma situação em que precise migrar o Banco de Dados ou restaurá‑lo, você precisará delas.**
+**Faça backup das suas chaves de criptografia e certifique-se de saber onde as guarda. Se você se deparar com uma situação em que precise migrar o Banco de Dados ou restaurá‑lo, precisará delas.**
 
 ![todo:image_alt_text](setting-up-reporting-services_10.png)
 
-**Image10:- backup da chave de criptografia do Report Server**
+**Image10:- Backup da chave de criptografia do Report Server**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Parabéns! Configuramos com sucesso o Reporting Services usando o Configuration Manager. Se você acessar a URL na aba Web Service URL, ela deve mostrar algo semelhante ao seguinte.**
+**Parabéns! Configuramos com sucesso o Reporting Services usando o Configuration Manager. Se você navegar para a URL na aba Web Service URL, deverá mostrar algo semelhante ao seguinte.**
 
 ![todo:image_alt_text](setting-up-reporting-services_11.png)
 
 **Image11:- Acesso ao Report Server após a instalação**
 
-**Motivo do erro: O SharePoint está instalado em nosso WFE e concluímos a configuração do Reporting Services. Neste exemplo, Reporting Services e SharePoint estão em máquinas diferentes. Se estivessem na mesma máquina, você não teria visto esse erro. Precisamos tecnicamente instalar o SharePoint na caixa RS. Isso significa que o IIS também será habilitado.**
+**Motivo do erro: O SharePoint está instalado em nosso WFE e concluímos a configuração do Reporting Services. Neste exemplo, o Reporting Services e o SharePoint estão em máquinas diferentes. Se estivessem na mesma máquina, você não teria visto esse erro. Precisamos, tecnicamente, instalar o SharePoint na caixa RS. Isso significa que o IIS também será habilitado.**
 {{% /alert %}}
-
 

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
@@ -1,10 +1,10 @@
 ---
 title: Configurando o Reporting Services
-linktitle: Configurando o Reporting Services
+linktitle: Setting up Reporting Services
 type: docs
 weight: 20
-url: /pt/reportingservices/setting-up-reporting-services/
-lastmod: "2026-07-29"
+url: /reportingservices/setting-up-reporting-services/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
@@ -15,86 +15,86 @@ Nossa primeira parada no Reporting Services Server é o Reporting Services Confi
 
 ## Conta de serviço:
 
-**Certifique‑se de entender qual conta de serviço você está usando para o Reporting Services. Se encontrarmos problemas, eles podem estar relacionados à conta de serviço que você está usando. O padrão é Network Service. Quando vamos implantar novas compilações, sempre usamos contas de domínio, porque é aí que provavelmente encontraremos problemas. Para esta instância do servidor, usamos uma conta de domínio chamada RSService.**
+**Certifique-se de entender qual conta de serviço você está usando para o Reporting Services. Se tivermos problemas, isso pode estar relacionado à conta de serviço que você está usando. O padrão é Serviço de Rede. Quando vamos implantar novas compilações, sempre usamos contas de domínio, porque é aí que provavelmente encontraremos problemas. Para esta instância de servidor, usamos uma conta de domínio chamada RSService.**
 
-![todo:image_alt_text](setting-up-reporting-services_1.png)
+![Set Up](setting-up-reporting-services_1.png)
 
-**Image1:- Configurando conta de serviço**
+**Imagem1: – Configurando conta de serviço**
 
-## URL do Serviço Web:
+## URL do serviço web:
 
 {{% alert color="primary" %}}
 
-**Precisaremos configurar a URL do Serviço Web. Este é o diretório virtual (vdir) do ReportServer que hospeda os Serviços Web usados pelo Reporting Services, e com o qual o SharePoint se comunicará. A menos que você queira personalizar as propriedades do vdir (ou seja, SSL, portas, cabeçalhos de host, etc…), você deve simplesmente clicar em Aplicar aqui e estará pronto para usar.**
-![todo:image_alt_text](setting-up-reporting-services_2.png)
+**Precisaremos configurar a URL do serviço Web. Este é o diretório virtual ReportServer (vdir) que hospeda os serviços Web Reporting Services usados ​​e com o qual o SharePoint se comunicará. A menos que você queira personalizar as propriedades do vdir (ou seja, SSL, portas, cabeçalhos de host, etc.), basta clicar em Aplicar aqui e pronto.**
+![Web Service URL](setting-up-reporting-services_2.png)
 
-**Imagem2:- Configurando a URL do Serviço Web Uma vez que a URL do serviço Web tenha sido configurada, você deverá ser capaz de ver os seguintes resultados**
+**Imagem2: - Configurando o URL do serviço da Web Depois que o URL do serviço da Web for configurado, você poderá ver os seguintes resultados **
 
-![todo:image_alt_text](setting-up-reporting-services_3.png)
+![Web Service URL Results](setting-up-reporting-services_3.png)
 
-**Imagem3:- Configuração bem-sucedida da URL do serviço Web**
+**Imagem3: - Configuração bem-sucedida do URL do serviço Web**
 {{% /alert %}}
 
 ## Banco de dados:
 
-**Precisamos criar o Banco de Dados do Catálogo do Reporting Services. Ele pode ser colocado em qualquer mecanismo de banco de dados SQL 2008 ou SQL 2008 R2. O SQL11 também funcionaria bem, mas ainda está em BETA. Essa ação criará dois bancos de dados, ReportServer e ReportServerTempDB, por padrão.**
+**Precisamos criar o banco de dados do catálogo do Reporting Services. Isso pode ser colocado em qualquer Mecanismo de Banco de Dados SQL 2008 ou SQL 2008 R2. SQL11 também funcionaria bem, mas ainda está em BETA. Esta ação criará dois bancos de dados, ReportServer e ReportServerTempDB, por padrão.**
 
 {{% alert color="primary" %}}
-**A outra etapa importante aqui é garantir que você escolha SharePoint Integrated para o tipo de banco de dados. Depois que essa escolha for feita, não poderá ser alterada.**
+**A outra etapa importante é certificar-se de escolher SharePoint Integrado para o tipo de banco de dados. Uma vez feita esta escolha, ela não poderá ser alterada.**
 
-![todo:image_alt_text](setting-up-reporting-services_4.png)
+![Creating Report Server Database](setting-up-reporting-services_4.png)
 
-**Image4:- Criando banco de dados do servidor de relatórios**
+**Imagem4:- Criando banco de dados do servidor de relatório**
 
-![todo:image_alt_text](setting-up-reporting-services_5.png)
+![Setting up Database Server and Authentication Type](setting-up-reporting-services_5.png)
 
-**Image5:- Configurando o servidor de banco de dados e o tipo de autenticação**
+**Imagem5:- Configurando servidor de banco de dados e tipo de autenticação**
 
-![todo:image_alt_text](setting-up-reporting-services_6.png)
+![Setting up Database Name and Mode](setting-up-reporting-services_6.png)
 
-**Image6:- Configurando o nome do banco de dados e o Modo**
+**Imagem6: - Configurando nome e modo do banco de dados**
 {{% /alert %}}
 
-**Para as credenciais, é assim que o Report Server se comunicará com o SQL Server. Qualquer conta que você selecionar receberá certos direitos dentro do banco de dados Catalog, bem como em alguns dos bancos de dados do sistema via RSExecRole. MSDB é um desses bancos de dados para uso de Assinaturas, pois utilizamos o SQL Agent.**
+**Para as credenciais, é assim que o Report Server se comunicará com o SQL Server. Qualquer conta que você selecionar receberá determinados direitos no banco de dados do Catálogo, bem como em alguns bancos de dados do sistema por meio do RSExecRole. MSDB é um desses bancos de dados para uso de assinatura, pois usamos o SQL Agent.**
 
-![todo:image_alt_text](setting-up-reporting-services_7.png)
+![Setting up Report Server database credentials](setting-up-reporting-services_7.png)
 
-**Image7:- Configurando as credenciais do banco de dados do Report Server**
+**Imagem7: - Configurando credenciais do banco de dados do Report Server**
 
 {{% alert color="primary" %}}
 
-**Depois que as credenciais do banco de dados forem especificadas, devemos ser capazes de obter os resultados conforme especificado abaixo.**
+**Depois que as credenciais do banco de dados forem especificadas, poderemos obter os resultados conforme especificado abaixo.**
 
-![todo:image_alt_text](setting-up-reporting-services_8.png)
+![Report Server database creation progress](setting-up-reporting-services_8.png)
 
-**Image8:- Progresso da criação do banco de dados do Report Server**
+**Imagem8: - Progresso da criação do banco de dados do Servidor de Relatórios**
 
-![todo:image_alt_text](setting-up-reporting-services_9.png)
+![Report Server database completion summary](setting-up-reporting-services_9.png)
 
-**Image9:- Resumo da conclusão do banco de dados do Report Server**
+**Imagem9: - Resumo de conclusão do banco de dados do Report Server**
 {{% /alert %}}
 
-## URL do Gerenciador de Relatórios:
+## URL do gerenciador de relatórios:
 
-**Podemos ignorar o URL do Report Manager, pois ele não é usado quando estamos no modo SharePoint Integrated. O SharePoint é nossa interface frontal. O Report Manager não funciona.**
+**Podemos ignorar o URL do Report Manager, pois ele não é usado quando estamos no modo integrado do SharePoint. SharePoint é nosso front-end. O Gerenciador de relatórios não funciona.**
 
-## Chaves de Criptografia:
+## Chaves de criptografia:
 
 {{% alert color="primary" %}}
-**Faça backup das suas chaves de criptografia e certifique-se de saber onde as guarda. Se você se deparar com uma situação em que precise migrar o Banco de Dados ou restaurá‑lo, precisará delas.**
+**Faça backup de suas chaves de criptografia e certifique-se de saber onde as guarda. Se você se encontrar em uma situação em que precise migrar o banco de dados ou restaurá-lo, você precisará deles.**
 
-![todo:image_alt_text](setting-up-reporting-services_10.png)
+![Report Server Encryption key backup](setting-up-reporting-services_10.png)
 
-**Image10:- Backup da chave de criptografia do Report Server**
+**Imagem10: - Backup da chave de criptografia do servidor de relatório**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Parabéns! Configuramos com sucesso o Reporting Services usando o Configuration Manager. Se você navegar para a URL na aba Web Service URL, deverá mostrar algo semelhante ao seguinte.**
+**Parabéns! Configuramos o Reporting Services com êxito usando o Configuration Manager. Se você navegar até o URL na guia URL do serviço Web, ele deverá mostrar algo semelhante ao seguinte.**
 
-![todo:image_alt_text](setting-up-reporting-services_11.png)
+![Report Server access after installation](setting-up-reporting-services_11.png)
 
-**Image11:- Acesso ao Report Server após a instalação**
+**Imagem11:- Reportar acesso ao servidor após instalação**
 
-**Motivo do erro: O SharePoint está instalado em nosso WFE e concluímos a configuração do Reporting Services. Neste exemplo, o Reporting Services e o SharePoint estão em máquinas diferentes. Se estivessem na mesma máquina, você não teria visto esse erro. Precisamos, tecnicamente, instalar o SharePoint na caixa RS. Isso significa que o IIS também será habilitado.**
+**Motivo do erro: o SharePoint está instalado em nosso WFE e concluímos a configuração do Reporting Services. Neste exemplo, o Reporting Services e o SharePoint estão em máquinas diferentes. Se eles estivessem na mesma máquina, você não teria visto esse erro. Tecnicamente, precisamos instalar o SharePoint no RS Box. Isso significa que o IIS também estará habilitado.**
 {{% /alert %}}
 

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
@@ -1,49 +1,49 @@
 ---
-title: Configurando o SharePoint no servidor do Reporting Services
-linktitle: Configurando o SharePoint no servidor do Reporting Services
+title: Configurando o SharePoint no Reporting Services Server
+linktitle: Setting up SharePoint on Reporting Services Server
 type: docs
 weight: 30
-url: /pt/reportingservices/setting-up-sharepoint-on-reporting-services-server/
-lastmod: "2026-07-29"
+url: /reportingservices/setting-up-sharepoint-on-reporting-services-server/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Agora precisamos executar etapas semelhantes às que fizemos para o SharePoint WFE. A primeira coisa é passar pela instalação dos pré-requisitos Prereq uisites e, quando concluída, iniciar a configuração do SharePoint.
+Agora precisamos executar etapas semelhantes às que fizemos para o WFE do SharePoint. A primeira coisa é passar pela instalação dos pré-requisitos e, quando terminar, iniciar a configuração do SharePoint.
 
 {{% /alert %}}
 
-Para a configuração, eu escolho Server Farm e uma instalação completa para combinar com a minha SharePoint Box, pois não quero uma instalação autônoma para SharePoint.
+Para a configuração, escolho Server Farm e uma instalação completa para corresponder ao meu SharePoint Box, pois não quero uma instalação autônoma para o SharePoint.
 
 ## Configuração do SharePoint
 
 {{% alert color="primary" %}}
 
-**No Assistente de Configuração do SharePoint, queremos conectar a uma fazenda existente.**
+**No Assistente de Configuração do SharePoint, queremos nos conectar a um farm existente.**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_1.png)
+![Assistente de configuração do SharePoint](setting-up-sharepoint-on-reporting-services-server_1.png)
 
-**Image1:- Assistente de configuração do SharePoint**
+**Imagem1:- Assistente de configuração do SharePoint**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**Em seguida, apontaremos para o banco de dados SharePoint_Config que nossa fazenda está usando. Se você não souber onde isso está, pode descobrir através do Central Admin em Configurações do Sistema -> Gerenciar Servidores nesta fazenda.**
+**Em seguida, apontaremos para o banco de dados SharePoint_Config que nosso farm está usando. Se você não sabe onde fica, você pode descobrir através do Central Admin em Configurações do Sistema -> Servidores Gerenciadores neste farm.**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_2.png)
+![Banco de dados de configuração do SharePoint](setting-up-sharepoint-on-reporting-services-server_2.png)
 
-**Image2:- Especificar configurações de banco de dados**
+**Imagem2:- Especifique as configurações do banco de dados**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_3.png)
+![Assistente de configuração do SharePoint](setting-up-sharepoint-on-reporting-services-server_3.png)
 
-**Image3:- Assistente de configuração do SharePoint**
+**Imagem3:- Assistente de configuração do SharePoint**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**Uma vez que o assistente seja concluído, isso é tudo o que precisamos fazer na caixa do Report Server por enquanto. Voltando para a URL do ReportServer, veremos outro erro, mas isso ocorre porque ainda não a configuramos através do Central Administrator.**
+**Depois que o assistente estiver concluído, isso é tudo que precisamos fazer na Caixa do Servidor de Relatórios por enquanto. Voltando à URL do ReportServer, veremos outro erro, mas é porque não o configuramos através do Administrador Central.**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_4.png)
+![Erro de configuração do SharePoint](setting-up-sharepoint-on-reporting-services-server_4.png)
 
-**Image4:- Erro do servidor de relatórios**
+**Imagem4:- Reportar erro do servidor**
 {{% /alert %}}

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
@@ -1,25 +1,25 @@
 ---
-title: Configurando o SharePoint no servidor Reporting Services
-linktitle: Configurando o SharePoint no servidor Reporting Services
+title: Configurando o SharePoint no servidor do Reporting Services
+linktitle: Configurando o SharePoint no servidor do Reporting Services
 type: docs
 weight: 30
 url: /pt/reportingservices/setting-up-sharepoint-on-reporting-services-server/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Agora precisamos executar etapas semelhantes às que fizemos para o SharePoint WFE. A primeira coisa é passar pela instalação dos pré-requisitos do uisites e, quando isso terminar, iniciar a configuração do SharePoint.
+Agora precisamos executar etapas semelhantes às que fizemos para o SharePoint WFE. A primeira coisa é passar pela instalação dos pré-requisitos Prereq uisites e, quando concluída, iniciar a configuração do SharePoint.
 
 {{% /alert %}}
 
-Para a configuração, escolho Farm de Servidores e uma instalação completa para corresponder à minha SharePoint Box, pois não quero uma instalação standalone para o SharePoint.
+Para a configuração, eu escolho Server Farm e uma instalação completa para combinar com a minha SharePoint Box, pois não quero uma instalação autônoma para SharePoint.
 
 ## Configuração do SharePoint
 
 {{% alert color="primary" %}}
 
-**No Assistente de Configuração do SharePoint, queremos conectar a uma farm existente.**
+**No Assistente de Configuração do SharePoint, queremos conectar a uma fazenda existente.**
 
 ![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_1.png)
 
@@ -28,7 +28,7 @@ Para a configuração, escolho Farm de Servidores e uma instalação completa pa
 
 {{% alert color="primary" %}}
 
-**Em seguida, apontaremos para o banco de dados SharePoint_Config que nossa fazenda está usando. Se você não souber onde ele está, pode descobrir através do Central Admin em Configurações do Sistema -> Gerenciar Servidores nesta fazenda.**
+**Em seguida, apontaremos para o banco de dados SharePoint_Config que nossa fazenda está usando. Se você não souber onde isso está, pode descobrir através do Central Admin em Configurações do Sistema -> Gerenciar Servidores nesta fazenda.**
 
 ![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_2.png)
 
@@ -41,10 +41,9 @@ Para a configuração, escolho Farm de Servidores e uma instalação completa pa
 
 {{% alert color="primary" %}}
 
-**Uma vez que o assistente terminou, isso é tudo que precisamos fazer na caixa do Report Server por enquanto. Voltando para a URL do ReportServer, veremos outro erro, mas isso ocorre porque ainda não o configuramos através do Central Administrator.**
+**Uma vez que o assistente seja concluído, isso é tudo o que precisamos fazer na caixa do Report Server por enquanto. Voltando para a URL do ReportServer, veremos outro erro, mas isso ocorre porque ainda não a configuramos através do Central Administrator.**
 
 ![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_4.png)
 
-**Image4:- Erro do servidor de relatório**
+**Image4:- Erro do servidor de relatórios**
 {{% /alert %}}
-


### PR DESCRIPTION
## Summary
- rebuild pt/reportingservices from en/reportingservices
- regenerate Markdown translations with the Hugo translation CLI
- preserve the locale asset set and backfill five CLI restoration failures from the existing Portuguese pages to keep the folder complete

## Validation
- matched English eportingservices file and Markdown counts
- checked that no @@DOC_TRANSLATE_ placeholders remain
