### PR TITLE
Translate reportingservices to Indonesian

### DIFF
--- a/id/reportingservices/_index.md
+++ b/id/reportingservices/_index.md
@@ -1,13 +1,13 @@
 ---
 title: Dokumentasi
-linktitle:  Aspose.PDF untuk Reporting Services
+linktitle:  Aspose.PDF for Reporting Services
 second_title: Aspose.PDF for Reporting Services
 type: docs
 weight: 120
 url: /id/reportingservices/
-description: Temukan Aspose.PDF for Reporting Services. Buat laporan PDF langsung dari SQL Server Reporting Services (SSRS) dengan penyesuaian lanjutan.
+description: Temukan Aspose.PDF for Reporting Services. Hasilkan laporan PDF langsung dari SQL Server Reporting Services (SSRS) dengan kustomisasi lanjutan.
 is_root: true
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
@@ -22,27 +22,26 @@ Microsoft SQL Server Reporting Services memenuhi kebutuhan yang dimiliki banyak 
 
 ## Topik
 
-- [Ikhtisar Produk](/pdf/id/reportingservices/product-overview/)
+- [Gambaran Produk](/pdf/id/reportingservices/product-overview/)
 - [Format File yang Didukung](/pdf/id/reportingservices/supported-file-formats/)
 - [Fitur](/pdf/id/reportingservices/features/)
-- [Galeri Laporan Contoh](/pdf/id/reportingservices/sample-reports-gallery/)
-- [Instal Aspose.Pdf untuk Reporting Services](/pdf/id/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [Lisensi Aspose.Pdf untuk Reporting Services](/pdf/id/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [Konfigurasikan Aspose.Pdf untuk Reporting Services](/pdf/id/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [Galeri Contoh Laporan](/pdf/id/reportingservices/sample-reports-gallery/)
+- [Instal Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [Lisensi Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [Konfigurasikan Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/configure-aspose-pdf-for-reporting-services/)
 - [Perluas Properti Item Laporan](/pdf/id/reportingservices/expand-report-items-properties/)
-- [Evaluasi Aspose.Pdf untuk Reporting Services](/pdf/id/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
+- [Evaluasi Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
 
-## Sumber Daya Aspose.PDF untuk Reporting Services
+## Aspose.PDF for Reporting Services Sumber Daya
 
-- [Gambaran Produk Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/product-overview/)
-- [Format File yang Didukung Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/supported-file-formats/)
-- [Fitur Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/features/)
-- [Catatan Rilis Aspose.PDF untuk Reporting Services](https://releases.aspose.com/pdf/reportingservices/release-notes/)
-- [Unduh Aspose.PDF untuk Reporting Services](https://releases.aspose.com/pdf/reportingservices/)
-- [Galeri Laporan Contoh Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/sample-reports-gallery/)
-- [Instal Aspose.Pdf untuk Reporting Services](/pdf/id/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [Lisensi Aspose.Pdf untuk Reporting Services](/pdf/id/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [Konfigurasikan Aspose.Pdf untuk Reporting Services](/pdf/id/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [Aspose.PDF for Reporting Services Gambaran Produk](/pdf/id/reportingservices/product-overview/)
+- [Aspose.PDF for Reporting Services Format File yang Didukung](/pdf/id/reportingservices/supported-file-formats/)
+- [Aspose.PDF for Reporting Services Fitur](/pdf/id/reportingservices/features/)
+- [Aspose.PDF for Reporting Services Catatan Rilis](https://releases.aspose.com/pdf/reportingservices/release-notes/)
+- [Unduh Aspose.PDF for Reporting Services](https://releases.aspose.com/pdf/reportingservices/)
+- [Galeri Laporan Contoh Aspose.PDF for Reporting Services](/pdf/id/reportingservices/sample-reports-gallery/)
+- [Instal Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [Lisensi Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [Konfigurasikan Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/configure-aspose-pdf-for-reporting-services/)
 - [Perluas Properti Item Laporan](/pdf/id/reportingservices/expand-report-items-properties/)
-- [Evaluasi Aspose.Pdf untuk Reporting Services](/pdf/id/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
-
+- [Evaluasi Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/evaluate-aspose-pdf-for-reporting-services/)

--- a/id/reportingservices/_index.md
+++ b/id/reportingservices/_index.md
@@ -4,44 +4,44 @@ linktitle:  Aspose.PDF for Reporting Services
 second_title: Aspose.PDF for Reporting Services
 type: docs
 weight: 120
-url: /id/reportingservices/
-description: Temukan Aspose.PDF for Reporting Services. Hasilkan laporan PDF langsung dari SQL Server Reporting Services (SSRS) dengan kustomisasi lanjutan.
+url: /reportingservices/
+description: Temukan Aspose.PDF untuk Layanan Pelaporan. Hasilkan laporan PDF langsung dari SQL Server Reporting Services (SSRS) dengan penyesuaian tingkat lanjut.
 is_root: true
-lastmod: "2026-07-29"
+lastmod: "2024-05-05"
 ---
 
 {{% alert color="primary" %}}
 
-![Logo Aspose.PDF for Reporting Services](home_5.png)
+![Aspose.PDF untuk Logo Layanan Pelaporan](home_5.png)
 
-## Selamat datang di Aspose.PDF for Reporting Services
+## Selamat datang di Aspose.PDF untuk Layanan Pelaporan
 
-Microsoft SQL Server Reporting Services memenuhi kebutuhan yang dimiliki banyak organisasi: kebutuhan untuk membangun solusi intelijen bisnis dan pelaporan. Sampai saat ini, pengembang harus menyematkan laporan ke dalam aplikasi mereka, atau organisasi harus membeli solusi pelaporan pihak ketiga yang mahal dan terkadang bermasalah. Sekarang, Microsoft SQL Server Reporting Services menawarkan solusi lengkap untuk mendistribusikan laporan di seluruh perusahaan; memungkinkan bisnis membuat keputusan yang lebih baik dan lebih cepat.
+Layanan Pelaporan Microsoft SQL Server memenuhi kebutuhan yang dimiliki banyak organisasi: kebutuhan untuk membangun intelijen bisnis dan solusi pelaporan. Hingga saat ini, pengembang diharuskan untuk menyematkan laporan ke dalam aplikasi mereka, atau organisasi diharuskan membeli solusi pelaporan pihak ketiga yang mahal dan terkadang bermasalah. Kini, Layanan Pelaporan Microsoft SQL Server menawarkan solusi lengkap untuk mendistribusikan laporan ke seluruh perusahaan; memungkinkan bisnis untuk membuat keputusan lebih baik dan lebih cepat.
 
 {{% /alert %}}
 
 ## Topik
 
-- [Gambaran Produk](/pdf/id/reportingservices/product-overview/)
+- [Ikhtisar Produk](/pdf/id/reportingservices/product-overview/)
 - [Format File yang Didukung](/pdf/id/reportingservices/supported-file-formats/)
 - [Fitur](/pdf/id/reportingservices/features/)
 - [Galeri Contoh Laporan](/pdf/id/reportingservices/sample-reports-gallery/)
-- [Instal Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [Lisensi Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [Konfigurasikan Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [Instal Aspose.PDF untuk Layanan Pelaporan](/pdf/id/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [Lisensi Aspose.PDF untuk Layanan Pelaporan](/pdf/id/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [Konfigurasikan Aspose.PDF untuk Layanan Pelaporan](/pdf/id/reportingservices/configure-aspose-pdf-for-reporting-services/)
 - [Perluas Properti Item Laporan](/pdf/id/reportingservices/expand-report-items-properties/)
-- [Evaluasi Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
+- [Evaluasi Aspose.PDF untuk Layanan Pelaporan](/pdf/id/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
 
-## Aspose.PDF for Reporting Services Sumber Daya
+## Aspose.PDF untuk Sumber Daya Layanan Pelaporan
 
-- [Aspose.PDF for Reporting Services Gambaran Produk](/pdf/id/reportingservices/product-overview/)
-- [Aspose.PDF for Reporting Services Format File yang Didukung](/pdf/id/reportingservices/supported-file-formats/)
-- [Aspose.PDF for Reporting Services Fitur](/pdf/id/reportingservices/features/)
-- [Aspose.PDF for Reporting Services Catatan Rilis](https://releases.aspose.com/pdf/reportingservices/release-notes/)
-- [Unduh Aspose.PDF for Reporting Services](https://releases.aspose.com/pdf/reportingservices/)
-- [Galeri Laporan Contoh Aspose.PDF for Reporting Services](/pdf/id/reportingservices/sample-reports-gallery/)
-- [Instal Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [Lisensi Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [Konfigurasikan Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [Aspose.PDF untuk Ikhtisar Produk Layanan Pelaporan](/pdf/id/reportingservices/product-overview/)
+- [Aspose.PDF untuk Layanan Pelaporan Format File yang Didukung](/pdf/id/reportingservices/supported-file-formats/)
+- [Aspose.PDF untuk Fitur Layanan Pelaporan](/pdf/id/reportingservices/features/)
+- [Aspose.PDF untuk Catatan Rilis Layanan Pelaporan](https://releases.aspose.com/pdf/reportingservices/release-notes/)
+- [Unduh Aspose.PDF untuk Layanan Pelaporan](https://releases.aspose.com/pdf/reportingservices/)
+- [Contoh Galeri Laporan Aspose.PDF untuk Layanan Pelaporan](/pdf/id/reportingservices/sample-reports-gallery/)
+- [Instal Aspose.PDF untuk Layanan Pelaporan](/pdf/id/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [Lisensi Aspose.PDF untuk Layanan Pelaporan](/pdf/id/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [Konfigurasikan Aspose.PDF untuk Layanan Pelaporan](/pdf/id/reportingservices/configure-aspose-pdf-for-reporting-services/)
 - [Perluas Properti Item Laporan](/pdf/id/reportingservices/expand-report-items-properties/)
-- [Evaluasi Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
+- [Evaluasi Aspose.PDF untuk Layanan Pelaporan](/pdf/id/reportingservices/evaluate-aspose-pdf-for-reporting-services/)

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
@@ -1,15 +1,15 @@
 ---
-title: Konfigurasi
-linktitle: Konfigurasi
+title: Konfigurasikan
+linktitle: Configure
 
 type: docs
 weight: 80
-url: /id/reportingservices/configure-aspose-pdf-for-reporting-services/
-description: Pelajari cara mengkonfigurasi Aspose.PDF for Reporting Services untuk menyesuaikan pengaturan output PDF bagi laporan SSRS Anda secara efisien.
-lastmod: "2026-07-29"
+url: /reportingservices/configure-aspose-pdf-for-reporting-services/
+description: Pelajari cara mengonfigurasi Aspose.PDF untuk Layanan Pelaporan guna menyesuaikan pengaturan keluaran PDF untuk laporan SSRS Anda secara efisien.
+lastmod: "2021-06-05"
 ---
 
 ## Bagian ini mencakup topik-topik berikut:
 
-- [Pengaturan Parameter](/pdf/id/reportingservices/setting-parameters/)
+- [Parameter Pengaturan](/pdf/id/reportingservices/setting-parameters/)
 - [Parameter yang Didukung](/pdf/id/reportingservices/supported-parameters/)

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
@@ -6,11 +6,10 @@ type: docs
 weight: 80
 url: /id/reportingservices/configure-aspose-pdf-for-reporting-services/
 description: Pelajari cara mengkonfigurasi Aspose.PDF for Reporting Services untuk menyesuaikan pengaturan output PDF bagi laporan SSRS Anda secara efisien.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-## Bagian ini mencakup topik berikut:
+## Bagian ini mencakup topik-topik berikut:
 
 - [Pengaturan Parameter](/pdf/id/reportingservices/setting-parameters/)
 - [Parameter yang Didukung](/pdf/id/reportingservices/supported-parameters/)
-

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
@@ -1,27 +1,26 @@
 ---
-title: Setting Parameters
+title: Parameter Pengaturan
 linktitle: Setting Parameters
 type: docs
 weight: 10
-url: /id/reportingservices/setting-parameters/
-description: Pelajari cara mengatur parameter untuk rendering PDF di Aspose.PDF for Reporting Services agar output dapat dikendalikan dengan presisi.
-lastmod: "2026-07-29"
+url: /reportingservices/setting-parameters/
+description: Cari tahu cara mengatur parameter untuk rendering PDF di Aspose.PDF untuk Layanan Pelaporan. Mencapai kontrol yang tepat atas output.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Anda dapat menentukan parameter konfigurasi tertentu yang memengaruhi cara Aspose.PDF for Reporting Services membuat dokumen. Bagian ini menjelaskan proses tersebut.
+Anda dapat menentukan parameter konfigurasi tertentu yang memengaruhi cara Aspose.PDF untuk Layanan Pelaporan menghasilkan dokumen. Bagian ini menjelaskan proses ini.
 
 {{% /alert %}}
 
-Untuk mengonfigurasi Aspose.PDF for Reporting Services, Anda perlu mengedit file `C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config`. Ini adalah file XML, dan konfigurasi renderer berada di dalam elemen ```<Extension>``` yang sesuai dengan renderer Aspose.PDF.
+Untuk mengonfigurasi Aspose.Pdf untuk Layanan Pelaporan, Anda perlu mengedit file `C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config`. Ini adalah file XML dan konfigurasi penyajinya ada di dalam elemen `<Extension>` yang sesuai dengan penyaji Aspose.PDF.
 
-**Example**
+## Contoh
 
-{{< highlight csharp >}}
-
+```xml
 <Render>
-...
+…
 <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
 <!--Insert configuration elements for exporting to PDF here. The following is an example
 For PageOrientation -->
@@ -30,19 +29,18 @@ For PageOrientation -->
     </Configuration>
 </Extension>
 </Render>
-
-{{< /highlight >}}
+```
 
 {{% alert color="primary" %}}
 
-Jika Anda ingin mengatur parameter hanya untuk file laporan tertentu, bukan untuk setiap laporan di server, Anda dapat menambahkan parameter laporan untuk laporan tersebut di Report Builder dengan langkah-langkah berikut (misalnya, kita akan menambahkan parameter `IsLandscape` yang ditunjukkan sebelumnya):
+Jika Anda ingin menetapkan parameter untuk file laporan tertentu namun tidak untuk setiap laporan di server, Anda dapat menambahkan parameter laporan untuk laporan tertentu di Pembuat Laporan dengan langkah-langkah berikut (misalnya, kami akan menambahkan parameter 'IsLandscape' yang ditunjukkan sebelumnya):
 
-1. Buka laporan di Report Designer, klik kanan folder `Parameters` pada panel `Report Data`, lalu pilih `Add Parameter...` (atau, sebagai alternatif, buka daftar `New` lalu pilih `Parameter...`).
- 
-![todo:image_alt_text](setting-parameters_1.png)
+1. Buka laporan di Perancang Laporan, klik kanan folder 'Parameter' di panel 'Data Laporan', dan pilih 'Tambahkan Parameter…' (atau, sebagai alternatif, tarik daftar 'Baru' dan pilih 'Parameter…').
 
-1. Di dialog `Report Parameter Properties`, buat parameter bernama `IsLandscape`, pilih tipe data Boolean, lalu tambahkan nilai True pada tab `Default Values`.
+![Parameters set up. Step 1](setting-parameters_1.png)
 
-![todo:image_alt_text](setting-parameters_2.png)
+1. Dalam dialog 'Report Parameter Properties', buat parameter bernama 'IsLandscape', dengan tipe data Boolean, dan tambahkan nilai True di tab 'Default Values'.
+
+![Parameters set up. Step 2](setting-parameters_2.png)
 
 {{% /alert %}}

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
@@ -1,22 +1,22 @@
 ---
-title: Mengatur Parameter
-linktitle: Mengatur Parameter
+title: Setting Parameters
+linktitle: Setting Parameters
 type: docs
 weight: 10
-url: /id/reportingservices/setting-parameters/
-description: Cari tahu cara mengatur parameter untuk render PDF di Aspose.PDF untuk Reporting Services. Capai kontrol yang tepat atas output.
-lastmod: "2026-06-19"
+url: /reportingservices/setting-parameters/
+description: Find out how to set parameters for PDF rendering in Aspose.PDF for Reporting Services. Achieve precise control over output.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Anda dapat menentukan parameter konfigurasi tertentu yang memengaruhi bagaimana Aspose.Pdf untuk Reporting Services menghasilkan dokumen. Bagian ini menjelaskan proses tersebut.
+You can specify certain configuration parameters that affect how Aspose.PDF for Reporting Services generates documents. This section describes this process.
 
 {{% /alert %}}
 
-Untuk mengkonfigurasi Aspose.Pdf untuk Reporting Services, Anda perlu mengedit file C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config. Ini adalah file XML dan konfigurasi renderer berada di dalamnya. ```<Extension>``` elemen yang sesuai dengan renderer Aspose.PDF.
+To configure Aspose.PDF for Reporting Services, you need to edit the C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config file. This is an XML file and the renderer configuration is inside the ```<Extension>``` element corresponding to the Aspose.PDF renderer.
 
-**Contoh**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -35,15 +35,14 @@ For PageOrientation -->
 
 {{% alert color="primary" %}}
 
-Jika Anda ingin mengatur parameter untuk file laporan tertentu tetapi tidak untuk setiap laporan di server, Anda dapat menambahkan parameter laporan untuk laporan tertentu di Report Builder dengan langkah-langkah berikut (misalnya, kami akan menambahkan parameter ‘IsLandscape’ yang ditunjukkan sebelumnya):
+If you want to set parameters for specific report file but not for every report on the server, you can add a report parameter for the specific report in the Report Builder as the following steps (for example, we’ll add an 'IsLandscape' parameter shown earlier):
 
-1. Buka laporan di Report Designer, klik kanan pada folder ‘Parameters’ di panel ‘Report Data’, dan pilih ‘Add Parameter…’ (atau, alternatifnya, tarik turun daftar ‘New’ dan pilih ‘Parameter…’).
+1. Open the report in the Report Designer, right-click on the 'Parameters' folder in the 'Report Data' pane, and select 'Add Parameter…' (or, alternately, pull down the 'New' list and select 'Parameter…').
  
 ![todo:image_alt_text](setting-parameters_1.png)
 
-1. Dalam dialog ‘Report Parameter Properties’, buat parameter dengan nama ‘IsLandscape’, dengan tipe data Boolean, dan tambahkan nilai True pada tab ‘Default Values’.
+1. In the 'Report Parameter Properties' dialog, create the parameter named 'IsLandscape', with the data type of Boolean, and add the value True in the 'Default Values' tab.
 
 ![todo:image_alt_text](setting-parameters_2.png)
 
 {{% /alert %}}
-

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
@@ -1,27 +1,25 @@
 ---
 title: Parameter yang Didukung
-linktitle: Parameter yang Didukung
+linktitle: Supported Parameters
 type: docs
 weight: 20
-url: /id/reportingservices/supported-parameters/
-description: Jelajahi parameter yang didukung dalam Aspose.PDF for Reporting Services untuk mengendalikan dan menyesuaikan rendering PDF Anda dengan mudah.
-lastmod: "2026-07-29"
+url: /reportingservices/supported-parameters/
+description: Jelajahi parameter yang didukung di Aspose.PDF untuk Layanan Pelaporan guna mengontrol dan menyesuaikan rendering PDF Anda dengan mudah.
+lastmod: "2021-06-05"
 ---
 
-Laporan yang diparameterkan adalah laporan yang menerima nilai masukan yang digunakan dalam pemrosesan laporan. Dengan laporan yang diparameterkan, Anda dapat mengubah output laporan berdasarkan nilai yang ditetapkan saat laporan dijalankan. Aspose.PDF for Reporting Services mendukung dua jenis parameter: parameter server laporan dan parameter laporan. Parameter server laporan digunakan untuk semua laporan di server laporan. Jika Anda ingin membuat beberapa parameter cocok untuk laporan tertentu, Anda harus menggunakan parameter laporan.
+Laporan berparameter adalah laporan yang menerima nilai masukan yang digunakan dalam pemrosesan laporan. Dengan laporan berparameter, Anda dapat memvariasikan output laporan berdasarkan nilai yang ditetapkan saat laporan dijalankan. Aspose.PDF untuk Layanan Pelaporan mendukung dua jenis parameter: parameter server laporan dan parameter laporan. Parameter server laporan digunakan untuk semua laporan di server laporan. Jika Anda ingin membuat beberapa parameter sesuai untuk laporan tertentu, Anda harus menggunakan parameter laporan.
 
-Saat ini, renderer Aspose.Pdf mendukung berbagai macam parameter, seperti:
+Saat ini, penyaji Aspose.Pdf mendukung berbagai parameter, seperti:
 
 **Bagian ini mencakup topik berikut:**
 
 - [Orientasi Halaman](/pdf/id/reportingservices/page-orientation/)
 - [Pemformatan HTML](/pdf/id/reportingservices/html-formatting/)
 - [Pengaturan Keamanan](/pdf/id/reportingservices/security-setting/)
-- [ApakahFontTertanam](/pdf/id/reportingservices/isfontembedded/)
-- [UkuranHalaman](/pdf/id/reportingservices/pagesize/)
+- [IsFont Tertanam](/pdf/id/reportingservices/isfontembedded/)
+- [Ukuran Halaman](/pdf/id/reportingservices/pagesize/)
 - [Ukuran margin halaman](/pdf/id/reportingservices/page-margin-size/)
 - [Metadata XMP](/pdf/id/reportingservices/xmp-metadata/)
 - [Informasi Debug](/pdf/id/reportingservices/debug-information/)
-- [Kesesuaian PDF_A](/pdf/id/reportingservices/pdf_a-conformance/)
-
-
+- [PDF_A Kesesuaian](/pdf/id/reportingservices/pdf_a-conformance/)

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
@@ -4,11 +4,11 @@ linktitle: Parameter yang Didukung
 type: docs
 weight: 20
 url: /id/reportingservices/supported-parameters/
-description: Jelajahi parameter yang didukung dalam Aspose.PDF for Reporting Services untuk mengontrol dan menyesuaikan rendering PDF Anda dengan mudah.
-lastmod: "2026-06-19"
+description: Jelajahi parameter yang didukung dalam Aspose.PDF for Reporting Services untuk mengendalikan dan menyesuaikan rendering PDF Anda dengan mudah.
+lastmod: "2026-07-29"
 ---
 
-Laporan yang diparameterisasi adalah laporan yang menerima nilai masukan yang digunakan dalam pemrosesan laporan. Dengan laporan yang diparameterisasi, Anda dapat mengubah output laporan berdasarkan nilai yang ditetapkan saat laporan dijalankan. Aspose.Pdf for Reporting Services mendukung dua jenis parameter: parameter server laporan dan parameter laporan. Parameter server laporan digunakan untuk semua laporan di server laporan. Jika Anda ingin membuat beberapa parameter sesuai untuk laporan tertentu, Anda harus menggunakan parameter laporan.
+Laporan yang diparameterkan adalah laporan yang menerima nilai masukan yang digunakan dalam pemrosesan laporan. Dengan laporan yang diparameterkan, Anda dapat mengubah output laporan berdasarkan nilai yang ditetapkan saat laporan dijalankan. Aspose.PDF for Reporting Services mendukung dua jenis parameter: parameter server laporan dan parameter laporan. Parameter server laporan digunakan untuk semua laporan di server laporan. Jika Anda ingin membuat beberapa parameter cocok untuk laporan tertentu, Anda harus menggunakan parameter laporan.
 
 Saat ini, renderer Aspose.Pdf mendukung berbagai macam parameter, seperti:
 
@@ -17,12 +17,11 @@ Saat ini, renderer Aspose.Pdf mendukung berbagai macam parameter, seperti:
 - [Orientasi Halaman](/pdf/id/reportingservices/page-orientation/)
 - [Pemformatan HTML](/pdf/id/reportingservices/html-formatting/)
 - [Pengaturan Keamanan](/pdf/id/reportingservices/security-setting/)
-- [IsFontEmbedded](/pdf/id/reportingservices/isfontembedded/)
+- [ApakahFontTertanam](/pdf/id/reportingservices/isfontembedded/)
 - [UkuranHalaman](/pdf/id/reportingservices/pagesize/)
 - [Ukuran margin halaman](/pdf/id/reportingservices/page-margin-size/)
 - [Metadata XMP](/pdf/id/reportingservices/xmp-metadata/)
 - [Informasi Debug](/pdf/id/reportingservices/debug-information/)
 - [Kesesuaian PDF_A](/pdf/id/reportingservices/pdf_a-conformance/)
-
 
 

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
@@ -1,36 +1,38 @@
 ---
 title: Informasi Debug
-linktitle: Informasi Debug
+linktitle: Debug Information
 type: docs
 weight: 90
-url: /id/reportingservices/debug-information/
-description: Akses dan analisis informasi debug untuk rendering PDF di Aspose.PDF for Reporting Services guna memecahkan masalah secara efektif.
-lastmod: "2026-07-29"
+url: /reportingservices/debug-information/
+description: Akses dan analisis informasi debug untuk rendering PDF di Aspose.PDF untuk Layanan Pelaporan guna memecahkan masalah secara efektif.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Tidak dapat dihindari bahwa ada sesuatu yang salah dengan rendering atau hasil rendering. Karena beberapa alasan seperti kerahasiaan atau privasi, kami tidak dapat memperoleh sumber data yang digunakan dalam laporan pengguna, sehingga tidak dapat mereproduksi kesalahan dalam laporan tersebut. Untuk mempermudah dan memperlancar komunikasi antara pelanggan dan pengembang, kami menambahkan parameter ini. Jika Anda mengalami masalah saat merender laporan Anda dengan Aspose.PDF for Reporting Services, silakan atur parameter laporan ini, maka Anda akan mendapatkan dokumen yang dirender dalam format XML. Setelah itu, harap unggah file XML tersebut kepada kami di forum produk.
+Tidak dapat dipungkiri jika ada yang salah pada rendering atau hasil yang dirender. Karena beberapa alasan seperti kerahasiaan atau privasi, kami tidak dapat menggunakan sumber data dalam laporan pengguna, sehingga tidak dapat mereproduksi kesalahan dalam laporan. Untuk membuat komunikasi antara pelanggan dan pengembang lebih mudah dan lancar, kami menambahkan parameter ini. Jika Anda menemui kendala saat merender laporan Anda dengan Aspose.PDF untuk Reporting Services, silakan atur parameter laporan ini, maka Anda akan mendapatkan dokumen yang dirender dengan format XML. Setelah itu, silakan posting file XML untuk kami di forum produk.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Nama Parameter**: SavingXmlFormat  
-**Tipe Tanggal**: Boolean  
-**Nilai yang didukung**: True, False (default)  
 
-**Contoh**
-{{< highlight csharp >}}
+```txt
+Parameter Name: SavingXmlFormat
+Date Type: Boolean  
+Values supported**: True, False (default)
+```
 
+## Contoh
+
+```xml
 <Render>
 ...
 <Extension Name="APPDF" Type=" Aspose.PDF.ReportingServices.Renderer,Aspose.PDF.ReportingServices">
 <Configuration>
-<SavingXmlFormat > Benar </SavingXmlFormat>
+<SavingXmlFormat > True </SavingXmlFormat>
 </Configuration>
 </Extension>
 </Render>
-
-{{< /highlight >}}
+```
 
 {{% /alert %}}

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
@@ -4,19 +4,19 @@ linktitle: Informasi Debug
 type: docs
 weight: 90
 url: /id/reportingservices/debug-information/
-description: Akses dan analisis informasi debug untuk rendering PDF di Aspose.PDF for Reporting Services untuk memperbaiki masalah secara efektif.
-lastmod: "2026-06-19"
+description: Akses dan analisis informasi debug untuk rendering PDF di Aspose.PDF for Reporting Services guna memecahkan masalah secara efektif.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Tidak dapat dihindari bahwa ada sesuatu yang salah dengan proses rendering atau hasil yang dirender. Karena beberapa alasan seperti kerahasiaan atau privasi, kami tidak dapat memperoleh sumber data yang digunakan dalam laporan pengguna, sehingga tidak dapat mereproduksi kesalahan dalam laporan tersebut. Untuk mempermudah dan memperlancar komunikasi antara pelanggan dan pengembang, kami menambahkan parameter ini. Jika Anda mengalami masalah saat merender laporan Anda dengan Aspose.PDF for Reporting Services, silakan tetapkan parameter laporan ini, maka Anda akan menerima dokumen yang dirender dalam format XML. Setelah itu, harap unggah file XML tersebut untuk kami di forum produk.
+Tidak dapat dihindari bahwa ada sesuatu yang salah dengan rendering atau hasil rendering. Karena beberapa alasan seperti kerahasiaan atau privasi, kami tidak dapat memperoleh sumber data yang digunakan dalam laporan pengguna, sehingga tidak dapat mereproduksi kesalahan dalam laporan tersebut. Untuk mempermudah dan memperlancar komunikasi antara pelanggan dan pengembang, kami menambahkan parameter ini. Jika Anda mengalami masalah saat merender laporan Anda dengan Aspose.PDF for Reporting Services, silakan atur parameter laporan ini, maka Anda akan mendapatkan dokumen yang dirender dalam format XML. Setelah itu, harap unggah file XML tersebut kepada kami di forum produk.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 **Nama Parameter**: SavingXmlFormat  
-**Tipe Data**: Boolean  
+**Tipe Tanggal**: Boolean  
 **Nilai yang didukung**: True, False (default)  
 
 **Contoh**
@@ -26,7 +26,7 @@ Tidak dapat dihindari bahwa ada sesuatu yang salah dengan proses rendering atau 
 ...
 <Extension Name="APPDF" Type=" Aspose.PDF.ReportingServices.Renderer,Aspose.PDF.ReportingServices">
 <Configuration>
-<SavingXmlFormat > True </SavingXmlFormat>
+<SavingXmlFormat > Benar </SavingXmlFormat>
 </Configuration>
 </Extension>
 </Render>
@@ -34,4 +34,3 @@ Tidak dapat dihindari bahwa ada sesuatu yang salah dengan proses rendering atau 
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
@@ -1,35 +1,35 @@
 ---
-title: Pemformatan HTML
-linktitle: Pemformatan HTML
+title: HTML Formatting
+linktitle: HTML Formatting
 type: docs
 weight: 20
-url: /id/reportingservices/html-formatting/
-description: Aktifkan pemformatan HTML dalam laporan PDF menggunakan Aspose.PDF for Reporting Services. Tambahkan gaya dan struktur dengan mudah.
-lastmod: "2026-06-19"
+url: /reportingservices/html-formatting/
+description: Enable HTML formatting in PDF reports using Aspose.PDF for Reporting Services. Add styles and structure with ease.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Kadang-kadang Anda mungkin ingin mengekspor teks dalam kotak teks dengan pemformatan. Sayangnya, Reporting Services tidak mendukung hal ini. Namun, Anda masih dapat melakukannya menggunakan Aspose.PDF for Reporting Services. Cukup aktifkan mode khusus di mana semua teks dalam kotak teks diperlakukan sebagai HTML dan masukkan tag HTML yang diperlukan untuk memformat teks dalam dokumen keluaran. Misalnya, untuk memiliki teks normal, tebal, dan miring dalam kotak teks yang sama, masukkan nilai kotak teks berikut:
+Sometimes you might wish to export text in textboxes with formatting. Unfortunately, Reporting Services does not support this. However, you still can implement it using Aspose.PDF for Reporting Services. Just enable a special mode in which all text in textboxes is treated as HTML and put the necessary HTML tags to format the text in the output document. For example, to have normal, bold and italic text in the same textbox, enter the following textbox value:
 
-Sebagian teks ini adalah ```<b>bold</b>``` dan teks lainnya adalah ```<i>italic</i>```.
+Some of this text is ```<b>bold</b>``` and other text is ```<i>italic</i>```.
 
-Saat diekspor, teks akan terlihat seperti sebagian dari teks ini **bold** dan teks lainnya *italic*.
+When exported, the text will look like as some of this text is **bold** and other text is *italic*.
 
-Harap perhatikan bahwa pendekatan ini memiliki beberapa keterbatasan
+Please note that this approach has some limitations
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-- Pemformatan tidak terlihat pada waktu desain (di Report Builder, portal web Reporting Services, dll.). Sebaliknya, Anda akan melihat teks HTML dalam bentuk teks biasa dengan tag.
-- Ekstensi render Aspose.PDF untuk Reporting Services mengenali dan memformat kode HTML dengan benar di kotak teks. Renderer PDF default dari Reporting Services akan mengekspor markup ini sebagai teks biasa.
+- The formatting isn’t visible in design time (in the Report Builder, Reporting Services web portal etc.). Instead, you will see the HTML text in form of plain text with tags.
+- Aspose.PDF for Reporting Services rendering extension recognizes and properly formats HTML code in textboxes. The default PDF renderer of Reporting Services will export this markup as plain text.
 
-**Nama Parameter**: IsHtmlTagSupported  
-**Tipe Data**: Boolean  
-**Nilai yang didukung**: True, False (default)   
+**Parameter Name**: IsHtmlTagSupported  
+**Date Type**: Boolean  
+**Values supported**: True, False (default)   
 
-**Contoh**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -44,10 +44,9 @@ Harap perhatikan bahwa pendekatan ini memiliki beberapa keterbatasan
 
 {{< /highlight >}}
 
-Jika Anda ingin menambahkan parameter ini di Report Designer, gunakan tipe data 'Boolean'.
+If you want to add this parameter in the Report Designer, use the 'Boolean' data type.
 
  
-Saat ini Aspose.Pdf for Reporting Services mendukung sebagian subset dari semua tag HTML. Anda dapat menemukan informasi lebih lanjut di Aspose.PDF [Dokumentasi](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
+Currently Aspose.PDF for Reporting Services supports a subset of all the HTML tags. You may find more information in the Aspose.PDF [Documentation](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
 
 {{% /alert %}}
-

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
@@ -1,39 +1,40 @@
 ---
-title: HTML Formatting
+title: Pemformatan HTML
 linktitle: HTML Formatting
 type: docs
 weight: 20
 url: /reportingservices/html-formatting/
-description: Enable HTML formatting in PDF reports using Aspose.PDF for Reporting Services. Add styles and structure with ease.
+description: Aktifkan pemformatan HTML dalam laporan PDF menggunakan Aspose.PDF untuk Layanan Pelaporan. Tambahkan gaya dan struktur dengan mudah.
 lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Sometimes you might wish to export text in textboxes with formatting. Unfortunately, Reporting Services does not support this. However, you still can implement it using Aspose.PDF for Reporting Services. Just enable a special mode in which all text in textboxes is treated as HTML and put the necessary HTML tags to format the text in the output document. For example, to have normal, bold and italic text in the same textbox, enter the following textbox value:
+Terkadang Anda mungkin ingin mengekspor teks dalam kotak teks dengan pemformatan. Sayangnya, Layanan Pelaporan tidak mendukung hal ini. Namun, Anda masih bisa menerapkannya menggunakan Aspose.PDF untuk Layanan Pelaporan. Cukup aktifkan mode khusus di mana semua teks di kotak teks diperlakukan sebagai HTML dan masukkan tag HTML yang diperlukan untuk memformat teks dalam dokumen keluaran. Misalnya, untuk memiliki teks normal, tebal, dan miring dalam kotak teks yang sama, masukkan nilai kotak teks berikut:
 
-Some of this text is ```<b>bold</b>``` and other text is ```<i>italic</i>```.
+Beberapa teks ini adalah `<b>bold</b>` dan teks lainnya adalah `<i>italic</i>`.
 
-When exported, the text will look like as some of this text is **bold** and other text is *italic*.
+Saat diekspor, teks akan terlihat seperti beberapa teks ini **tebal** dan teks lainnya *miring*.
 
-Please note that this approach has some limitations
+Harap dicatat bahwa pendekatan ini memiliki beberapa keterbatasan
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-- The formatting isn’t visible in design time (in the Report Builder, Reporting Services web portal etc.). Instead, you will see the HTML text in form of plain text with tags.
-- Aspose.PDF for Reporting Services rendering extension recognizes and properly formats HTML code in textboxes. The default PDF renderer of Reporting Services will export this markup as plain text.
+- Pemformatan tidak terlihat pada waktu desain (di Pembuat Laporan, portal web Layanan Pelaporan, dll.). Sebaliknya, Anda akan melihat teks HTML dalam bentuk teks biasa dengan tag.
+- Ekstensi rendering Aspose.PDF untuk Layanan Pelaporan mengenali dan memformat kode HTML dengan benar di kotak teks. Perender PDF default Layanan Pelaporan akan mengekspor markup ini sebagai teks biasa.
 
-**Parameter Name**: IsHtmlTagSupported  
-**Date Type**: Boolean  
-**Values supported**: True, False (default)   
+```text
+Parameter Name: IsHtmlTagSupported  
+Date Type: Boolean  
+Values supported: True, False (default)   
+```
 
-**Example**
+## Contoh
 
-{{< highlight csharp >}}
-
- <Render>
+```xml
+<Render>
 ...
     <Extension Name="APPDF" Type=" Aspose.PDF.ReportingServices.Renderer,Aspose.PDF.ReportingServices ">
     <Configuration>
@@ -41,12 +42,10 @@ Please note that this approach has some limitations
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
+Jika Anda ingin menambahkan parameter ini di Perancang Laporan, gunakan tipe data `Boolean`.
 
-If you want to add this parameter in the Report Designer, use the 'Boolean' data type.
-
- 
-Currently Aspose.PDF for Reporting Services supports a subset of all the HTML tags. You may find more information in the Aspose.PDF [Documentation](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
+Saat ini Aspose.Pdf untuk Layanan Pelaporan mendukung subset dari semua tag HTML. Anda dapat menemukan informasi lebih lanjut di Aspose.PDF [Dokumentasi](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
 
 {{% /alert %}}

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
@@ -4,12 +4,12 @@ linktitle: IsFontEmbedded
 type: docs
 weight: 50
 url: /id/reportingservices/isfontembedded/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-RS designer tidak mendukung font yang ditanamkan untuk teks; dengan Aspose.PDF for Reporting Services Anda dapat dengan mudah menyematkan informasi font ke dalam dokumen PDF Anda.
+RS designer tidak mendukung font yang disematkan untuk teks; dengan Aspose.PDF for Reporting Services Anda dapat dengan mudah menyematkan informasi font ke dalam dokumen PDF Anda.
 
 {{% /alert %}}
 
@@ -25,7 +25,7 @@ RS designer tidak mendukung font yang ditanamkan untuk teks; dengan Aspose.PDF f
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsFontEmbedded>True</IsFontEmbedded>
+    <IsFontEmbedded>Benar</IsFontEmbedded>
     </Configuration>
     </Extension>
 </Render>
@@ -33,4 +33,3 @@ RS designer tidak mendukung font yang ditanamkan untuk teks; dengan Aspose.PDF f
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
@@ -1,35 +1,33 @@
 ---
-title: IsFontEmbedded
+title: IsFont Tertanam
 linktitle: IsFontEmbedded
 type: docs
 weight: 50
-url: /id/reportingservices/isfontembedded/
-lastmod: "2026-07-29"
+url: /reportingservices/isfontembedded/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-RS designer tidak mendukung font yang disematkan untuk teks; dengan Aspose.PDF for Reporting Services Anda dapat dengan mudah menyematkan informasi font ke dalam dokumen PDF Anda.
+Perancang RS tidak mendukung font yang disematkan untuk teks; dengan Aspose.PDF untuk Layanan Pelaporan Anda dapat dengan mudah menyematkan informasi font ke dalam dokumen PDF Anda.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**Nama Parameter**: IsFontEmbedded  
-**Tipe Data**: Boolean  
-**Nilai yang didukung**: True, False (default)  
+```txt
+Parameter Name: IsFontEmbedded  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**Contoh**
-{{< highlight csharp >}}
+## Contoh
 
+```xml
 <Render>
-…
+...
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsFontEmbedded>Benar</IsFontEmbedded>
+    <IsFontEmbedded>True</IsFontEmbedded>
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
@@ -1,44 +1,46 @@
 ---
 title: Ukuran margin halaman
-linktitle: Ukuran margin halaman
+linktitle: Page margin size
 type: docs
 weight: 70
-url: /id/reportingservices/page-margin-size/
-description: Sesuaikan ukuran margin halaman pada laporan PDF dengan Aspose.PDF for Reporting Services untuk meningkatkan keterbacaan dan tata letak.
-lastmod: "2026-07-29"
+url: /reportingservices/page-margin-size/
+description: Sesuaikan ukuran margin halaman dalam laporan PDF dengan Aspose.PDF untuk Layanan Pelaporan untuk meningkatkan keterbacaan dan tata letak.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Desainer laporan Reporting Services tidak mendukung pengaturan ukuran margin halaman. Aspose.PDF for Reporting Services menyediakan empat parameter untuk mengatur ukuran margin halaman yang sesuai, yaitu:
+Perancang laporan Layanan Pelaporan tidak mendukung pengaturan ukuran margin halaman. Aspose.PDF untuk Layanan Pelaporan menyediakan empat parameter untuk mengatur ukuran margin halaman yang sesuai, yaitu:
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-1)  
-**Nama Parameter**: PageMarginLeft  
-**Tipe Tanggal**: Float  
-**Nilai yang didukung**:  Setiap angka positif atau nol
+```text
+Parameter Name: PageMarginLeft  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-2)  
-**Nama Parameter**: PageMarginRight  
-**Tipe Tanggal**: Float  
-**Nilai yang didukung**:  Setiap angka positif atau nol
+```text
+Parameter Name: PageMarginRight  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-3)  
-**Nama Parameter**: PageMarginTop  
-**Tipe Tanggal**: Float  
-**Nilai yang didukung**:  Setiap angka positif atau nol
+```text
+Parameter Name: PageMarginTop  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-4)  
-**Nama Parameter**: PageMarginBottom  
-**Tipe Tanggal**: Float  
-**Nilai yang didukung**:  Setiap angka positif atau nol
+```text
+Parameter Name: PageMarginBottom  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-**Contoh**
+## Contoh
 
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type=" Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices ">
@@ -50,7 +52,4 @@ Desainer laporan Reporting Services tidak mendukung pengaturan ukuran margin hal
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
@@ -4,13 +4,13 @@ linktitle: Ukuran margin halaman
 type: docs
 weight: 70
 url: /id/reportingservices/page-margin-size/
-description: Sesuaikan ukuran margin halaman dalam laporan PDF dengan Aspose.PDF for Reporting Services untuk meningkatkan keterbacaan dan tata letak.
-lastmod: "2026-06-19"
+description: Sesuaikan ukuran margin halaman pada laporan PDF dengan Aspose.PDF for Reporting Services untuk meningkatkan keterbacaan dan tata letak.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Perancang laporan Reporting Services tidak mendukung pengaturan ukuran margin halaman. Aspose.Pdf for Reporting Services menyediakan empat parameter untuk mengatur ukuran margin halaman yang sesuai, yaitu:
+Desainer laporan Reporting Services tidak mendukung pengaturan ukuran margin halaman. Aspose.PDF for Reporting Services menyediakan empat parameter untuk mengatur ukuran margin halaman yang sesuai, yaitu:
 
 {{% /alert %}}
 
@@ -54,4 +54,3 @@ Perancang laporan Reporting Services tidak mendukung pengaturan ukuran margin ha
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
@@ -1,37 +1,36 @@
 ---
 title: Orientasi Halaman
-linktitle: Orientasi Halaman
+linktitle: Page Orientation
 type: docs
 weight: 10
-url: /id/reportingservices/page-orientation/
-description: Konfigurasikan orientasi halaman untuk laporan PDF di Aspose.PDF for Reporting Services. Sesuaikan tata letak untuk presentasi yang lebih baik.
-lastmod: "2026-07-29"
+url: /reportingservices/page-orientation/
+description: Konfigurasikan orientasi halaman untuk laporan PDF di Aspose.PDF untuk Layanan Pelaporan. Sesuaikan tata letak untuk presentasi yang lebih baik.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Definition Language tidak memungkinkan menentukan orientasi halaman dalam laporan secara eksplisit. Dengan Aspose.PDF for Reporting Services Anda dapat dengan mudah menginstruksikan pengekspor untuk menghasilkan dokumen PDF dengan orientasi halaman lanskap. Orientasi default adalah potret.
+Bahasa Definisi Laporan tidak memungkinkan penentuan orientasi halaman dalam laporan secara eksplisit. Dengan Aspose.PDF untuk Layanan Pelaporan Anda dapat dengan mudah menginstruksikan eksportir untuk menghasilkan dokumen PDF dengan orientasi halaman lanskap. Orientasi defaultnya adalah potret.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+The default orientation is portrait.
+Parameter Name: IsLandscape
+Date Type: Boolean
+Values supported: True, False (default)
+```
 
-Orientasi default adalah potret.
-**Nama Parameter**: IsLandscape
-**Tipe Data**: Boolean
-**Nilai yang didukung**: True, False (bawaan)
+## Contoh
 
-**Contoh**
-{{< highlight csharp >}}
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsLandscape>Benar</IsLandscape>
+    <IsLandscape>True</IsLandscape>
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
-
-{{% /alert %}}

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
@@ -4,13 +4,13 @@ linktitle: Orientasi Halaman
 type: docs
 weight: 10
 url: /id/reportingservices/page-orientation/
-description: Konfigurasikan orientasi halaman untuk laporan PDF di Aspose.PDF for Reporting Services. Sesuaikan tata letak untuk tampilan yang lebih baik.
-lastmod: "2026-06-19"
+description: Konfigurasikan orientasi halaman untuk laporan PDF di Aspose.PDF for Reporting Services. Sesuaikan tata letak untuk presentasi yang lebih baik.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Report Definition Language tidak mengizinkan penentuan orientasi halaman dalam laporan secara eksplisit. Dengan Aspose.PDF for Reporting Services Anda dapat dengan mudah menginstruksikan pengekspor untuk menghasilkan dokumen PDF dengan orientasi halaman lanskap. Orientasi default adalah potret.
+Report Definition Language tidak memungkinkan menentukan orientasi halaman dalam laporan secara eksplisit. Dengan Aspose.PDF for Reporting Services Anda dapat dengan mudah menginstruksikan pengekspor untuk menghasilkan dokumen PDF dengan orientasi halaman lanskap. Orientasi default adalah potret.
 
 {{% /alert %}}
 
@@ -19,7 +19,7 @@ Report Definition Language tidak mengizinkan penentuan orientasi halaman dalam l
 Orientasi default adalah potret.
 **Nama Parameter**: IsLandscape
 **Tipe Data**: Boolean
-**Nilai yang didukung**: True, False (default)
+**Nilai yang didukung**: True, False (bawaan)
 
 **Contoh**
 {{< highlight csharp >}}
@@ -27,7 +27,7 @@ Orientasi default adalah potret.
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsLandscape>True</IsLandscape>
+    <IsLandscape>Benar</IsLandscape>
     </Configuration>
     </Extension>
 </Render>
@@ -35,4 +35,3 @@ Orientasi default adalah potret.
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
@@ -1,23 +1,23 @@
 ---
-title: UkuranHalaman
-linktitle: UkuranHalaman
+title: PageSize
+linktitle: PageSize
 type: docs
 weight: 60
 url: /id/reportingservices/pagesize/
-description: Sesuaikan ukuran halaman untuk laporan PDF di Aspose.PDF for Reporting Services untuk memenuhi persyaratan dokumen khusus.
-lastmod: "2026-06-19"
+description: Sesuaikan ukuran halaman untuk laporan PDF di Aspose.PDF for Reporting Services agar memenuhi persyaratan dokumen tertentu.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Desainer laporan Reporting Services tidak mendukung ukuran halaman umum seperti A4, B5, Letter, dan sebagainya. Dengan Aspose.Pdf for Reporting Services, Anda dapat mengatasinya seperti pada contoh berikut.
+Desainer laporan Reporting Services tidak mendukung ukuran halaman umum seperti A4, B5, Letter, dan sebagainya. Dengan Aspose.PDF for Reporting Services, Anda dapat melakukannya seperti pada contoh berikut.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
 **Nama Parameter**: PageSize  
-**Tipe Tanggal**: String  
+**Jenis Tanggal**: String  
 **Nilai yang didukung**: A0, A1, A2, A3, A4, A5, A6, B5, Letter, Legal, Ledger, P11x17  
 
 **Contoh**
@@ -36,4 +36,3 @@ Desainer laporan Reporting Services tidak mendukung ukuran halaman umum seperti 
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
@@ -1,29 +1,28 @@
 ---
-title: PageSize
+title: Ukuran Halaman
 linktitle: PageSize
 type: docs
 weight: 60
-url: /id/reportingservices/pagesize/
-description: Sesuaikan ukuran halaman untuk laporan PDF di Aspose.PDF for Reporting Services agar memenuhi persyaratan dokumen tertentu.
-lastmod: "2026-07-29"
+url: /reportingservices/pagesize/
+description: Sesuaikan ukuran halaman untuk laporan PDF di Aspose.PDF untuk Layanan Pelaporan untuk memenuhi persyaratan dokumen tertentu.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Desainer laporan Reporting Services tidak mendukung ukuran halaman umum seperti A4, B5, Letter, dan sebagainya. Dengan Aspose.PDF for Reporting Services, Anda dapat melakukannya seperti pada contoh berikut.
+Perancang laporan Layanan Pelaporan tidak mendukung ukuran halaman umum seperti A4, B5, Letter dan sebagainya. Dengan Aspose.PDF for Reporting Services, Anda bisa mendapatkannya seperti pada contoh berikut.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+Parameter Name: PageSize  
+Date Type: String  
+Values supported: A0, A1, A2, A3, A4, A5, A6, B5, Letter, Legal, Ledger, P11x17  
+```
 
-**Nama Parameter**: PageSize  
-**Jenis Tanggal**: String  
-**Nilai yang didukung**: A0, A1, A2, A3, A4, A5, A6, B5, Letter, Legal, Ledger, P11x17  
+## Contoh
 
-**Contoh**
-
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
@@ -32,7 +31,4 @@ Desainer laporan Reporting Services tidak mendukung ukuran halaman umum seperti 
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
@@ -4,13 +4,13 @@ linktitle: Kesesuaian PDF_A
 type: docs
 weight: 100
 url: /id/reportingservices/pdf_a-conformance/
-description: Aktifkan kesesuaian PDF/A di Aspose.PDF untuk Reporting Services. Buat dokumen yang sesuai dengan standar arsip dengan mudah.
-lastmod: "2026-06-19"
+description: Aktifkan kesesuaian PDF/A di Aspose.PDF for Reporting Services. Buat dokumen yang mematuhi standar arsip dengan mudah.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Anda dapat memperoleh pengantar tentang Kesesuaian PDF/A (PDF yang Dapat Diarsipkan) dalam dokumentasi Aspose.PDF.
+Anda dapat memperoleh pengantar tentang Kesesuaian PDF/A (PDF yang dapat diarsipkan) dalam dokumentasi Aspose.PDF.
 
 Jika Anda ingin membuat dokumen PDF/A, tambahkan parameter laporan berikut.
 
@@ -37,4 +37,3 @@ Jika Anda ingin membuat dokumen PDF/A, tambahkan parameter laporan berikut.
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
@@ -1,31 +1,30 @@
 ---
-title: Kesesuaian PDF_A
-linktitle: Kesesuaian PDF_A
+title: PDF_A Kesesuaian
+linktitle: PDF_A Conformance
 type: docs
 weight: 100
-url: /id/reportingservices/pdf_a-conformance/
-description: Aktifkan kesesuaian PDF/A di Aspose.PDF for Reporting Services. Buat dokumen yang mematuhi standar arsip dengan mudah.
-lastmod: "2026-07-29"
+url: /reportingservices/pdf_a-conformance/
+description: Aktifkan kesesuaian PDF/A di Aspose.PDF untuk Layanan Pelaporan. Buat dokumen yang sesuai dengan arsip dengan mudah.
+lastmod: "2025-05-22"
 ---
 
 {{% alert color="primary" %}}
 
-Anda dapat memperoleh pengantar tentang Kesesuaian PDF/A (PDF yang dapat diarsipkan) dalam dokumentasi Aspose.PDF.
+Anda bisa mendapatkan pengenalan Kesesuaian PDF/A (PDF yang Dapat Diarsipkan) di dokumentasi Aspose.PDF.
 
 Jika Anda ingin membuat dokumen PDF/A, tambahkan parameter laporan berikut.
 
 {{% /alert %}}
 
+```text
+Parameter Name: PdfConformance  
+Date Type: String  
+Values supported: PdfA1A, PdfA1B, PdfA2A, PdfA2B, PdfA2U, PdfA3A, PdfA3B, PdfA3U, PdfA4, PdfA4E, PdfA4F  
+```
 
-{{% alert color="primary" %}}
+## Contoh
 
-**Nama Parameter**: PdfConformance  
-**Tipe Data**: String  
-**Nilai yang didukung**: PdfA1A, PdfA1B, PdfA2A, PdfA2B, PdfA2U, PdfA3A, PdfA3B, PdfA3U, PdfA4, PdfA4E, PdfA4F  
-
-**Contoh**
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
@@ -34,6 +33,4 @@ Jika Anda ingin membuat dokumen PDF/A, tambahkan parameter laporan berikut.
     </Configuration>
     </Extension>
 </Render>
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
@@ -4,18 +4,18 @@ linktitle: Pengaturan Keamanan
 type: docs
 weight: 30
 url: /id/reportingservices/security-setting/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Keamanan selalu menjadi masalah paling penting di setiap bidang, baik itu perlindungan jaringan maupun dokumen PDF. Dokumen dibuat aman karena banyak alasan: penulis dokumen mungkin ingin menjaga isi dokumen tetap aman dan tidak ingin orang lain mengubahnya, dll.
+Keamanan selalu menjadi isu paling penting di setiap bidang, baik itu perlindungan jaringan maupun dokumen PDF. Dokumen dibuat aman untuk banyak alasan yang mungkin: penulis dokumen mungkin ingin menjaga isi dokumen tetap aman dan tidak ingin mengizinkan orang lain mengubahnya, dll.
 
-Aspose.Pdf for Reporting Services telah sangat memperhatikan aspek keamanan tersebut dengan menyediakan fitur-fitur ini kepada pengembang yang dapat berguna bagi mereka untuk melindungi dokumen PDF mereka. Oleh karena itu, ia menyertakan sejumlah parameter yang memungkinkan pengembang menerapkan berbagai tindakan keamanan pada dokumen PDF.
+Aspose.PDF for Reporting Services telah sangat memperhatikan aspek keamanan tersebut dengan menyediakan fitur-fitur ini kepada pengembang yang dapat berguna bagi mereka untuk melindungi dokumen PDF mereka. Oleh karena itu, ia berisi sejumlah parameter yang memungkinkan pengembang menerapkan berbagai langkah keamanan pada dokumen PDF.
 
-Salah satu langkah ini adalah melindungi dokumen PDF dengan kata sandi selama proses enkripsi. Anda juga dapat membatasi atau mengizinkan modifikasi isi, menyalin konten, mencetak dokumen, atau mengizinkan/menonaktifkan pengisian formulir. Saat ini fitur-fitur tersebut belum didukung oleh PDF Exporter bawaan SQL Reporting Services, tetapi Anda dapat menerapkannya menggunakan Aspose.Pdf for Reporting Services. Cukup tambahkan parameter keamanan yang sesuai ke laporan atau file konfigurasi server laporan, dan Anda akan dapat membuat dokumen PDF yang aman dengan hak istimewa terbatas.
+Salah satu langkah ini adalah melindungi dokumen PDF dengan kata sandi selama enkripsi. Anda juga dapat membatasi atau mengizinkan modifikasi konten, menyalin konten, pencetakan dokumen, atau mengizinkan/menonaktifkan pengisian formulir. Fitur-fitur ini saat ini tidak didukung oleh Ekspor PDF default SQL Reporting Services, tetapi Anda dapat mengimplementasikan fitur-fitur ini menggunakan Aspose.PDF for Reporting Services. Cukup tambahkan parameter keamanan yang sesuai ke laporan atau file konfigurasi server laporan, dan Anda akan dapat membuat dokumen PDF yang aman dengan hak istimewa terbatas.
 
-Saat ini, renderer Aspose.Pdf for Reporting Services mendukung atribut keamanan berikut:
+Saat ini, renderer Aspose.PDF for Reporting Services mendukung atribut keamanan berikut:
 
 {{% /alert %}}
 
@@ -23,11 +23,11 @@ Saat ini, renderer Aspose.Pdf for Reporting Services mendukung atribut keamanan 
 
 **Nama Parameter**: Password Pengguna  
 **Tipe Data**: String  
-**Nilai yang didukung**: Teks biasa apa saja
+**Nilai yang didukung**: Teks biasa apa pun
 
 **Nama Parameter**: Password Master  
 **Tipe Data**: String  
-**Nilai yang didukung**: Teks biasa apa saja 
+**Nilai yang didukung**: Teks biasa apa pun 
 
 **Nama Parameter**: IsCopyingAllowed  
 **Tipe Data**: Boolean  
@@ -54,8 +54,8 @@ Saat ini, renderer Aspose.Pdf for Reporting Services mendukung atribut keamanan 
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
     <UserPassword>aspose</UserPassword>
-    <IsCopyingAllowed>False</IsCopyingAllowed>
-    <IsPrintingAllowed>False</IsPrintingAllowed>
+    <IsCopyingAllowed>Salah</IsCopyingAllowed>
+    <IsPrintingAllowed>Salah</IsPrintingAllowed>
     </Configuration>
     </Extension>
 </Render>
@@ -63,4 +63,3 @@ Saat ini, renderer Aspose.Pdf for Reporting Services mendukung atribut keamanan 
 {{< /highlight >}}
 
 {{% /alert %}}
-

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
@@ -1,65 +1,72 @@
 ---
 title: Pengaturan Keamanan
-linktitle: Pengaturan Keamanan
+linktitle: Security Setting
 type: docs
 weight: 30
-url: /id/reportingservices/security-setting/
-lastmod: "2026-07-29"
+url: /reportingservices/security-setting/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Keamanan selalu menjadi isu paling penting di setiap bidang, baik itu perlindungan jaringan maupun dokumen PDF. Dokumen dibuat aman untuk banyak alasan yang mungkin: penulis dokumen mungkin ingin menjaga isi dokumen tetap aman dan tidak ingin mengizinkan orang lain mengubahnya, dll.
+Keamanan selalu menjadi isu terpenting di segala bidang, baik itu perlindungan jaringan atau dokumen PDF. Dokumen dibuat aman karena berbagai kemungkinan alasan: penulis dokumen mungkin ingin menjaga konten dokumen tetap aman dan tidak ingin membiarkan orang lain mengubahnya, dll.
 
-Aspose.PDF for Reporting Services telah sangat memperhatikan aspek keamanan tersebut dengan menyediakan fitur-fitur ini kepada pengembang yang dapat berguna bagi mereka untuk melindungi dokumen PDF mereka. Oleh karena itu, ia berisi sejumlah parameter yang memungkinkan pengembang menerapkan berbagai langkah keamanan pada dokumen PDF.
+Aspose.PDF untuk Layanan Pelaporan telah sangat memperhatikan aspek keamanan tersebut dengan menyediakan fitur-fitur ini kepada pengembang yang dapat berguna bagi mereka untuk melindungi dokumen PDF mereka. Oleh karena itu, ini berisi sejumlah parameter yang memungkinkan pengembang menerapkan tindakan keamanan berbeda pada dokumen PDF.
 
-Salah satu langkah ini adalah melindungi dokumen PDF dengan kata sandi selama enkripsi. Anda juga dapat membatasi atau mengizinkan modifikasi konten, menyalin konten, pencetakan dokumen, atau mengizinkan/menonaktifkan pengisian formulir. Fitur-fitur ini saat ini tidak didukung oleh Ekspor PDF default SQL Reporting Services, tetapi Anda dapat mengimplementasikan fitur-fitur ini menggunakan Aspose.PDF for Reporting Services. Cukup tambahkan parameter keamanan yang sesuai ke laporan atau file konfigurasi server laporan, dan Anda akan dapat membuat dokumen PDF yang aman dengan hak istimewa terbatas.
+Salah satu langkah ini adalah melindungi dokumen PDF dengan kata sandi selama enkripsi. Anda juga dapat membatasi atau mengizinkan modifikasi konten, penyalinan konten, pencetakan dokumen, atau mengizinkan/menonaktifkan pengisian formulir. Fitur-fitur ini saat ini tidak didukung oleh Eksportir PDF Layanan Pelaporan SQL default tetapi Anda dapat mengimplementasikan fitur-fitur ini menggunakan Aspose.PDF untuk Layanan Pelaporan. Cukup tambahkan parameter keamanan yang sesuai ke laporan atau file konfigurasi server laporan, dan Anda akan dapat membuat dokumen PDF aman dengan hak istimewa terbatas.
 
-Saat ini, renderer Aspose.PDF for Reporting Services mendukung atribut keamanan berikut:
+Saat ini, perender Aspose.PDF untuk Layanan Pelaporan mendukung atribut keamanan berikut:
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+Parameter Name: User Password  
+Date Type: String  
+Values supported: Any plain text
+```
 
-**Nama Parameter**: Password Pengguna  
-**Tipe Data**: String  
-**Nilai yang didukung**: Teks biasa apa pun
+```text
+Parameter Name: Master Password  
+Date Type: String  
+Values supported: Any plain text 
+```
 
-**Nama Parameter**: Password Master  
-**Tipe Data**: String  
-**Nilai yang didukung**: Teks biasa apa pun 
+```text
+Parameter Name: IsCopyingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default) 
+```
 
-**Nama Parameter**: IsCopyingAllowed  
-**Tipe Data**: Boolean  
-**Nilai yang didukung**: True, False (default)  
+```text
+Parameter Name: IsPrintingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**Nama Parameter**: IsPrintingAllowed  
-**Tipe Data**: Boolean  
-**Nilai yang didukung**: True, False (default)  
+```text
+Parameter Name: IsContentsModifyingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default) 
+```
 
-**Nama Parameter**: IsContentsModifyingAllowed  
-**Tipe Data**: Boolean  
-**Nilai yang didukung**: True, False (default)  
+```text
+Parameter Name: IsFormFillingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**Nama Parameter**: IsFormFillingAllowed  
-**Tipe Data**: Boolean  
-**Nilai yang didukung**: True, False (default)  
+## Contoh
 
-**Contoh**
-
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
     <UserPassword>aspose</UserPassword>
-    <IsCopyingAllowed>Salah</IsCopyingAllowed>
-    <IsPrintingAllowed>Salah</IsPrintingAllowed>
+    <IsCopyingAllowed>False</IsCopyingAllowed>
+    <IsPrintingAllowed>False</IsPrintingAllowed>
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
-
-{{% /alert %}}

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
@@ -1,39 +1,46 @@
 ---
 title: Metadata XMP
-linktitle: Metadata XMP
+linktitle: XMP Metadata
 type: docs
 weight: 80
-url: /id/reportingservices/xmp-metadata/
-description: Pelajari cara mengelola metadata XMP dalam laporan PDF menggunakan Aspose.PDF for Reporting Services. Tingkatkan penanganan metadata dokumen.
-lastmod: "2026-07-29"
+url: /reportingservices/xmp-metadata/
+description: Pelajari cara mengelola metadata XMP dalam laporan PDF menggunakan Aspose.PDF untuk Layanan Pelaporan. Meningkatkan penanganan metadata dokumen.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Desainer laporan Reporting Services tidak mendukung penyisipan metadata XMP ke dalam dokumen. Aspose.PDF for Reporting Services menyediakan empat parameter untuk mengatur metadata XMP yang sesuai, yaitu:
+Perancang laporan Layanan Pelaporan tidak mendukung penyematan metadata XMP dalam dokumen. Aspose.PDF untuk Layanan Pelaporan menyediakan empat parameter untuk mengatur metadata XMP yang sesuai, yaitu:
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**Nama Parameter**: CreationDate  
-**Tipe Tanggal**: String  
-**Nilai yang didukung**: Tanggal dalam salah satu format tanggal
+```text
+**Parameter Name: CreationDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats
+```
 
-**Nama Parameter**: ModifyDate  
-**Tipe Tanggal**: String  
-**Nilai yang didukung**: Tanggal dalam salah satu format tanggal 
+```text
+**Parameter Name: ModifyDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats 
+```
 
-**Nama Parameter**: MetaDataDate  
-**Tipe Tanggal**: String  
-**Nilai yang didukung**: Tanggal dalam salah satu format tanggal 
+```text
+**Parameter Name: MetaDataDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats 
+```
 
-**Nama Parameter**: CreatorTool  
-**Tipe Tanggal**: String  
-**Nilai yang didukung**: Teks biasa apa saja  
+```text
+**Parameter Name: CreatorTool  
+**Date Type: String  
+**Values supported: Any plain text  
+```
 
-**Contoh**
-{{< highlight csharp >}}
+## Contoh
 
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer, Aspose.Pdf.ReportingServices">
@@ -45,8 +52,6 @@ Desainer laporan Reporting Services tidak mendukung penyisipan metadata XMP ke d
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
-
-{{% /alert %}}
 

--- a/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
+++ b/id/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
@@ -4,31 +4,31 @@ linktitle: Metadata XMP
 type: docs
 weight: 80
 url: /id/reportingservices/xmp-metadata/
-description: Pelajari cara mengelola metadata XMP dalam laporan PDF menggunakan Aspose.PDF untuk Reporting Services. Tingkatkan penanganan metadata dokumen.
-lastmod: "2026-06-19"
+description: Pelajari cara mengelola metadata XMP dalam laporan PDF menggunakan Aspose.PDF for Reporting Services. Tingkatkan penanganan metadata dokumen.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Desainer laporan Reporting Services tidak mendukung penyematan metadata XMP dalam dokumen. Aspose.PDF untuk Reporting Services menyediakan empat parameter untuk mengatur metadata XMP yang sesuai, yaitu:
+Desainer laporan Reporting Services tidak mendukung penyisipan metadata XMP ke dalam dokumen. Aspose.PDF for Reporting Services menyediakan empat parameter untuk mengatur metadata XMP yang sesuai, yaitu:
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 **Nama Parameter**: CreationDate  
-**Jenis Tanggal**: String  
+**Tipe Tanggal**: String  
 **Nilai yang didukung**: Tanggal dalam salah satu format tanggal
 
 **Nama Parameter**: ModifyDate  
-**Jenis Tanggal**: String  
+**Tipe Tanggal**: String  
 **Nilai yang didukung**: Tanggal dalam salah satu format tanggal 
 
 **Nama Parameter**: MetaDataDate  
-**Jenis Tanggal**: String  
+**Tipe Tanggal**: String  
 **Nilai yang didukung**: Tanggal dalam salah satu format tanggal 
 
 **Nama Parameter**: CreatorTool  
-**Jenis Tanggal**: String  
+**Tipe Tanggal**: String  
 **Nilai yang didukung**: Teks biasa apa saja  
 
 **Contoh**
@@ -41,7 +41,7 @@ Desainer laporan Reporting Services tidak mendukung penyematan metadata XMP dala
     <CreationDate>2017-12-10</CreationDate>
     <ModifyDate>2018-1-12</ModifyDate>
     <MetaDataDate>2018-3-7</MetaDataDate>
-    <CreatorTool>Aspose.Pdf for Reporting Services</CreatorTool>
+    <CreatorTool>Aspose.PDF for Reporting Services</CreatorTool>
     </Configuration>
     </Extension>
 </Render>
@@ -49,5 +49,4 @@ Desainer laporan Reporting Services tidak mendukung penyematan metadata XMP dala
 {{< /highlight >}}
 
 {{% /alert %}}
-
 

--- a/id/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
+++ b/id/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
@@ -1,25 +1,25 @@
 ---
 title: Evaluasi Aspose.Pdf
-linktitle: Evaluasi Aspose.Pdf
+linktitle: Evaluate Aspose.Pdf
 type: docs
 weight: 110
-url: /id/reportingservices/evaluate-aspose-pdf-for-reporting-services/
-description: Coba Aspose.PDF for Reporting Services secara gratis. Pelajari cara mengevaluasi fiturnya sebelum membuat keputusan pembelian.
-lastmod: "2026-07-29"
+url: /reportingservices/evaluate-aspose-pdf-for-reporting-services/
+description: Coba Aspose.PDF untuk Layanan Pelaporan secara gratis. Pelajari cara mengevaluasi fitur-fiturnya sebelum membuat keputusan pembelian.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Halaman ini menjelaskan perbedaan antara versi berlisensi dan versi evaluasi Aspose.PDF for Reporting Services
+Halaman ini menyatakan perbedaan antara versi berlisensi dan evaluasi Aspose.PDF untuk Layanan Pelaporan
 
 {{% /alert %}}
 
-Anda dapat dengan mudah mengunduh [Aspose.PDF for Reporting Services](https://downloads.aspose.com/pdf/reportingservices) untuk evaluasi. Unduhan evaluasi sama dengan unduhan yang dibeli. Versi evaluasi secara otomatis menjadi berlisensi ketika Anda menempatkan file lisensi di folder yang berisi Aspose.PDF.ReportingServices.dll atau beberapa baris kode untuk menginisialisasi lisensi saat menggunakan komponen dengan Report Viewer dalam mode lokal. Versi evaluasi Aspose.PDF for Reporting Services (tanpa lisensi yang ditentukan) menyediakan fungsi lengkap produk, namun menambahkan watermark evaluasi di bagian atas dokumen saat merender file .RDL ke format PDF. Anda dapat mengunjungi halaman berikut untuk petunjuk lebih lanjut tentang [Cara Melisensikan Aspose.PDF for Reporting Services](/pdf/id/reportingservices/license-aspose-pdf-for-reporting-services/)
+Anda dapat dengan mudah mengunduh [Aspose.PDF untuk Layanan Pelaporan](https://downloads.aspose.com/pdf/reportingservices) untuk evaluasi. Unduhan evaluasi sama dengan unduhan yang dibeli. Versi evaluasi menjadi berlisensi ketika Anda menempatkan file lisensi di folder yang berisi Aspose.PDF.ReportingServices.dll atau beberapa baris kode untuk menginisialisasi lisensi ketika menggunakan komponen dengan Penampil Laporan dalam mode lokal. Versi evaluasi Aspose.PDF untuk Layanan Pelaporan (tanpa lisensi yang ditentukan) menyediakan fungsionalitas produk penuh, namun menyisipkan tanda air evaluasi di bagian atas dokumen saat merender file .RDL ke format PDF. Anda dapat mengunjungi halaman berikut untuk instruksi lebih lanjut [cara Lisensi Aspose.PDF untuk Layanan Pelaporan](/pdf/id/reportingservices/license-aspose-pdf-for-reporting-services/)
 
-![todo:image_alt_text](evaluate-aspose-pdf-for-reporting-services_1.png)
+![Evaluasi](evaluate-aspose-pdf-for-reporting-services_1.png)
 
 {{% alert color="primary" %}}
 
-Jika Anda ingin menguji Aspose.PDF for Reporting Services tanpa batasan versi evaluasi, Anda juga dapat meminta Lisensi Sementara selama 30 hari. Silakan merujuk ke [Bagaimana cara mendapatkan Lisensi Sementara?](<https://about.aspose.com/>)
+Jika Anda ingin menguji Aspose.PDF untuk Layanan Pelaporan tanpa batasan versi evaluasi, Anda juga dapat meminta Lisensi Sementara 30 hari. Silakan merujuk ke [Bagaimana cara mendapatkan Lisensi Sementara?](<https://about.aspose.com/>)
 
 {{% /alert %}}

--- a/id/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
+++ b/id/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
@@ -4,23 +4,22 @@ linktitle: Evaluasi Aspose.Pdf
 type: docs
 weight: 110
 url: /id/reportingservices/evaluate-aspose-pdf-for-reporting-services/
-description: Coba Aspose.PDF untuk Reporting Services secara gratis. Pelajari cara mengevaluasi fiturnya sebelum membuat keputusan pembelian.
-lastmod: "2026-06-19"
+description: Coba Aspose.PDF for Reporting Services secara gratis. Pelajari cara mengevaluasi fiturnya sebelum membuat keputusan pembelian.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Halaman ini menjelaskan perbedaan antara versi berlisensi dan versi evaluasi Aspose.PDF untuk Reporting Services
+Halaman ini menjelaskan perbedaan antara versi berlisensi dan versi evaluasi Aspose.PDF for Reporting Services
 
 {{% /alert %}}
 
-Anda dapat dengan mudah mengunduh [Aspose.PDF untuk Reporting Services](https://downloads.aspose.com/pdf/reportingservices) untuk evaluasi. Unduhan evaluasi sama dengan unduhan yang dibeli. Versi evaluasi secara otomatis menjadi berlisensi ketika Anda menempatkan file lisensi di folder yang berisi Aspose.PDF.ReportingServices.dll atau beberapa baris kode untuk menginisialisasi lisensi saat menggunakan komponen dengan Report Viewer dalam mode lokal. Versi evaluasi Aspose.PDF untuk Reporting Services (tanpa lisensi yang ditentukan) memberikan fungsionalitas produk penuh, namun menambahkan watermark evaluasi di bagian atas dokumen saat merender file .RDL ke format PDF. Anda dapat mengunjungi halaman berikut untuk petunjuk lebih lanjut tentang [Cara Melisensikan Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/license-aspose-pdf-for-reporting-services/)
+Anda dapat dengan mudah mengunduh [Aspose.PDF for Reporting Services](https://downloads.aspose.com/pdf/reportingservices) untuk evaluasi. Unduhan evaluasi sama dengan unduhan yang dibeli. Versi evaluasi secara otomatis menjadi berlisensi ketika Anda menempatkan file lisensi di folder yang berisi Aspose.PDF.ReportingServices.dll atau beberapa baris kode untuk menginisialisasi lisensi saat menggunakan komponen dengan Report Viewer dalam mode lokal. Versi evaluasi Aspose.PDF for Reporting Services (tanpa lisensi yang ditentukan) menyediakan fungsi lengkap produk, namun menambahkan watermark evaluasi di bagian atas dokumen saat merender file .RDL ke format PDF. Anda dapat mengunjungi halaman berikut untuk petunjuk lebih lanjut tentang [Cara Melisensikan Aspose.PDF for Reporting Services](/pdf/id/reportingservices/license-aspose-pdf-for-reporting-services/)
 
 ![todo:image_alt_text](evaluate-aspose-pdf-for-reporting-services_1.png)
 
 {{% alert color="primary" %}}
 
-Jika Anda ingin menguji Aspose.PDF untuk Reporting Services tanpa batasan versi evaluasi, Anda juga dapat meminta Lisensi Sementara selama 30 hari. Silakan merujuk ke [Cara mendapatkan Lisensi Sementara?](<https://about.aspose.com/>)
+Jika Anda ingin menguji Aspose.PDF for Reporting Services tanpa batasan versi evaluasi, Anda juga dapat meminta Lisensi Sementara selama 30 hari. Silakan merujuk ke [Bagaimana cara mendapatkan Lisensi Sementara?](<https://about.aspose.com/>)
 
 {{% /alert %}}
-

--- a/id/reportingservices/expand-report-items-properties/_index.md
+++ b/id/reportingservices/expand-report-items-properties/_index.md
@@ -1,11 +1,11 @@
 ---
-title: Perluas Properti Item Laporan
-linktitle: Perluas Properti Item Laporan
+title: Perluas Alat Peraga Item Laporan
+linktitle: Expand Report Items Props
 type: docs
 weight: 90
-url: /id/reportingservices/expand-report-items-properties/
-description: Tingkatkan laporan SSRS dengan Aspose.PDF. Pelajari cara memperluas properti item laporan untuk penyesuaian PDF yang terperinci.
-lastmod: "2026-07-29"
+url: /reportingservices/expand-report-items-properties/
+description: Tingkatkan laporan SSRS dengan Aspose.PDF. Pelajari cara memperluas properti item laporan untuk penyesuaian PDF mendetail.
+lastmod: "2021-06-05"
 ---
 
 **Bagian ini mencakup topik berikut:**

--- a/id/reportingservices/expand-report-items-properties/_index.md
+++ b/id/reportingservices/expand-report-items-properties/_index.md
@@ -4,12 +4,11 @@ linktitle: Perluas Properti Item Laporan
 type: docs
 weight: 90
 url: /id/reportingservices/expand-report-items-properties/
-description: Tingkatkan laporan SSRS dengan Aspose.PDF. Pelajari cara memperluas properti item laporan untuk kustomisasi PDF yang detail.
-lastmod: "2026-06-19"
+description: Tingkatkan laporan SSRS dengan Aspose.PDF. Pelajari cara memperluas properti item laporan untuk penyesuaian PDF yang terperinci.
+lastmod: "2026-07-29"
 ---
 
 **Bagian ini mencakup topik berikut:**
 
 - [Menambahkan Properti Kustom](/pdf/id/reportingservices/adding-custom-properties/)
 - [Properti Kustom Didukung](/pdf/id/reportingservices/custom-properties-supported/)
-

--- a/id/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
+++ b/id/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
@@ -4,8 +4,8 @@ linktitle: Menambahkan Properti Kustom
 type: docs
 weight: 10
 url: /id/reportingservices/adding-custom-properties/
-description: Pelajari cara menambahkan properti kustom ke laporan PDF dengan Aspose.PDF for Reporting Services. Sesuaikan dokumen Anda secara efisien.
-lastmod: "2026-06-19"
+description: Pelajari cara menambahkan properti kustom ke laporan PDF dengan Aspose.PDF for Reporting Services. Sesuaikan dokumen Anda dengan efisien.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
@@ -20,11 +20,11 @@ Anda dapat menambahkan properti kustom untuk beberapa item laporan guna memperlu
 
 Untuk menambahkan properti khusus, Anda perlu mengedit file kode dokumen RDL dalam langkah-langkah berikut:
 
-1. Seperti pada gambar berikut, buka proyek Anda, navigasikan ke Solution Explorer, dan klik kanan pada file laporan yang dipilih, kemudian pilih item menu 'View Code'.
+1. Seperti pada gambar berikut, buka proyek Anda, navigasikan ke Solution Explorer, dan klik kanan pada file laporan yang dipilih, kemudian pilih menu ‘View Code’.
 
 ![todo:image_alt_text](adding-custom-properties_1.png)
 
-2. Edit file kode XML. Misalnya, jika Anda ingin menambahkan properti khusus untuk item laporan diagram, Anda perlu menambahkan kode yang mirip dengan teks berwarna merah pada contoh berikut.
+2. Edit file kode XML. Misalnya, jika Anda ingin menambahkan properti khusus untuk item laporan chart, Anda perlu menambahkan kode yang mirip dengan teks berwarna merah pada contoh berikut.
 
 **Contoh**
 
@@ -39,8 +39,8 @@ Untuk menambahkan properti khusus, Anda perlu mengedit file kode dokumen RDL dal
     </style>     
     <CustomProperties>
       <CustomProperty>
-        <Name>IsInList</Name>
-        <Value>True</Value>
+        <Name>ApakahDalamDaftar</Name>
+        <Value>Benar</Value>
       </CustomProperty>
     </CustomProperties>
 </chart> 
@@ -50,4 +50,3 @@ Untuk menambahkan properti khusus, Anda perlu mengedit file kode dokumen RDL dal
 Dalam contoh fragmen kode ini, nama properti khusus adalah IsInList, dan nilainya adalah 'True'.
 
 {{% /alert %}}
-

--- a/id/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
+++ b/id/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
@@ -1,35 +1,32 @@
 ---
 title: Menambahkan Properti Kustom
-linktitle: Menambahkan Properti Kustom
+linktitle: Adding Custom Properties
 type: docs
 weight: 10
-url: /id/reportingservices/adding-custom-properties/
-description: Pelajari cara menambahkan properti kustom ke laporan PDF dengan Aspose.PDF for Reporting Services. Sesuaikan dokumen Anda dengan efisien.
-lastmod: "2026-07-29"
+url: /reportingservices/adding-custom-properties/
+description: Pelajari cara menambahkan properti khusus ke laporan PDF dengan Aspose.PDF untuk Layanan Pelaporan. Sesuaikan dokumen Anda secara efisien.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Anda dapat menambahkan properti kustom untuk beberapa item laporan guna memperluas penggunaannya, seperti ToC, panah garis, dan sebagainya. Bagian ini menjelaskan proses tersebut.
+Anda dapat menambahkan properti khusus untuk beberapa item laporan guna memperluas penggunaannya, seperti ToC, panah garis, dan sebagainya. Bagian ini menjelaskan proses ini.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+Anda dapat menambahkan properti khusus untuk beberapa item laporan guna memperluas penggunaannya, seperti Daftar Isi, panah garis, dan sebagainya. Bagian ini menjelaskan proses ini.
 
-Anda dapat menambahkan properti kustom untuk beberapa item laporan guna memperluas penggunaannya, seperti Daftar Isi, panah garis, dan sebagainya. Bagian ini menjelaskan proses tersebut.
+Untuk menambahkan properti khusus, Anda perlu mengedit file kode dokumen RDL dengan langkah-langkah berikut:
 
-Untuk menambahkan properti khusus, Anda perlu mengedit file kode dokumen RDL dalam langkah-langkah berikut:
+1. Seperti pada gambar berikut, buka proyek Anda, navigasikan ke penjelajah solusi, dan klik kanan pada file laporan yang dipilih, lalu pilih item menu 'Lihat Kode'.
 
-1. Seperti pada gambar berikut, buka proyek Anda, navigasikan ke Solution Explorer, dan klik kanan pada file laporan yang dipilih, kemudian pilih menu ‘View Code’.
+![Add Custom Properties](adding-custom-properties_1.png)
 
-![todo:image_alt_text](adding-custom-properties_1.png)
+2. Edit file kode XML. Misalnya, jika Anda ingin menambahkan properti khusus untuk item laporan bagan, Anda perlu menambahkan kode yang mirip dengan teks merah pada contoh berikut.
 
-2. Edit file kode XML. Misalnya, jika Anda ingin menambahkan properti khusus untuk item laporan chart, Anda perlu menambahkan kode yang mirip dengan teks berwarna merah pada contoh berikut.
+## Contoh
 
-**Contoh**
-
-{{< highlight csharp >}}
-
+```xml
 <chart Name="chart1">
     <Left>5.5cm</Left>
     <Top>0.5cm</Top>
@@ -39,14 +36,12 @@ Untuk menambahkan properti khusus, Anda perlu mengedit file kode dokumen RDL dal
     </style>     
     <CustomProperties>
       <CustomProperty>
-        <Name>ApakahDalamDaftar</Name>
-        <Value>Benar</Value>
+        <Name>IsInList</Name>
+        <Value>True</Value>
       </CustomProperty>
     </CustomProperties>
 </chart> 
+```
 
-{{< /highlight >}}
+Dalam contoh fragmen kode ini, nama properti khusus adalah IsInList, dan nilainya adalah `True`.
 
-Dalam contoh fragmen kode ini, nama properti khusus adalah IsInList, dan nilainya adalah 'True'.
-
-{{% /alert %}}

--- a/id/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
+++ b/id/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
@@ -4,8 +4,8 @@ linktitle: Properti Kustom Didukung
 type: docs
 weight: 20
 url: /id/reportingservices/custom-properties-supported/
-description: Periksa properti kustom yang didukung di Aspose.PDF untuk Reporting Services. Maksimalkan fleksibilitas dalam output PDF Anda.
-lastmod: "2026-06-19"
+description: Periksa properti kustom yang didukung dalam Aspose.PDF for Reporting Services. Maksimalkan fleksibilitas dalam output PDF Anda.
+lastmod: "2026-07-29"
 ---
 
 **Bagian ini mencakup topik berikut:**
@@ -13,5 +13,4 @@ lastmod: "2026-06-19"
 - [Daftar Isi Daftar Tabel atau Gambar](/pdf/id/reportingservices/table-of-contents-list-of-tables-or-figures/)
 - [Panah Garis](/pdf/id/reportingservices/line-arrows/)
 - [Catatan Kaki Catatan Akhir](/pdf/id/reportingservices/footnote-endnote/)
-- [Rata Penuh Perataan Teks](/pdf/id/reportingservices/justify-fulljustify-text-alignment/)
-
+- [Justify FullJustify Penjajaran Teks](/pdf/id/reportingservices/justify-fulljustify-text-alignment/)

--- a/id/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
+++ b/id/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
@@ -1,11 +1,11 @@
 ---
 title: Properti Kustom Didukung
-linktitle: Properti Kustom Didukung
+linktitle: Custom Properties Supported
 type: docs
 weight: 20
-url: /id/reportingservices/custom-properties-supported/
-description: Periksa properti kustom yang didukung dalam Aspose.PDF for Reporting Services. Maksimalkan fleksibilitas dalam output PDF Anda.
-lastmod: "2026-07-29"
+url: /reportingservices/custom-properties-supported/
+description: Periksa properti kustom yang didukung di Aspose.PDF untuk Layanan Pelaporan. Maksimalkan fleksibilitas dalam keluaran PDF Anda.
+lastmod: "2021-06-05"
 ---
 
 **Bagian ini mencakup topik berikut:**
@@ -13,4 +13,4 @@ lastmod: "2026-07-29"
 - [Daftar Isi Daftar Tabel atau Gambar](/pdf/id/reportingservices/table-of-contents-list-of-tables-or-figures/)
 - [Panah Garis](/pdf/id/reportingservices/line-arrows/)
 - [Catatan Kaki Catatan Akhir](/pdf/id/reportingservices/footnote-endnote/)
-- [Justify FullJustify Penjajaran Teks](/pdf/id/reportingservices/justify-fulljustify-text-alignment/)
+- [Justify FullJustify Perataan Teks](/pdf/id/reportingservices/justify-fulljustify-text-alignment/)

--- a/id/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
+++ b/id/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
@@ -1,30 +1,30 @@
 ---
-title: Catatan Kaki Akhir
-linktitle: Catatan Kaki Akhir
+title: Catatan Kaki Catatan Akhir
+linktitle: Catatan Kaki Catatan Akhir
 type: docs
 weight: 30
 url: /id/reportingservices/footnote-endnote/
-description: Tambahkan catatan kaki dan catatan akhir ke laporan PDF Anda dengan Aspose.PDF for Reporting Services. Berikan referensi dokumen yang terperinci.
-lastmod: "2026-06-19"
+description: Tambahkan catatan kaki dan catatan akhir ke laporan PDF Anda dengan Aspose.PDF for Reporting Services. Berikan referensi dokumen yang detail.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Report Builder tidak dapat mengatur catatan kaki atau catatan akhir untuk kotak teks. Dengan Aspose.Pdf for Reporting Services, Anda dapat melakukannya dengan mudah dengan menambahkan properti khusus.
+Report Builder tidak dapat mengatur catatan kaki atau catatan akhir untuk kotak teks. Dengan Aspose.PDF for Reporting Services, Anda dapat melakukannya dengan mudah dengan menambahkan properti khusus.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-Catatan kaki
-**Custom Property** **Name**: Footnote
-**Custom Property Value**: *nilai* *harus* *berupa* *string*
+Catatan Kaki
+**Custom Property** **Name**: Catatan Kaki
+**Custom Property Value**: *nilai* *harus* *berupa* *string*
 
 Catatan Akhir
 **Custom Property** **Name**: Catatan Akhir
-**Custom Property Value**: *nilai* *harus* *menjadi* *sebuah* *string*
+**Custom Property Value**: *nilai* *harus* *berupa* *sebuah* *string*
 
 {{% alert color="primary" %}}
-Dalam contoh berikut, laporan berisi Textbox dengan nilai 'AsposePdf4RS', dan kami ingin menambahkan deskripsi tambahan dalam bentuk catatan kaki dengan teks "An optional PDF renderer for SSRS from Aspose Pty. Ltd.".
+Dalam contoh berikut, laporan berisi sebuah Textbox dengan nilai 'AsposePdf4RS', dan kami ingin menambahkan deskripsi tambahan dalam bentuk catatan kaki dengan teks "An optional PDF renderer for SSRS from Aspose Pty. Ltd.".
 {{% /alert %}}
 
 **Contoh**
@@ -54,4 +54,3 @@ Dalam contoh berikut, laporan berisi Textbox dengan nilai 'AsposePdf4RS', dan ka
 </Textbox>
 ```
 {{% /alert %}}
-

--- a/id/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
+++ b/id/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
@@ -1,33 +1,34 @@
 ---
 title: Catatan Kaki Catatan Akhir
-linktitle: Catatan Kaki Catatan Akhir
+linktitle: Footnote Endnote
 type: docs
 weight: 30
-url: /id/reportingservices/footnote-endnote/
-description: Tambahkan catatan kaki dan catatan akhir ke laporan PDF Anda dengan Aspose.PDF for Reporting Services. Berikan referensi dokumen yang detail.
-lastmod: "2026-07-29"
+url: /reportingservices/footnote-endnote/
+description: Tambahkan catatan kaki dan catatan akhir ke laporan PDF Anda dengan Aspose.PDF untuk Layanan Pelaporan. Berikan referensi dokumen terperinci.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Builder tidak dapat mengatur catatan kaki atau catatan akhir untuk kotak teks. Dengan Aspose.PDF for Reporting Services, Anda dapat melakukannya dengan mudah dengan menambahkan properti khusus.
+Pembuat Laporan tidak dapat menyetel catatan kaki atau catatan akhir untuk kotak teks. Dengan Aspose.PDF untuk Layanan Pelaporan, Anda dapat melakukannya dengan mudah dengan menambahkan properti khusus.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-Catatan Kaki
-**Custom Property** **Name**: Catatan Kaki
-**Custom Property Value**: *nilai* *harus* *berupa* *string*
+```text
+Footnote
+Custom Property `Name`: Footnote
+Custom Property Value: `the` `value` `should` `be` `a` `string`
+```
 
-Catatan Akhir
-**Custom Property** **Name**: Catatan Akhir
-**Custom Property Value**: *nilai* *harus* *berupa* *sebuah* *string*
+```text
+Endnote
+Custom Property `Name`: Endnote
+Custom Property Value: `the` `value` `should` `be` `a` `string`
+```
 
-{{% alert color="primary" %}}
-Dalam contoh berikut, laporan berisi sebuah Textbox dengan nilai 'AsposePdf4RS', dan kami ingin menambahkan deskripsi tambahan dalam bentuk catatan kaki dengan teks "An optional PDF renderer for SSRS from Aspose Pty. Ltd.".
-{{% /alert %}}
+Dalam contoh berikut, laporan berisi Kotak Teks dengan nilai `AsposePdf4RS`, dan kami ingin menambahkan deskripsi tambahan dalam bentuk catatan kaki dengan teks "Perender PDF opsional untuk SSRS dari Aspose Pty. Ltd.".
 
-**Contoh**
+## Contoh
 
 ```cs
 <Textbox Name="Textbox1">
@@ -53,4 +54,3 @@ Dalam contoh berikut, laporan berisi sebuah Textbox dengan nilai 'AsposePdf4RS',
 </Paragraphs>
 </Textbox>
 ```
-{{% /alert %}}

--- a/id/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
+++ b/id/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
@@ -1,37 +1,37 @@
 ---
-title: Penjajaran Teks Justify FullJustify
-linktitle: Penjajaran Teks Justify FullJustify
+title: Justify FullJustify Perataan Teks
+linktitle: Justify FullJustify Text Alignment
 type: docs
 weight: 40
-url: /id/reportingservices/justify-fulljustify-text-alignment/
-description: Capai penjajaran teks yang sempurna dalam laporan PDF dengan Aspose.PDF for Reporting Services. Mendukung opsi justify dan full justify.
-lastmod: "2026-07-29"
+url: /reportingservices/justify-fulljustify-text-alignment/
+description: Raih perataan teks sempurna dalam laporan PDF dengan Aspose.PDF untuk Layanan Pelaporan. Dukungan untuk opsi pembenaran dan pembenaran penuh.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report builder tidak mendukung kemampuan untuk menentukan penjajaran teks untuk kotak teks “Justify” dan “FullJustify”. Dengan Aspose.PDF for Reporting Services, Anda dapat melakukannya dengan mudah dengan menambahkan properti khusus.
+Pembuat laporan tidak mendukung kemampuan untuk menentukan perataan teks untuk kotak teks `Justify` Dan `FullJustify`. Dengan Aspose.PDF untuk Layanan Pelaporan, Anda dapat melakukannya dengan mudah dengan menambahkan properti khusus.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**Nama Properti Kustom** : TextAlignment  
-**Tipe Properti Kustom** : String  
-**Nilai Properti Kustom** : Justify, FullJustify  
+```text
+Custom Property `Name`: TextAlignment  
+Custom Property `Type`: String  
+Custom Property `Values`: Justify, FullJustify  
+```
 
-Dalam laporan, kode harus seperti berikut:
+Dalam laporan, kodenya harus seperti berikut:
 
-**Contoh**
+## Contoh
 
-{{< highlight csharp >}}
+```xml
 <Textbox Name="textbox1">
 <value> AsposePdf4RS </value>     
   <CustomProperties>
    <CustomProperty>
-     <Name>Perataan Teks</Name>
-     <Value>Ratakan</Value>
+     <Name>TextAlignment</Name>
+     <Value>Justify</Value>
    </CustomProperty>
   </CustomProperties>
 </Textbox>
-{{< /highlight >}}
-{{% /alert %}}
+```

--- a/id/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
+++ b/id/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
@@ -4,22 +4,22 @@ linktitle: Penjajaran Teks Justify FullJustify
 type: docs
 weight: 40
 url: /id/reportingservices/justify-fulljustify-text-alignment/
-description: Capai penjajaran teks yang sempurna dalam laporan PDF dengan Aspose.PDF for Reporting Services. Dukung opsi justify dan full justify.
-lastmod: "2026-06-19"
+description: Capai penjajaran teks yang sempurna dalam laporan PDF dengan Aspose.PDF for Reporting Services. Mendukung opsi justify dan full justify.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Report builder tidak mendukung kemampuan untuk menentukan penjajaran teks untuk textbox “Justify” dan “FullJustify”. Dengan Aspose.Pdf for Reporting Services, Anda dapat melakukannya dengan mudah dengan menambahkan properti khusus.
+Report builder tidak mendukung kemampuan untuk menentukan penjajaran teks untuk kotak teks “Justify” dan “FullJustify”. Dengan Aspose.PDF for Reporting Services, Anda dapat melakukannya dengan mudah dengan menambahkan properti khusus.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 **Nama Properti Kustom** : TextAlignment  
-**Jenis Properti Khusus** : String  
-**Nilai Properti Khusus** : Justify, FullJustify  
+**Tipe Properti Kustom** : String  
+**Nilai Properti Kustom** : Justify, FullJustify  
 
-Dalam laporan kode harus seperti berikut:
+Dalam laporan, kode harus seperti berikut:
 
 **Contoh**
 
@@ -28,11 +28,10 @@ Dalam laporan kode harus seperti berikut:
 <value> AsposePdf4RS </value>     
   <CustomProperties>
    <CustomProperty>
-     <Name>TextAlignment</Name>
-     <Value>Justify</Value>
+     <Name>Perataan Teks</Name>
+     <Value>Ratakan</Value>
    </CustomProperty>
   </CustomProperties>
 </Textbox>
 {{< /highlight >}}
 {{% /alert %}}
-

--- a/id/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
+++ b/id/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
@@ -1,44 +1,46 @@
 ---
 title: Panah Garis
-linktitle: Panah Garis
+linktitle: Line Arrows
 type: docs
 weight: 20
-url: /id/reportingservices/line-arrows/
-description: Pelajari cara menambahkan panah garis dalam laporan PDF menggunakan Aspose.PDF for Reporting Services. Tingkatkan visual laporan dengan mudah.
-lastmod: "2026-07-29"
+url: /reportingservices/line-arrows/
+description: Pelajari cara menambahkan panah garis dalam laporan PDF menggunakan Aspose.PDF untuk Layanan Pelaporan. Sempurnakan visual laporan dengan mudah.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Spesifikasi RDL tidak menentukan panah pada elemen garis, sehingga report builder tidak mendukung pengaturan panah untuk garis. Dengan Aspose.PDF for Reporting Services Anda dapat melakukannya dengan mudah.
+Spesifikasi RDL tidak menentukan panah pada elemen garis, sehingga pembuat laporan tidak mendukung pengaturan panah untuk garis. Dengan Aspose.PDF untuk Layanan Pelaporan Anda dapat melakukannya dengan mudah.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+Saat ini, perender Aspose.PDF mendukung penambahan panah di awal atau akhir baris dengan menambahkan properti khusus.
 
-Saat ini, renderer Aspose.PDF mendukung penambahan panah di awal atau akhir garis dengan menambahkan properti khusus.
+```text
+Add Start Arrow for Line  
+Custom Property `Name`: HasArrowAtStart  
+Custom Property `Value`: True  
+```
 
-Tambahkan Panah Awal untuk Garis  
-**Properti Kustom** **Nama**: HasArrowAtStart  
-**Nilai Properti Kustom**: True  
+```text
+Add End Arrow for Line  
+Custom Property `Name`: HasArrowAtEnd  
+Custom Property `Value`: True  
+```
 
-Tambahkan Panah Akhir untuk Garis  
-**Properti Kustom** **Nama**: HasArrowAtEnd  
-**Nilai Properti Kustom**: True  
+Misalnya, ada dua baris yang diberi nama `line1` Dan `line2` dalam file laporan saat ini, dan baris1 memiliki panah awal, baris2 memiliki panah awal dan akhir, untuk memenuhi persyaratan ini, Anda dapat menambahkan properti khusus seperti pada potongan kode berikut.
 
-Sebagai contoh, terdapat dua garis bernama 'line1' dan 'line2' dalam file laporan saat ini, dan line1 memiliki panah awal, line2 memiliki panah awal dan akhir; untuk memenuhi persyaratan ini, Anda dapat menambahkan properti kustom seperti pada fragmen kode berikut.
+## Contoh
 
-**Contoh**
-
-{{< highlight csharp >}}
+```xml
  <Line Name="line1">
     <Style>
       ......
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>MemilikiPanahDiAwal</Name>
-        <Value>Benar</Value>
+        <Name>HasArrowAtStart</Name>
+        <Value>True</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
@@ -49,15 +51,14 @@ Sebagai contoh, terdapat dua garis bernama 'line1' dan 'line2' dalam file lapora
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>MemilikiPanahDiAwal</Name>
-        <Value>Benar</Value>
+        <Name>HasArrowAtStart</Name>
+        <Value>True</Value>
       </CustomProperty>
 <CustomProperty>
         <Name>HasArrowAtEnd</Name>
-        <Value>Benar</Value>
+        <Value>True</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
+```
 
-{{< /highlight >}}
-{{% /alert %}}

--- a/id/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
+++ b/id/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
@@ -4,13 +4,13 @@ linktitle: Panah Garis
 type: docs
 weight: 20
 url: /id/reportingservices/line-arrows/
-description: Pelajari cara menambahkan panah garis dalam laporan PDF menggunakan Aspose.PDF for Reporting Services. Tingkatkan tampilan laporan dengan mudah.
-lastmod: "2026-06-19"
+description: Pelajari cara menambahkan panah garis dalam laporan PDF menggunakan Aspose.PDF for Reporting Services. Tingkatkan visual laporan dengan mudah.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Spesifikasi RDL tidak menentukan panah untuk elemen garis, sehingga report builder tidak mendukung pengaturan panah untuk garis. Dengan Aspose.Pdf for Reporting Services Anda dapat melakukannya dengan mudah.
+Spesifikasi RDL tidak menentukan panah pada elemen garis, sehingga report builder tidak mendukung pengaturan panah untuk garis. Dengan Aspose.PDF for Reporting Services Anda dapat melakukannya dengan mudah.
 
 {{% /alert %}}
 
@@ -26,7 +26,7 @@ Tambahkan Panah Akhir untuk Garis
 **Properti Kustom** **Nama**: HasArrowAtEnd  
 **Nilai Properti Kustom**: True  
 
-Sebagai contoh, terdapat dua garis bernama ‘line1’ dan ‘line2’ dalam file laporan saat ini, dan line1 memiliki panah awal, line2 memiliki panah awal dan akhir, untuk memenuhi persyaratan ini, Anda dapat menambahkan properti kustom seperti pada potongan kode berikut.
+Sebagai contoh, terdapat dua garis bernama 'line1' dan 'line2' dalam file laporan saat ini, dan line1 memiliki panah awal, line2 memiliki panah awal dan akhir; untuk memenuhi persyaratan ini, Anda dapat menambahkan properti kustom seperti pada fragmen kode berikut.
 
 **Contoh**
 
@@ -37,8 +37,8 @@ Sebagai contoh, terdapat dua garis bernama ‘line1’ dan ‘line2’ dalam fil
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>HasArrowAtStart</Name>
-        <Value>True</Value>
+        <Name>MemilikiPanahDiAwal</Name>
+        <Value>Benar</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
@@ -49,16 +49,15 @@ Sebagai contoh, terdapat dua garis bernama ‘line1’ dan ‘line2’ dalam fil
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>HasArrowAtStart</Name>
-        <Value>True</Value>
+        <Name>MemilikiPanahDiAwal</Name>
+        <Value>Benar</Value>
       </CustomProperty>
 <CustomProperty>
         <Name>HasArrowAtEnd</Name>
-        <Value>True</Value>
+        <Value>Benar</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
 
 {{< /highlight >}}
 {{% /alert %}}
-

--- a/id/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
+++ b/id/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
@@ -1,25 +1,25 @@
 ---
-title: Daftar Isi Daftar Tabel atau Gambar
-linktitle: Daftar Isi Daftar Tabel atau Gambar
+title: Table of Contents List of Tables or Figures
+linktitle: Table of Contents List of Tables or Figures
 type: docs
 weight: 10
-url: /id/reportingservices/table-of-contents-list-of-tables-or-figures/
-description: Pelajari cara menambahkan Daftar Isi, Daftar Tabel, atau Gambar dalam laporan PDF menggunakan Aspose.PDF for Reporting Services.
-lastmod: "2026-06-19"
+url: /reportingservices/table-of-contents-list-of-tables-or-figures/
+description: Learn how to add a Table of Contents, List of Tables, or Figures in PDF reports using Aspose.PDF for Reporting Services.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Designer tidak mendukung penambahan daftar isi untuk dokumen laporan. Dengan Aspose.Pdf for Reporting Services Anda dapat dengan mudah menginstruksikan perender PDF untuk menghasilkan dokumen PDF dengan Daftar Isi, atau Daftar Tabel atau Gambar. Anda dapat melakukannya dalam langkah-langkah berikut:
+Report Designer does not support adding table of contents for report documents. With Aspose.PDF for Reporting Services you can easily instruct the PDF render to produce PDF documents with Table of Contents, or List of Tables or Figures. You can do it in the following steps:
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-Pastikan bahwa file Aspose.Pdf.ListSectionStyle.xml ada di ```<Instance>```/bin, di mana ```<Instance>``` adalah direktori dari Report Server. Jika file tidak ada, buat di dalamnya ```<Instance>```direktori /bin dan letakkan markup berikut di dalamnya.
+Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/bin, where ```<Instance>``` is the directory of the Report Server. If the file does not exist, create it in the ```<Instance>```/bin directory and place the following markup inside.
 
-## Daftar Isi
+## Table of Contents
 
-**Contoh**
+**Example**
 
 ```cs
 <ListSection ListType="TableOfContents">
@@ -41,9 +41,9 @@ Pastikan bahwa file Aspose.Pdf.ListSectionStyle.xml ada di ```<Instance>```/bin,
 </ListSection>
 ```
 
-##  Daftar Tabel
+##  List of TableS
 
-**Contoh**
+**Example**
 
 ```cs
 <ListSection ListType="ListOfTables">
@@ -53,9 +53,9 @@ Pastikan bahwa file Aspose.Pdf.ListSectionStyle.xml ada di ```<Instance>```/bin,
 </ListSection>
 ```
 
-## Daftar Gambar
+## List of Figures
 
-**Contoh**
+**Example**
 
 ```cs
  <ListSection ListType="ListOfFigures">
@@ -66,41 +66,40 @@ Pastikan bahwa file Aspose.Pdf.ListSectionStyle.xml ada di ```<Instance>```/bin,
 
 ```
 
-Silakan merujuk ke bagian 'Working with TOC' dari dokumentasi online Aspose.Pdf.
+Please refer to 'Working with TOC' section of the Aspose.Pdf online documentation.
 
-**2-** Tambahkan parameter laporan 'IsListSectionSupported' dan setel nilainya menjadi True seperti yang ditunjukkan dalam paragraf 'List Section'.
-**3-** Tambahkan properti khusus untuk item laporan Anda yang ingin Anda masukkan dalam Daftar Isi, Daftar Tabel, atau Daftar Gambar.
+**2-** Add report parameter 'IsListSectionSupported' and set the value to be True as shown in the 'List Section' paragraph.
+**3-** Add custom property for your report item you want to be listed in Table of Contents, List of Tables or Figures.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**Nama Properti Kustom** :IsInList
-**Nilai Properti** :Boolean
-**Nilai Properti Kustom** : True or False
+**Custom Property Name** :IsInList
+**Property Value** :Boolean
+**Custom Property Value** : True or False
 
 {{% alert color="primary" %}}
 
-Menandai item laporan saat ini sebagai terdaftar berdasarkan indeks dalam tabel isi, atau daftar tabel atau gambar.
+Marks the current report item as listed by index in the table of contents, or the list of tables or figures.
 
 {{% /alert %}}
 
-**Nama Properti Kustom** : Judul
-**Tipe Properti Kustom** : String
+**Custom Property Name** : Title
+**Custom Property Type** : String
 
 {{% alert color="primary" %}}
 
-Judul item yang ditampilkan dalam tabel isi, daftar tabel, atau gambar.
+The item title displayed in the table of contents, list of tables or figures.
 {{% /alert %}}
 
-**Nama Properti Kustom** : ListLevel
-**Tipe Properti Kustom** : Integer
+**Custom Property Name** : ListLevel
+**Custom Property Type** : Integer
 
 {{% alert color="primary" %}}
 
-Tingkat item yang terdaftar yang ditampilkan dalam daftar isi.
+The level of listed items displayed in the table of contents.
 
 {{% /alert %}}
 
 {{% /alert %}}
-

--- a/id/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
+++ b/id/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
@@ -1,25 +1,24 @@
 ---
-title: Table of Contents List of Tables or Figures
+title: Daftar Isi Daftar Tabel atau Gambar
 linktitle: Table of Contents List of Tables or Figures
 type: docs
 weight: 10
 url: /reportingservices/table-of-contents-list-of-tables-or-figures/
-description: Learn how to add a Table of Contents, List of Tables, or Figures in PDF reports using Aspose.PDF for Reporting Services.
+description: Pelajari cara menambahkan Daftar Isi, Daftar Tabel, atau Gambar dalam laporan PDF menggunakan Aspose.PDF untuk Layanan Pelaporan.
 lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Designer does not support adding table of contents for report documents. With Aspose.PDF for Reporting Services you can easily instruct the PDF render to produce PDF documents with Table of Contents, or List of Tables or Figures. You can do it in the following steps:
+Perancang Laporan tidak mendukung penambahan daftar isi untuk dokumen laporan. Dengan Aspose.PDF untuk Layanan Pelaporan Anda dapat dengan mudah menginstruksikan render PDF untuk menghasilkan dokumen PDF dengan Daftar Isi, atau Daftar Tabel atau Gambar. Anda dapat melakukannya dengan langkah-langkah berikut:
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/bin, where ```<Instance>``` is the directory of the Report Server. If the file does not exist, create it in the ```<Instance>```/bin directory and place the following markup inside.
+Pastikan file Aspose.Pdf.ListSectionStyle.xml ada di direktori ```<Instance>```/bin, where ```<Instance>``` is the directory of the Report Server. If the file does not exist, create it in the ```<Instance>```/bin dan letakkan markup berikut di dalamnya.
 
-## Table of Contents
+## Daftar isi
 
-**Example**
+### Contoh
 
 ```cs
 <ListSection ListType="TableOfContents">
@@ -41,9 +40,9 @@ Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/b
 </ListSection>
 ```
 
-##  List of TableS
+##  Daftar tabel
 
-**Example**
+### Contoh
 
 ```cs
 <ListSection ListType="ListOfTables">
@@ -53,9 +52,9 @@ Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/b
 </ListSection>
 ```
 
-## List of Figures
+## Daftar Gambar
 
-**Example**
+### Contoh
 
 ```cs
  <ListSection ListType="ListOfFigures">
@@ -66,40 +65,29 @@ Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/b
 
 ```
 
-Please refer to 'Working with TOC' section of the Aspose.Pdf online documentation.
+Silakan lihat bagian 'Bekerja dengan TOC' pada dokumentasi online Aspose.Pdf.
 
-**2-** Add report parameter 'IsListSectionSupported' and set the value to be True as shown in the 'List Section' paragraph.
-**3-** Add custom property for your report item you want to be listed in Table of Contents, List of Tables or Figures.
+**2-** Tambahkan parameter laporan `IsListSectionSupported` dan atur nilainya menjadi True seperti yang ditunjukkan pada paragraf `List Section`.
+**3-** Tambahkan properti khusus untuk item laporan yang ingin Anda cantumkan di Daftar Isi, Daftar Tabel, atau Gambar.
 
-{{% /alert %}}
+```text
+Custom Property Name: IsInList
+Property Value: Boolean
+Custom Property Value: True or False
+```
 
-{{% alert color="primary" %}}
+Menandai item laporan saat ini sebagaimana tercantum berdasarkan indeks pada daftar isi, atau daftar tabel atau gambar.
 
-**Custom Property Name** :IsInList
-**Property Value** :Boolean
-**Custom Property Value** : True or False
+```text
+Custom Property Name: Title
+Custom Property Type: String
+```
 
-{{% alert color="primary" %}}
+Judul item ditampilkan dalam daftar isi, daftar tabel atau gambar.
 
-Marks the current report item as listed by index in the table of contents, or the list of tables or figures.
+```text
+Custom Property Name: ListLevel
+Custom Property Type: Integer
+```
 
-{{% /alert %}}
-
-**Custom Property Name** : Title
-**Custom Property Type** : String
-
-{{% alert color="primary" %}}
-
-The item title displayed in the table of contents, list of tables or figures.
-{{% /alert %}}
-
-**Custom Property Name** : ListLevel
-**Custom Property Type** : Integer
-
-{{% alert color="primary" %}}
-
-The level of listed items displayed in the table of contents.
-
-{{% /alert %}}
-
-{{% /alert %}}
+Tingkat item yang terdaftar ditampilkan dalam daftar isi.

--- a/id/reportingservices/features/_index.md
+++ b/id/reportingservices/features/_index.md
@@ -4,14 +4,14 @@ linktitle: Fitur
 type: docs
 weight: 30
 url: /id/reportingservices/features/
-description: Temukan fitur utama Aspose.PDF for Reporting Services. Tingkatkan laporan SSRS dengan kemampuan rendering PDF lanjutan dan penyesuaian.
-lastmod: "2026-06-19"
+description: Temukan fitur utama Aspose.PDF for Reporting Services. Tingkatkan laporan SSRS dengan kemampuan render PDF canggih dan kustomisasi.
+lastmod: "2026-07-29"
 ---
 
 **Bagian ini mencakup topik berikut:**
-- [Dukungan RDL yang Komprehensif](/pdf/id/reportingservices/comprehensive-rdl-support/)
-- [Dukungan Laporan Parameterisasi](/pdf/id/reportingservices/parameterized-report-support/)
-- [Dukungan Item Laporan Kustom](/pdf/id/reportingservices/custom-report-item-support/)
-- [Penerapan yang Mudah dan Ringan](/pdf/id/reportingservices/easy-and-lightweight-deployment/)
-- [Dukungan Teknis Gratis Kelas Dunia](/pdf/id/reportingservices/world-class-free-technical-support/)
 
+- [Dukungan RDL Komprehensif](/pdf/id/reportingservices/comprehensive-rdl-support/)
+- [Dukungan Laporan Berparameter](/pdf/id/reportingservices/parameterized-report-support/)
+- [Dukungan Item Laporan Kustom](/pdf/id/reportingservices/custom-report-item-support/)
+- [Penyebaran yang Mudah dan Ringan](/pdf/id/reportingservices/easy-and-lightweight-deployment/)
+- [Dukungan Teknis Gratis Kelas Dunia](/pdf/id/reportingservices/world-class-free-technical-support/)

--- a/id/reportingservices/features/_index.md
+++ b/id/reportingservices/features/_index.md
@@ -1,17 +1,17 @@
 ---
 title: Fitur
-linktitle: Fitur
+linktitle: Features
 type: docs
 weight: 30
-url: /id/reportingservices/features/
-description: Temukan fitur utama Aspose.PDF for Reporting Services. Tingkatkan laporan SSRS dengan kemampuan render PDF canggih dan kustomisasi.
-lastmod: "2026-07-29"
+url: /reportingservices/features/
+description: Temukan fitur utama Aspose.PDF untuk Layanan Pelaporan. Sempurnakan laporan SSRS dengan kemampuan dan penyesuaian rendering PDF tingkat lanjut.
+lastmod: "2021-06-05"
 ---
 
 **Bagian ini mencakup topik berikut:**
 
-- [Dukungan RDL Komprehensif](/pdf/id/reportingservices/comprehensive-rdl-support/)
+- [Dukungan RDL yang Komprehensif](/pdf/id/reportingservices/comprehensive-rdl-support/)
 - [Dukungan Laporan Berparameter](/pdf/id/reportingservices/parameterized-report-support/)
 - [Dukungan Item Laporan Kustom](/pdf/id/reportingservices/custom-report-item-support/)
-- [Penyebaran yang Mudah dan Ringan](/pdf/id/reportingservices/easy-and-lightweight-deployment/)
+- [Penerapan yang Mudah dan Ringan](/pdf/id/reportingservices/easy-and-lightweight-deployment/)
 - [Dukungan Teknis Gratis Kelas Dunia](/pdf/id/reportingservices/world-class-free-technical-support/)

--- a/id/reportingservices/features/comprehensive-rdl-support/_index.md
+++ b/id/reportingservices/features/comprehensive-rdl-support/_index.md
@@ -1,30 +1,30 @@
 ---
 title: Dukungan RDL yang Komprehensif
-linktitle: Dukungan RDL yang Komprehensif
+linktitle: Comprehensive RDL Support
 type: docs
 weight: 10
-url: /id/reportingservices/comprehensive-rdl-support/
-description: Temukan dukungan RDL yang komprehensif dalam Aspose.PDF untuk Reporting Services. Render laporan SQL Server kompleks menjadi PDF profesional.
-lastmod: "2026-07-29"
+url: /reportingservices/comprehensive-rdl-support/
+description: Temukan dukungan RDL yang komprehensif di Aspose.PDF untuk Layanan Pelaporan. Render laporan SQL Server yang kompleks ke PDF profesional.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF untuk Reporting Services mendukung spesifikasi RDL. Artinya:
+Aspose.PDF untuk Layanan Pelaporan mendukung spesifikasi RDL. Artinya:
 
 * Tidak perlu mendesain ulang atau menyesuaikan laporan yang ada.
-* Tidak perlu menggunakan desainer laporan tertentu. Anda dapat menggunakan desainer laporan RDL apa pun dan laporan akan diekspor persis seperti yang Anda rancang.
+* Tidak perlu menggunakan perancang laporan tertentu. Anda dapat menggunakan perancang laporan RDL mana pun dan laporan akan diekspor persis seperti yang Anda rancang.
 
 {{% /alert %}}
 
-## **Elemen RDL yang Didukung**
-Aspose.PDF for Reporting Services mendukung elemen RDL berikut:
+## Elemen RDL yang didukung
+Aspose.PDF untuk Layanan Pelaporan mendukung elemen RDL berikut:
 
 - Bagian
 - Header, footer
-- Kotak Teks
+- Kotak teks
 - Gambar
-- Diagram
+- Grafik
 - Daftar
 - Tabel
 - Matriks
@@ -32,5 +32,5 @@ Aspose.PDF for Reporting Services mendukung elemen RDL berikut:
 - Persegi panjang
 - Garis
 - Sub Laporan
-- Panel gauge (RS2008)
+- Panel pengukur (RS2008)
 - Tablix (RS2008)

--- a/id/reportingservices/features/comprehensive-rdl-support/_index.md
+++ b/id/reportingservices/features/comprehensive-rdl-support/_index.md
@@ -4,16 +4,16 @@ linktitle: Dukungan RDL yang Komprehensif
 type: docs
 weight: 10
 url: /id/reportingservices/comprehensive-rdl-support/
-description: Temukan dukungan RDL yang komprehensif dalam Aspose.PDF for Reporting Services. Render laporan SQL Server yang kompleks menjadi PDF profesional.
-lastmod: "2026-06-19"
+description: Temukan dukungan RDL yang komprehensif dalam Aspose.PDF untuk Reporting Services. Render laporan SQL Server kompleks menjadi PDF profesional.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.Pdf for Reporting Services mendukung spesifikasi RDL. Artinya:
+Aspose.PDF untuk Reporting Services mendukung spesifikasi RDL. Artinya:
 
-* Tidak perlu merancang ulang atau menyesuaikan laporan yang ada.
-* Tidak perlu menggunakan desainer laporan khusus. Anda dapat menggunakan desainer laporan RDL apa pun dan laporan akan diekspor persis seperti yang Anda rancang.
+* Tidak perlu mendesain ulang atau menyesuaikan laporan yang ada.
+* Tidak perlu menggunakan desainer laporan tertentu. Anda dapat menggunakan desainer laporan RDL apa pun dan laporan akan diekspor persis seperti yang Anda rancang.
 
 {{% /alert %}}
 
@@ -22,7 +22,7 @@ Aspose.PDF for Reporting Services mendukung elemen RDL berikut:
 
 - Bagian
 - Header, footer
-- Kotak teks
+- Kotak Teks
 - Gambar
 - Diagram
 - Daftar
@@ -34,4 +34,3 @@ Aspose.PDF for Reporting Services mendukung elemen RDL berikut:
 - Sub Laporan
 - Panel gauge (RS2008)
 - Tablix (RS2008)
-

--- a/id/reportingservices/features/custom-report-item-support/_index.md
+++ b/id/reportingservices/features/custom-report-item-support/_index.md
@@ -5,18 +5,17 @@ type: docs
 weight: 30
 url: /id/reportingservices/custom-report-item-support/
 description: Manfaatkan dukungan item laporan kustom di Aspose.PDF for Reporting Services. Capai output PDF yang disesuaikan dan berkualitas tinggi dengan mudah.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Dalam Spesifikasi RDL untuk RS2016, RS2017, RS2019, RS2022, dan Power BI, hampir setiap item laporan dapat diperluas dengan menambahkan properti kustom. Saat ini Aspose.PDF untuk Reporting Services 2016, 2017, 2019, 2022, dan Power BI mendukung tiga properti tersebut, yaitu:
+Dalam Spesifikasi RDL untuk RS2016, RS2017, RS2019, RS2022, dan Power BI, hampir setiap item laporan dapat diperluas dengan menambahkan properti kustom. Saat ini Aspose.PDF for Reporting Services 2016, 2017, 2019, 2022, dan Power BI mendukung tiga properti semacam itu, yaitu:
 
-- Daftar isi, daftar tabel atau gambar.
+- Daftar isi, daftar tabel, atau gambar.
 - Panah Garis.
-- Catatan kaki/Akhir.
+- Catatan kaki/Catatan akhir.
 
 Cari tahu cara menggunakannya dalam [Perluas Properti Item Laporan](/pdf/id/reportingservices/expand-report-items-properties/) artikel.
 
 {{% /alert %}}
-

--- a/id/reportingservices/features/custom-report-item-support/_index.md
+++ b/id/reportingservices/features/custom-report-item-support/_index.md
@@ -1,21 +1,21 @@
 ---
 title: Dukungan Item Laporan Kustom
-linktitle: Dukungan Item Laporan Kustom
+linktitle: Custom Report Item Support
 type: docs
 weight: 30
-url: /id/reportingservices/custom-report-item-support/
-description: Manfaatkan dukungan item laporan kustom di Aspose.PDF for Reporting Services. Capai output PDF yang disesuaikan dan berkualitas tinggi dengan mudah.
-lastmod: "2026-07-29"
+url: /reportingservices/custom-report-item-support/
+description: Manfaatkan dukungan item laporan khusus di Aspose.PDF untuk Layanan Pelaporan. Dapatkan hasil PDF yang disesuaikan dan berkualitas tinggi dengan mudah.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Dalam Spesifikasi RDL untuk RS2016, RS2017, RS2019, RS2022, dan Power BI, hampir setiap item laporan dapat diperluas dengan menambahkan properti kustom. Saat ini Aspose.PDF for Reporting Services 2016, 2017, 2019, 2022, dan Power BI mendukung tiga properti semacam itu, yaitu:
+Dalam Spesifikasi RDL untuk RS2016, RS2017, RS2019, RS2022, dan Power BI, hampir setiap item laporan dapat diperluas dengan menambahkan properti kustom. Saat ini Aspose.PDF untuk Layanan Pelaporan 2016, 2017, 2019, 2022, dan Power BI mendukung tiga properti tersebut, yaitu:
 
-- Daftar isi, daftar tabel, atau gambar.
+- Daftar isi, daftar tabel atau gambar.
 - Panah Garis.
-- Catatan kaki/Catatan akhir.
+- Catatan Kaki/Catatan Akhir.
 
-Cari tahu cara menggunakannya dalam [Perluas Properti Item Laporan](/pdf/id/reportingservices/expand-report-items-properties/) artikel.
+Cari tahu cara menggunakannya di [Perluas Properti Item Laporan](/pdf/id/reportingservices/expand-report-items-properties/) artikel.
 
 {{% /alert %}}

--- a/id/reportingservices/features/easy-and-lightweight-deployment/_index.md
+++ b/id/reportingservices/features/easy-and-lightweight-deployment/_index.md
@@ -1,21 +1,21 @@
 ---
-title: Distribusi Mudah dan Ringan
-linktitle: Distribusi Mudah dan Ringan
+title: Penerapan yang Mudah dan Ringan
+linktitle: Easy and Lightweight Deployment
 type: docs
 weight: 40
-url: /id/reportingservices/easy-and-lightweight-deployment/
-description: Pelajari cara menyebarkan Aspose.PDF for Reporting Services dengan usaha minimal. Penyiapan yang ringan memastikan implementasi cepat dan efisiensi.
-lastmod: "2026-07-29"
+url: /reportingservices/easy-and-lightweight-deployment/
+description: Pelajari cara menerapkan Aspose.PDF untuk Layanan Pelaporan dengan sedikit usaha. Penyiapan yang ringan memastikan implementasi dan efisiensi yang cepat.
+lastmod: "2021-06-05"
 ---
 
-**Aspose.PDF for Reporting Services** adalah ekstensi rendering khusus untuk Microsoft SQL Server 2016/2017/2019/2022 Reporting Services dan Power BI Report Server. Aspose.PDF for Reporting Services disediakan sebagai satu paket instalasi MSI yang dapat dipasang pada komputer yang menjalankan salah satu berikut:
+**Aspose.PDF untuk Layanan Pelaporan** adalah ekstensi rendering khusus untuk Layanan Pelaporan Microsoft SQL Server 2016/2017/2019/2022 dan Server Laporan Power BI. Aspose.PDF untuk Layanan Pelaporan disediakan sebagai penginstal MSI tunggal yang dapat diinstal pada komputer yang menjalankan salah satu dari berikut ini:
 
-- Microsoft SQL Server 2016 Reporting Services  
-- Microsoft SQL Server 2017 Reporting Services  
-- Microsoft SQL Server 2019 Reporting Services  
-- Microsoft SQL Server 2022 Reporting Services  
-- Microsoft Power BI Report Server
+- Layanan Pelaporan Microsoft SQL Server 2016  
+- Layanan Pelaporan Microsoft SQL Server 2017  
+- Layanan Pelaporan Microsoft SQL Server 2019  
+- Layanan Pelaporan Microsoft SQL Server 2022  
+- Server Laporan Microsoft Power BI
  
-Aspose.PDF for Reporting Services mudah diterapkan dan dikelola, karena hanya terdiri dari satu assembly .NET Aspose.Pdf.ReportingServices.dll, yang sepenuhnya ditulis dalam C#, mematuhi CLS, dan hanya berisi kode terkelola yang aman. Anda diwajibkan memiliki .NET Framework 4.8.1 terpasang di server.
+Aspose.PDF untuk Layanan Pelaporan mudah disebarkan dan dikelola, karena hanya terdiri dari satu rakitan .NET Aspose.Pdf.ReportingServices.dll, ditulis sepenuhnya dalam C#, sesuai dengan CLS dan hanya berisi kode terkelola yang aman. Anda harus menginstal .NET Framework 4.8.1 di server.
 
-Aspose.Pdf.ReportingServices.dll harus disalin ke direktori ReportServer\bin dan file konfigurasi harus diperbarui agar Reporting Services menyadari ekstensi rendering baru. Langkah-langkah ini dilakukan oleh penginstal Aspose.PDF for Reporting Services, tetapi Anda juga dapat melakukannya secara manual seperti yang dijelaskan lebih lanjut dalam dokumentasi ini.
+Aspose.Pdf.ReportingServices.dll harus disalin ke direktori ReportServer\bin dan file konfigurasi harus diperbarui sehingga Layanan Pelaporan mengetahui ekstensi rendering baru. Langkah-langkah ini dilakukan oleh penginstal Aspose.PDF untuk Layanan Pelaporan, namun Anda juga dapat melakukannya secara manual seperti yang dijelaskan lebih lanjut dalam dokumentasi ini.

--- a/id/reportingservices/features/easy-and-lightweight-deployment/_index.md
+++ b/id/reportingservices/features/easy-and-lightweight-deployment/_index.md
@@ -1,14 +1,14 @@
 ---
-title: Mudah dan Ringan dalam Penyebaran
-linktitle: Mudah dan Ringan dalam Penyebaran
+title: Distribusi Mudah dan Ringan
+linktitle: Distribusi Mudah dan Ringan
 type: docs
 weight: 40
 url: /id/reportingservices/easy-and-lightweight-deployment/
-description: Pelajari cara menyebarkan Aspose.PDF untuk Reporting Services dengan upaya minimal. Pengaturan ringan memastikan implementasi cepat dan efisiensi.
-lastmod: "2026-06-19"
+description: Pelajari cara menyebarkan Aspose.PDF for Reporting Services dengan usaha minimal. Penyiapan yang ringan memastikan implementasi cepat dan efisiensi.
+lastmod: "2026-07-29"
 ---
 
-**Aspose.Pdf for Reporting Services** adalah ekstensi rendering khusus untuk Microsoft SQL Server 2016/2017/2019/2022 Reporting Services dan Power BI Report Server. Aspose.Pdf for Reporting Services disediakan sebagai satu paket instalasi MSI tunggal yang dapat dipasang pada komputer yang menjalankan salah satu berikut ini:
+**Aspose.PDF for Reporting Services** adalah ekstensi rendering khusus untuk Microsoft SQL Server 2016/2017/2019/2022 Reporting Services dan Power BI Report Server. Aspose.PDF for Reporting Services disediakan sebagai satu paket instalasi MSI yang dapat dipasang pada komputer yang menjalankan salah satu berikut:
 
 - Microsoft SQL Server 2016 Reporting Services  
 - Microsoft SQL Server 2017 Reporting Services  
@@ -16,7 +16,6 @@ lastmod: "2026-06-19"
 - Microsoft SQL Server 2022 Reporting Services  
 - Microsoft Power BI Report Server
  
-Aspose.Pdf for Reporting Services mudah untuk di‑deploy dan dikelola, karena terdiri hanya dari satu assembly .NET Aspose.Pdf.ReportingServices.dll, yang ditulis sepenuhnya dalam C#, mematuhi CLS, dan hanya berisi kode terkelola yang aman. Anda harus memiliki .NET Framework 4.8.1 yang terinstal di server.
+Aspose.PDF for Reporting Services mudah diterapkan dan dikelola, karena hanya terdiri dari satu assembly .NET Aspose.Pdf.ReportingServices.dll, yang sepenuhnya ditulis dalam C#, mematuhi CLS, dan hanya berisi kode terkelola yang aman. Anda diwajibkan memiliki .NET Framework 4.8.1 terpasang di server.
 
-Aspose.Pdf.ReportingServices.dll harus disalin ke direktori ReportServer\bin dan file konfigurasi harus diperbarui agar Reporting Services menyadari ekstensi rendering baru. Langkah‑langkah ini dilakukan oleh installer Aspose.Pdf for Reporting Services, tetapi Anda juga dapat melakukannya secara manual seperti yang dijelaskan lebih lanjut dalam dokumentasi ini.
-
+Aspose.Pdf.ReportingServices.dll harus disalin ke direktori ReportServer\bin dan file konfigurasi harus diperbarui agar Reporting Services menyadari ekstensi rendering baru. Langkah-langkah ini dilakukan oleh penginstal Aspose.PDF for Reporting Services, tetapi Anda juga dapat melakukannya secara manual seperti yang dijelaskan lebih lanjut dalam dokumentasi ini.

--- a/id/reportingservices/features/parameterized-report-support/_index.md
+++ b/id/reportingservices/features/parameterized-report-support/_index.md
@@ -1,28 +1,27 @@
 ---
-title: Dukungan Laporan Parameterisasi
-linktitle: Dukungan Laporan Parameterisasi
+title: Dukungan Laporan Berparameter
+linktitle: Dukungan Laporan Berparameter
 type: docs
 weight: 20
 url: /id/reportingservices/parameterized-report-support/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-Laporan yang diparameterisasi adalah laporan yang menerima nilai input yang digunakan dalam pemrosesan laporan. Dengan laporan parameterisasi, Anda dapat mengubah output laporan berdasarkan nilai yang ditetapkan saat laporan dijalankan. Aspose.Pdf for Reporting Services mendukung dua jenis parameter: parameter server laporan dan parameter laporan. Parameter server laporan digunakan untuk semua laporan di server laporan. Jika Anda ingin membuat beberapa parameter cocok untuk laporan tertentu, Anda harus menggunakan parameter laporan.
+Laporan berparameter adalah laporan yang menerima nilai masukan yang digunakan dalam pemrosesan laporan. Dengan laporan berparameter, Anda dapat mengubah output laporan berdasarkan nilai yang ditetapkan saat laporan dijalankan. Aspose.PDF for Reporting Services mendukung dua jenis parameter: parameter server laporan dan parameter laporan. Parameter server laporan digunakan untuk semua laporan di server laporan. Jika Anda ingin membuat beberapa parameter cocok untuk laporan tertentu, Anda harus menggunakan parameter laporan.
 
-Saat ini, renderer Aspose.Pdf mendukung berbagai macam parameter, seperti:
+Saat ini, renderer Aspose.Pdf mendukung berbagai macam parameter, antara lain:
 
 ## **Parameter yang Didukung**
-Pada versi saat ini, renderer Aspose.PDF mendukung banyak aspek parameter, yaitu:
+Pada versi saat ini, render Aspose.PDF mendukung banyak aspek parameter, yaitu:
 
 - Orientasi halaman
 - Pemformatan HTML
-- Atribut keamanan
-- Ukuran halaman
-- Ukuran margin halaman
-- Penyematan font
-- Kesesuaian PDF/A
+- Atribut Keamanan
+- Ukuran Halaman
+- Ukuran Margin Halaman
+- Penyematan Font
+- Kepatuhan PDF/A
 - metadata XMP
 - Informasi debug
 
-Pelajari lebih lanjut tentang parameter dari [Konfigurasikan Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/configure-aspose-pdf-for-reporting-services/) artikel.
-
+Cari tahu lebih banyak tentang parameter dari [Konfigurasikan Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/configure-aspose-pdf-for-reporting-services/) artikel.

--- a/id/reportingservices/features/parameterized-report-support/_index.md
+++ b/id/reportingservices/features/parameterized-report-support/_index.md
@@ -1,27 +1,27 @@
 ---
 title: Dukungan Laporan Berparameter
-linktitle: Dukungan Laporan Berparameter
+linktitle: Parameterized Report Support
 type: docs
 weight: 20
-url: /id/reportingservices/parameterized-report-support/
-lastmod: "2026-07-29"
+url: /reportingservices/parameterized-report-support/
+lastmod: "2021-06-05"
 ---
 
-Laporan berparameter adalah laporan yang menerima nilai masukan yang digunakan dalam pemrosesan laporan. Dengan laporan berparameter, Anda dapat mengubah output laporan berdasarkan nilai yang ditetapkan saat laporan dijalankan. Aspose.PDF for Reporting Services mendukung dua jenis parameter: parameter server laporan dan parameter laporan. Parameter server laporan digunakan untuk semua laporan di server laporan. Jika Anda ingin membuat beberapa parameter cocok untuk laporan tertentu, Anda harus menggunakan parameter laporan.
+Laporan berparameter adalah laporan yang menerima nilai masukan yang digunakan dalam pemrosesan laporan. Dengan laporan berparameter, Anda dapat memvariasikan output laporan berdasarkan nilai yang ditetapkan saat laporan dijalankan. Aspose.PDF untuk Layanan Pelaporan mendukung dua jenis parameter: parameter server laporan dan parameter laporan. Parameter server laporan digunakan untuk semua laporan di server laporan. Jika Anda ingin membuat beberapa parameter sesuai untuk laporan tertentu, Anda harus menggunakan parameter laporan.
 
-Saat ini, renderer Aspose.Pdf mendukung berbagai macam parameter, antara lain:
+Saat ini, penyaji Aspose.Pdf mendukung berbagai parameter, seperti:
 
-## **Parameter yang Didukung**
+## Parameter yang Didukung
 Pada versi saat ini, render Aspose.PDF mendukung banyak aspek parameter, yaitu:
 
 - Orientasi halaman
 - Pemformatan HTML
-- Atribut Keamanan
-- Ukuran Halaman
-- Ukuran Margin Halaman
-- Penyematan Font
-- Kepatuhan PDF/A
-- metadata XMP
+- Atribut keamanan
+- Ukuran halaman
+- Ukuran margin halaman
+- Penyematan font
+- Kesesuaian PDF/A
+- Metadata XMP
 - Informasi debug
 
-Cari tahu lebih banyak tentang parameter dari [Konfigurasikan Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/configure-aspose-pdf-for-reporting-services/) artikel.
+Cari tahu lebih lanjut tentang parameter dari [Konfigurasikan Aspose.PDF untuk Layanan Pelaporan](/pdf/id/reportingservices/configure-aspose-pdf-for-reporting-services/) artikel.

--- a/id/reportingservices/features/world-class-free-technical-support/_index.md
+++ b/id/reportingservices/features/world-class-free-technical-support/_index.md
@@ -4,13 +4,13 @@ linktitle: Dukungan Teknis Gratis Kelas Dunia
 type: docs
 weight: 50
 url: /id/reportingservices/world-class-free-technical-support/
-description: Nikmati dukungan teknis gratis bertaraf dunia untuk Aspose.PDF for Reporting Services. Dapatkan bantuan ahli kapan saja Anda membutuhkannya.
-lastmod: "2026-06-19"
+description: Nikmati dukungan teknis gratis kelas dunia untuk Aspose.PDF for Reporting Services. Dapatkan bantuan ahli kapan saja Anda memerlukannya.
+lastmod: "2026-07-29"
 ---
 
-Aspose terkenal karena dukungan teknisnya yang gratis dan tidak terbatas, yang didukung oleh artikel teknis, manual, forum, dan dukungan serta pengembang produk yang selalu siap. Jika ada versi baru atau Hot Fix produk yang dirilis, semua rilis baru tersedia secara gratis jika Anda memiliki langganan yang aktif.
+Aspose dikenal karena dukungan teknisnya yang gratis dan tidak terbatas, yang didukung oleh artikel teknis, manual, forum, serta dukungan siap sedia kapan saja dan pengembang produk. Jika ada versi baru atau Hot Fix dari sebuah produk yang dirilis, semua rilis baru tersedia secara gratis jika Anda memiliki langganan yang aktif.
 
-**Aspose.Support Forums** adalah tempat tidak hanya untuk menyelesaikan masalah teknis, tetapi juga berpartisipasi dalam diskusi pengembangan dengan komunitas pengguna Aspose yang dinamis dan terus berkembang. Saat ini terdapat lebih dari 129.000 pengguna yang terdaftar di situs web Aspose.
+**Aspose.Support Forums** adalah tempat tidak hanya untuk menyelesaikan masalah teknis, tetapi juga berpartisipasi dalam diskusi pengembangan dengan komunitas pengguna Aspose yang dinamis dan terus berkembang. Saat ini terdapat lebih dari 129.000 pengguna terdaftar di situs web Aspose.
 
 Aspose.Blogs adalah tempat untuk mencari informasi tentang rilis terbaru dan apa yang dikatakan oleh pengembang Aspose.
 

--- a/id/reportingservices/features/world-class-free-technical-support/_index.md
+++ b/id/reportingservices/features/world-class-free-technical-support/_index.md
@@ -1,21 +1,21 @@
 ---
 title: Dukungan Teknis Gratis Kelas Dunia
-linktitle: Dukungan Teknis Gratis Kelas Dunia
+linktitle: World Class Free Technical Support
 type: docs
 weight: 50
-url: /id/reportingservices/world-class-free-technical-support/
-description: Nikmati dukungan teknis gratis kelas dunia untuk Aspose.PDF for Reporting Services. Dapatkan bantuan ahli kapan saja Anda memerlukannya.
-lastmod: "2026-07-29"
+url: /reportingservices/world-class-free-technical-support/
+description: Nikmati dukungan teknis gratis kelas dunia untuk Aspose.PDF untuk Layanan Pelaporan. Dapatkan bantuan ahli kapan pun Anda membutuhkannya.
+lastmod: "2021-06-05"
 ---
 
-Aspose dikenal karena dukungan teknisnya yang gratis dan tidak terbatas, yang didukung oleh artikel teknis, manual, forum, serta dukungan siap sedia kapan saja dan pengembang produk. Jika ada versi baru atau Hot Fix dari sebuah produk yang dirilis, semua rilis baru tersedia secara gratis jika Anda memiliki langganan yang aktif.
+Aspose terkenal dengan dukungan teknisnya yang gratis dan tidak terbatas, yang didukung oleh artikel teknis, manual, forum, dan dukungan siap pakai serta pengembang produk sepanjang masa. Jika ada versi baru atau Perbaikan Terbaru suatu produk dirilis, semua rilis baru tersedia gratis jika Anda memiliki langganan aktif.
 
-**Aspose.Support Forums** adalah tempat tidak hanya untuk menyelesaikan masalah teknis, tetapi juga berpartisipasi dalam diskusi pengembangan dengan komunitas pengguna Aspose yang dinamis dan terus berkembang. Saat ini terdapat lebih dari 129.000 pengguna terdaftar di situs web Aspose.
+**Aspose.Support Forums** adalah tempat tidak hanya untuk menyelesaikan masalah teknis, namun juga berpartisipasi dalam diskusi pembangunan dengan komunitas pengguna Aspose yang dinamis dan terus berkembang. Saat ini ada lebih dari 129.000 pengguna yang terdaftar di situs Aspose.
 
-Aspose.Blogs adalah tempat untuk mencari informasi tentang rilis terbaru dan apa yang dikatakan oleh pengembang Aspose.
+Aspose.Blogs adalah tempat untuk mencari informasi tentang rilis terbaru dan apa yang dikatakan pengembang Aspose.
 
-Ada banyak aktivitas di Aspose.Support Forums:
+Ada banyak aktivitas di Aspose. Forum Dukungan:
 
-![todo:image_alt_text](world-class-free-technical-support.png)
+![Free Technical Support](world-class-free-technical-support.png)
 
  

--- a/id/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
+++ b/id/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
@@ -1,19 +1,17 @@
 ---
 title: Instal Aspose.PDF
-linktitle: Instal Aspose.PDF
+linktitle: Install Aspose.PDF
 type: docs
 weight: 50
-url: /id/reportingservices/install-aspose-pdf-for-reporting-services/
-description: Pelajari cara menginstal Aspose.PDF untuk Reporting Services. Ikuti panduan langkah demi langkah ini untuk mengaktifkan fungsi ekspor PDF di SSRS.
-lastmod: "2026-07-29"
+url: /reportingservices/install-aspose-pdf-for-reporting-services/
+description: Pelajari cara menginstal Aspose.PDF untuk Layanan Pelaporan. Ikuti panduan langkah demi langkah ini untuk mengaktifkan fungsionalitas ekspor PDF di SSRS.
+lastmod: "2021-06-05"
 ---
-
-{{% alert color="primary" %}}
 
 **Bagian ini mencakup topik berikut:**
 
-- [Instal dengan MSI Installer](/pdf/id/reportingservices/install-with-msi-installer/)
-- [Instal secara manual](/pdf/id/reportingservices/install-manually/)
-- [Instal dengan Alat Konfigurasi](/pdf/id/reportingservices/install-with-configuring-tool/)
+- [Instal dengan Penginstal MSI](/pdf/reportingservices/install-with-msi-installer/)
+- [Instal Secara Manual](/pdf/reportingservices/install-manually/)
+- [Instal dengan Alat Konfigurasi](/pdf/reportingservices/install-with-configuring-tool/)
 
-{{% /alert %}}
+

--- a/id/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
+++ b/id/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
@@ -5,7 +5,7 @@ type: docs
 weight: 50
 url: /id/reportingservices/install-aspose-pdf-for-reporting-services/
 description: Pelajari cara menginstal Aspose.PDF untuk Reporting Services. Ikuti panduan langkah demi langkah ini untuk mengaktifkan fungsi ekspor PDF di SSRS.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
@@ -17,4 +17,3 @@ lastmod: "2026-06-19"
 - [Instal dengan Alat Konfigurasi](/pdf/id/reportingservices/install-with-configuring-tool/)
 
 {{% /alert %}}
-

--- a/id/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
+++ b/id/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
@@ -4,11 +4,10 @@ linktitle: Instal Secara Manual
 type: docs
 weight: 20
 url: /id/reportingservices/install-manually/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-**Bagian ini mencakup topik berikut:**
+**Bagian ini mencakup topik-topik berikut:**
 
-- [Instal ke Server Laporan](/pdf/id/reportingservices/install-to-report-server/)
-
+- [Instal ke Report Server](/pdf/id/reportingservices/install-to-report-server/)
 

--- a/id/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
+++ b/id/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
@@ -1,13 +1,13 @@
 ---
 title: Instal Secara Manual
-linktitle: Instal Secara Manual
+linktitle: Install Manually
 type: docs
 weight: 20
-url: /id/reportingservices/install-manually/
-lastmod: "2026-07-29"
+url: /reportingservices/install-manually/
+lastmod: "2021-06-05"
 ---
 
-**Bagian ini mencakup topik-topik berikut:**
+**Bagian ini mencakup topik berikut:**
 
-- [Instal ke Report Server](/pdf/id/reportingservices/install-to-report-server/)
+- [Instal ke Server Laporan](/pdf/reportingservices/install-to-report-server/)
 

--- a/id/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
+++ b/id/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
@@ -1,5 +1,5 @@
 ---
-title: Install to Report Server
+title: Instal ke Server Laporan
 linktitle: Install to Report Server
 type: docs
 weight: 10
@@ -9,52 +9,38 @@ lastmod: "2021-06-05"
 
 {{% alert color="primary" %}}
 
-You only need to follow these steps if you install Aspose.PDF for Reporting Services manually, not using the MSI installer. MSI installer performs all necessary installation and registration actions automatically.
+Anda hanya perlu mengikuti langkah-langkah ini jika Anda menginstal Aspose.PDF untuk Layanan Pelaporan secara manual, tidak menggunakan penginstal MSI. Penginstal MSI melakukan semua tindakan instalasi dan registrasi yang diperlukan secara otomatis.
 
 {{% /alert %}}
 
-In the following steps, you will need to copy and modify files in the directory where Microsoft SQL Server Reporting Services is installed. The SSRS 2016 assembly is located in the \Bin\SSRS2016 directory of the zip package; the SSRS 2017 assembly is located in the \Bin\SSRS2017 directory; the SSRS 2019 assembly is located in the \Bin\SSRS2019 directory; the SSRS 2022 assembly is located in the \Bin\SSRS2022 directory; the Power BI Report Server assembly is located in the \Bin\PowerBI directory. 
+Pada langkah-langkah berikut, Anda perlu menyalin dan memodifikasi file di direktori tempat Layanan Pelaporan Microsoft SQL Server diinstal. Perakitan SSRS 2016 terletak di direktori \Bin\SSRS2016 paket zip; perakitan SSRS 2017 terletak di direktori \Bin\SSRS2017; perakitan SSRS 2019 terletak di direktori \Bin\SSRS2019; perakitan SSRS 2022 terletak di direktori \Bin\SSRS2022; rakitan Server Laporan Power BI terletak di direktori \Bin\PowerBI.
 
-{{% alert color="primary" %}}
+**Langkah 1.** Temukan direktori instalasi Server Laporan. Direktori akar untuk Microsoft SQL Server biasanya C:\Program Files\Microsoft SQL Server. Proses lebih lanjut sedikit berbeda untuk Layanan Pelaporan 2016, Layanan Pelaporan 2017 dan yang lebih baru, dan Server Laporan Power BI:
 
-**Step 1.** Locate the Report Server installation directory. The root directory for Microsoft SQL Server is usually C:\Program Files\Microsoft SQL Server. Further process is slightly different for Reporting Services 2016, Reporting Services 2017 and later, and Power BI Report Server:
+- Report Server 2016 secara default diinstal di direktori C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer. Jika Anda menggunakan instans dengan nama khusus dan bukan instans default, jalur defaultnya adalah C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
+- Report Server 2017 dan yang lebih baru secara default diinstal di direktori C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer.
+- Server Laporan Power BI secara default diinstal di direktori C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer.
 
-- Report Server 2016 by default is installed in the C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer directory. If you are using custom named instances instead of the default one, the default path will be C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
-- Report Server 2017 and later by default is installed in the C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer directory.
-- Power BI Report Server by default is installed in the C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer directory.
+Dalam teks berikut, direktori instalasi Layanan Pelaporan (salah satu jalur yang disebutkan di atas) akan dirujuk sebagai `<Instance>`.
 
-In the following text the installation directory of the Reporting Services (one of the aforementioned paths) will be referenced to as ```<Instance>```.
-{{% /alert %}}
+**Langkah 2.** Salin Aspose.Pdf.ReportingServices.dll untuk versi SSRS yang sesuai ke folder `<Instance>\bin`.
 
-{{% alert color="primary" %}}
-**Step 2.** Copy Aspose.Pdf.ReportingServices.dll for the corresponding SSRS version to the ```<Instance>```\bin folder.
-{{% /alert %}}
+**Langkah 3.** Daftarkan Aspose.PDF untuk Layanan Pelaporan sebagai ekstensi rendering. Buka file `<Instance>\rsreportserver.config` dan tambahkan baris berikut ke dalam elemen `<Render>`:
 
-{{% alert color="primary" %}}
-**Step 3.** Register Aspose.PDF for Reporting Services as a rendering extension. Open the ```<Instance>```\rsreportserver.config file and add the following lines into the ```<Render>``` element:
-{{% /alert %}}
+## Contoh
 
-**Example**
-
-{{< highlight csharp >}}
-
- <Render>
+```xml
+<Render>
 ...
-<!--Start here.-->
-
 <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices"/>
-
 </Render>
+```
 
-{{< /highlight >}}
+**Langkah 4.** Berikan Aspose.PDF untuk Layanan Pelaporan dengan izin untuk mengeksekusi. Buka file `<Instance>\rssrvpolicy.config` dan tambahkan teks berikut sebagai item terakhir di elemen kedua di luar `<CodeGroup>` yang seharusnya `<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):`
 
-{{% alert color="primary" %}}
-**Step 4.** Provide Aspose.PDF for Reporting Services with permissions to execute. Open the ```<Instance>```\rssrvpolicy.config file and add the following text as the last item in the second to outer ```<CodeGroup>``` element (which should be ```<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):```
-{{% /alert %}}
+## Contoh
 
-**Example**
-
-{{< highlight csharp >}}
+```xml
 
  <CodeGroup>
 ...
@@ -77,20 +63,14 @@ Name="Aspose.Pdf_for_Reporting_Services" Description="This code group grants ful
 </CodeGroup>
 
 </CodeGroup>
+```
 
-{{< /highlight >}}
+**Langkah 5.** Verifikasi bahwa Aspose.PDF untuk Layanan Pelaporan berhasil diinstal. Buka portal web Layanan Pelaporan dan periksa daftar format ekspor yang tersedia untuk laporan. Anda dapat meluncurkan portal web dengan memulai browser web dan mengetikkan URL portal web Layanan Pelaporan di bilah alamat (secara default adalah http://@@KEEP_0@@/reports/). Pilih salah satu laporan yang tersedia di portal web Anda dan tarik daftar tarik-turun Ekspor. Anda akan melihat daftar format ekspor termasuk yang disediakan oleh ekstensi Aspose.PDF untuk Layanan Pelaporan. Pilih PDF melalui item Aspose.PDF.
 
-{{% alert color="primary" %}}
-**Step 5.** Verify that Aspose.PDF for Reporting Services was installed successfully. Open the Reporting Services web portal and check the list of available export formats for a report. You can launch the web portal by starting a web browser and typing the Reporting Services web portal URL in the address bar (by default it is http://```<Reporting_Services_server_name>```/reports/). Select one of the reports available in your web portal and pull the Export dropdown list. You should see the list of export formats including the ones provided by the Aspose.PDF for Reporting Services extension. Select PDF via Aspose.PDF item.
+![Install to report server](install-to-report-server_1.png)
 
- 
-{{% /alert %}}
+Klik item yang dipilih. Ini akan menghasilkan laporan dalam format yang dipilih, mengirimkannya ke klien, dan, tergantung pada pengaturan browser web Anda, menampilkan dialog Simpan File untuk memilih tempat menyimpan laporan yang diekspor, atau secara otomatis mengunduh file ke folder Unduhan Anda.
 
-![todo:image_alt_text](install-to-report-server_1.png)
+Selamat, Anda telah berhasil menginstal Aspose.PDF untuk Layanan Pelaporan dan mengekspor laporan sebagai dokumen PDF!
 
-Click the selected item. It will generate the report in the selected format, send it to the client, and, depending on your web browser settings, either show you the Save File dialog to choose where to save the exported report, or automatically download the file to the your Downloads folder.
-
-{{% alert color="primary" %}}
-Congratulations, you’ve successfully installed Aspose.PDF for Reporting Services and exported a report as a PDF document!
-{{% /alert %}}
 

--- a/id/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
+++ b/id/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
@@ -1,40 +1,40 @@
 ---
-title: Instal ke Report Server
-linktitle: Instal ke Report Server
+title: Install to Report Server
+linktitle: Install to Report Server
 type: docs
 weight: 10
-url: /id/reportingservices/install-to-report-server/
-lastmod: "2026-06-19"
+url: /reportingservices/install-to-report-server/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Anda hanya perlu mengikuti langkah-langkah ini jika Anda menginstal Aspose.PDF for Reporting Services secara manual, tidak menggunakan installer MSI. Installer MSI melakukan semua tindakan instalasi dan pendaftaran yang diperlukan secara otomatis.
+You only need to follow these steps if you install Aspose.PDF for Reporting Services manually, not using the MSI installer. MSI installer performs all necessary installation and registration actions automatically.
 
 {{% /alert %}}
 
-Dalam langkah-langkah berikut, Anda perlu menyalin dan memodifikasi file di direktori tempat Microsoft SQL Server Reporting Services diinstal. Assembly SSRS 2016 terletak di direktori \Bin\SSRS2016 dalam paket zip; assembly SSRS 2017 terletak di direktori \Bin\SSRS2017; assembly SSRS 2019 terletak di direktori \Bin\SSRS2019; assembly SSRS 2022 terletak di direktori \Bin\SSRS2022; assembly Power BI Report Server terletak di direktori \Bin\PowerBI. 
+In the following steps, you will need to copy and modify files in the directory where Microsoft SQL Server Reporting Services is installed. The SSRS 2016 assembly is located in the \Bin\SSRS2016 directory of the zip package; the SSRS 2017 assembly is located in the \Bin\SSRS2017 directory; the SSRS 2019 assembly is located in the \Bin\SSRS2019 directory; the SSRS 2022 assembly is located in the \Bin\SSRS2022 directory; the Power BI Report Server assembly is located in the \Bin\PowerBI directory. 
 
 {{% alert color="primary" %}}
 
-**Step 1.** Temukan direktori instalasi Report Server. Direktori root untuk Microsoft SQL Server biasanya C:\Program Files\Microsoft SQL Server. Proses selanjutnya sedikit berbeda untuk Reporting Services 2016, Reporting Services 2017 dan yang lebih baru, serta Power BI Report Server:
+**Step 1.** Locate the Report Server installation directory. The root directory for Microsoft SQL Server is usually C:\Program Files\Microsoft SQL Server. Further process is slightly different for Reporting Services 2016, Reporting Services 2017 and later, and Power BI Report Server:
 
-- Report Server 2016 secara default diinstal di direktori C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer. Jika Anda menggunakan instance dengan nama khusus selain yang default, jalur default akan menjadi C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
-- Report Server 2017 dan versi selanjutnya secara default diinstal di direktori C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer.
-- Power BI Report Server secara default diinstal di direktori C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer.
+- Report Server 2016 by default is installed in the C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer directory. If you are using custom named instances instead of the default one, the default path will be C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
+- Report Server 2017 and later by default is installed in the C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer directory.
+- Power BI Report Server by default is installed in the C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer directory.
 
-Dalam teks berikut, direktori instalasi Reporting Services (salah satu jalur yang disebutkan di atas) akan dirujuk sebagai ```<Instance>```.
+In the following text the installation directory of the Reporting Services (one of the aforementioned paths) will be referenced to as ```<Instance>```.
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Langkah 2.** Salin Aspose.Pdf.ReportingServices.dll untuk versi SSRS yang sesuai ke ```<Instance>```folder \bin.
+**Step 2.** Copy Aspose.Pdf.ReportingServices.dll for the corresponding SSRS version to the ```<Instance>```\bin folder.
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Langkah 3.** Daftarkan Aspose.Pdf untuk Reporting Services sebagai ekstensi rendering. Buka ```<Instance>```\rsreportserver.config file dan tambahkan baris berikut ke dalam ```<Render>``` elemen:
+**Step 3.** Register Aspose.PDF for Reporting Services as a rendering extension. Open the ```<Instance>```\rsreportserver.config file and add the following lines into the ```<Render>``` element:
 {{% /alert %}}
 
-**Contoh**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -49,10 +49,10 @@ Dalam teks berikut, direktori instalasi Reporting Services (salah satu jalur yan
 {{< /highlight >}}
 
 {{% alert color="primary" %}}
-**Step 4.** Sediakan Aspose.Pdf for Reporting Services dengan izin untuk dijalankan. Buka file ```<Instance>```\rssrvpolicy.config dan tambahkan teks berikut sebagai item terakhir dalam elemen ```<CodeGroup>``` kedua dari luar (yang seharusnya ```<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):```):
+**Step 4.** Provide Aspose.PDF for Reporting Services with permissions to execute. Open the ```<Instance>```\rssrvpolicy.config file and add the following text as the last item in the second to outer ```<CodeGroup>``` element (which should be ```<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):```
 {{% /alert %}}
 
-**Contoh**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -81,20 +81,16 @@ Name="Aspose.Pdf_for_Reporting_Services" Description="This code group grants ful
 {{< /highlight >}}
 
 {{% alert color="primary" %}}
-**Langkah 5.** Verifikasi bahwa Aspose.Pdf for Reporting Services telah diinstal dengan sukses. Buka portal web Reporting Services dan periksa daftar format ekspor yang tersedia untuk sebuah laporan. Anda dapat meluncurkan portal web dengan memulai peramban web dan mengetikkan URL portal web Reporting Services di bilah alamat (secara default adalah http://```<Reporting_Services_server_name>```/reports/). Pilih salah satu laporan yang tersedia di portal web Anda dan tarik daftar dropdown Export. Anda harus melihat daftar format ekspor termasuk yang disediakan oleh ekstensi Aspose.Pdf for Reporting Services. Pilih item PDF via Aspose.PDF.
+**Step 5.** Verify that Aspose.PDF for Reporting Services was installed successfully. Open the Reporting Services web portal and check the list of available export formats for a report. You can launch the web portal by starting a web browser and typing the Reporting Services web portal URL in the address bar (by default it is http://```<Reporting_Services_server_name>```/reports/). Select one of the reports available in your web portal and pull the Export dropdown list. You should see the list of export formats including the ones provided by the Aspose.PDF for Reporting Services extension. Select PDF via Aspose.PDF item.
 
  
 {{% /alert %}}
 
 ![todo:image_alt_text](install-to-report-server_1.png)
 
-Klik item yang dipilih. Itu akan menghasilkan laporan dalam format yang dipilih, mengirimkannya ke klien, dan, tergantung pada pengaturan peramban web Anda, baik menampilkan dialog Simpan File untuk memilih tempat menyimpan laporan yang diekspor, atau secara otomatis mengunduh file ke folder Unduhan Anda.
+Click the selected item. It will generate the report in the selected format, send it to the client, and, depending on your web browser settings, either show you the Save File dialog to choose where to save the exported report, or automatically download the file to the your Downloads folder.
 
 {{% alert color="primary" %}}
-Selamat, Anda telah berhasil menginstal Aspose.Pdf for Reporting Services dan mengekspor laporan sebagai dokumen PDF!
+Congratulations, you’ve successfully installed Aspose.PDF for Reporting Services and exported a report as a PDF document!
 {{% /alert %}}
-
-
-
-
 

--- a/id/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
+++ b/id/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
@@ -1,14 +1,14 @@
 ---
-title: Instal dengan Alat Pengaturan
-linktitle: Instal dengan Alat Pengaturan
+title: Instal dengan Alat Konfigurasi
+linktitle: Instal dengan Alat Konfigurasi
 type: docs
 weight: 30
 url: /id/reportingservices/install-with-configuring-tool/
-description: Panduan langkah demi langkah untuk menginstal Aspose.PDF untuk Reporting Services menggunakan alat konfigurasi untuk integrasi yang mulus.
-lastmod: "2026-06-19"
+description: Panduan langkah demi langkah untuk menginstal Aspose.PDF for Reporting Services menggunakan alat konfigurasi untuk integrasi yang mulus.
+lastmod: "2026-07-29"
 ---
 
-Alat Konfigurasi Aspose.Pdf untuk Reporting Services dapat membantu Anda mengonfigurasi ekstensi Aspose.Pdf untuk Reporting Services untuk semua versi Report Server (RS) yang didukung. Saat ini mendukung RS2016, RS2017, RS2019, RS2022, dan Power BI Report Server. Alat Konfigurasi memerlukan .NET Framework 4.8.
+Alat Konfigurasi Aspose.PDF for Reporting Services dapat membantu Anda mengkonfigurasi ekstensi Aspose.PDF for Reporting Services untuk setiap versi Report Server (RS) yang didukung. Saat ini mendukung RS2016, RS2017, RS2019, RS2022, dan Power BI Report Server. Alat Konfigurasi memerlukan .NET Framework 4.8.
 
 Jika Anda ingin menginstal ekstensi dan mendaftarkannya ke Report Server, pilih tipe aksi ‘Register’. Untuk membatalkan pendaftaran dan menghapus ekstensi, pilih tipe aksi ‘Unregister’.
 
@@ -16,10 +16,9 @@ Jika Anda ingin menginstal ekstensi dan mendaftarkannya ke Report Server, pilih 
 
 **Langkah-langkah berikut menjelaskan cara menggunakannya secara detail:**
 
-1. Masukkan atau telusuri jalur file DLL untuk ekstensi Aspose.Pdf for Reporting Services;
-1. Pilih jenis aksi yang sesuai: Register atau Unregister;
-1. Pilih tab yang sesuai dengan versi Report Server yang ingin Anda konfigurasikan. Pastikan Anda telah memilih file DLL yang ditujukan untuk versi RS Anda. Jika versi produk yang diminta tidak terpasang di mesin, alat konfigurasi akan memberi Anda petunjuk. Jika Anda mengonfigurasi ekstensi untuk instance RS2016 yang bernama (bukan yang default \u0027MSSQLSERVER\u0027), silakan masukkan nama instance khusus, lalu tekan tombol \u0027Refresh\u0027.
-1. Pastikan jalur dan nama file konfigurasi yang ditampilkan di kotak teks bagian bawah sudah benar. Jika tidak, Anda dapat menekan tombol \u0027Refresh\u0027 untuk mencoba menemukan instance RS lagi, atau Anda dapat mencarinya secara manual.
-1. Tekan tombol \u0027Config\u0027. Alat kini akan mencoba melakukan konfigurasi yang diminta, dan akan memberi tahu Anda apakah konfigurasi berhasil atau tidak.
+1. Masukkan atau telusuri jalur file DLL untuk ekstensi Aspose.PDF for Reporting Services;
+1. Pilih jenis tindakan yang sesuai: Register atau Unregister;
+1. Pilih tab yang sesuai dengan versi Report Server yang ingin Anda konfigurasi.Silakan pastikan bahwa Anda memilih file DLL yang ditujukan untuk versi RS Anda. Jika versi produk yang diminta tidak terpasang di mesin, alat konfigurasi akan memberi Anda tip. Jika Anda mengkonfigurasi ekstensi untuk instance RS2016 yang bernama (bukan yang default 'MSSQLSERVER'), silakan masukkan nama instance khusus, lalu tekan tombol 'Refresh' button.
+1. Pastikan bahwa jalur dan nama file konfigurasi yang ditampilkan di kotak teks bagian bawah sudah benar. Jika tidak, Anda dapat menekan tombol 'Refresh' untuk mencoba menemukan instance RS lagi, atau Anda dapat mencarinya secara manual.
+1. Tekan tombol 'Config'. Alat sekarang akan mencoba melakukan konfigurasi yang diminta, dan akan memberi tahu Anda apakah konfigurasi berhasil atau tidak.
  
-

--- a/id/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
+++ b/id/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
@@ -1,24 +1,23 @@
 ---
 title: Instal dengan Alat Konfigurasi
-linktitle: Instal dengan Alat Konfigurasi
+linktitle: Install with Configuring Tool
 type: docs
 weight: 30
-url: /id/reportingservices/install-with-configuring-tool/
-description: Panduan langkah demi langkah untuk menginstal Aspose.PDF for Reporting Services menggunakan alat konfigurasi untuk integrasi yang mulus.
-lastmod: "2026-07-29"
+url: /reportingservices/install-with-configuring-tool/
+description: Panduan langkah demi langkah untuk menginstal Aspose.PDF untuk Layanan Pelaporan menggunakan alat konfigurasi untuk integrasi yang lancar.
+lastmod: "2021-06-05"
 ---
 
-Alat Konfigurasi Aspose.PDF for Reporting Services dapat membantu Anda mengkonfigurasi ekstensi Aspose.PDF for Reporting Services untuk setiap versi Report Server (RS) yang didukung. Saat ini mendukung RS2016, RS2017, RS2019, RS2022, dan Power BI Report Server. Alat Konfigurasi memerlukan .NET Framework 4.8.
+Alat Konfigurasi Aspose.PDF untuk Layanan Pelaporan dapat membantu Anda mengonfigurasi ekstensi Aspose.PDF untuk Layanan Pelaporan untuk versi Server Laporan (RS) apa pun yang didukung. Saat ini mendukung RS2016, RS2017, RS2019, RS2022, dan Power BI Report Server. Alat Konfigurasi memerlukan .NET Framework 4.8.
 
-Jika Anda ingin menginstal ekstensi dan mendaftarkannya ke Report Server, pilih tipe aksi ‘Register’. Untuk membatalkan pendaftaran dan menghapus ekstensi, pilih tipe aksi ‘Unregister’.
+Jika Anda ingin memasang ekstensi dan mendaftarkannya ke Server Laporan, pilih jenis tindakan `Register`. Untuk membatalkan pendaftaran dan mencopot pemasangan ekstensi, pilih jenis tindakan `Unregister`.
 
-![todo:image_alt_text](install-with-configuring-tool_1.png)
+![Install with configuring tool](install-with-configuring-tool_1.png)
 
 **Langkah-langkah berikut menjelaskan cara menggunakannya secara detail:**
 
-1. Masukkan atau telusuri jalur file DLL untuk ekstensi Aspose.PDF for Reporting Services;
-1. Pilih jenis tindakan yang sesuai: Register atau Unregister;
-1. Pilih tab yang sesuai dengan versi Report Server yang ingin Anda konfigurasi.Silakan pastikan bahwa Anda memilih file DLL yang ditujukan untuk versi RS Anda. Jika versi produk yang diminta tidak terpasang di mesin, alat konfigurasi akan memberi Anda tip. Jika Anda mengkonfigurasi ekstensi untuk instance RS2016 yang bernama (bukan yang default 'MSSQLSERVER'), silakan masukkan nama instance khusus, lalu tekan tombol 'Refresh' button.
-1. Pastikan bahwa jalur dan nama file konfigurasi yang ditampilkan di kotak teks bagian bawah sudah benar. Jika tidak, Anda dapat menekan tombol 'Refresh' untuk mencoba menemukan instance RS lagi, atau Anda dapat mencarinya secara manual.
-1. Tekan tombol 'Config'. Alat sekarang akan mencoba melakukan konfigurasi yang diminta, dan akan memberi tahu Anda apakah konfigurasi berhasil atau tidak.
- 
+1. Masukkan atau telusuri jalur file DLL untuk ekstensi Aspose.PDF untuk Layanan Pelaporan;
+1. Pilih jenis tindakan yang sesuai: Daftar atau Batalkan Pendaftaran;
+1. Pilih tab yang sesuai dengan versi Server Laporan yang ingin Anda konfigurasi. Pastikan Anda memilih file DLL yang ditujukan untuk versi RS Anda. Jika versi produk yang diminta tidak diinstal pada mesin, alat konfigurasi akan memberi tahu Anda tip. Jika Anda mengonfigurasi ekstensi untuk instans RS2016 yang diberi nama (bukan yang default 'MSSQLSERVER'), silakan masukkan nama instans khusus, lalu tekan tombol 'Segarkan'.
+1. Pastikan jalur dan nama file konfigurasi yang ditampilkan di kotak teks bawah sudah benar. Jika tidak, Anda dapat menekan tombol 'Segarkan' untuk mencoba menemukan kembali instance RS, atau Anda dapat mencarinya secara manual.
+1. Tekan tombol 'Konfigurasi'. Alat tersebut sekarang akan mencoba membuat konfigurasi yang diminta, dan akan memberi tahu Anda apakah konfigurasi berhasil atau tidak.

--- a/id/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
+++ b/id/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
@@ -4,21 +4,20 @@ linktitle: Instal dengan MSI Installer
 type: docs
 weight: 10
 url: /id/reportingservices/install-with-msi-installer/
-description: Pelajari cara menginstal Aspose.PDF for Reporting Services menggunakan MSI installer. Panduan sederhana untuk penyiapan cepat.
-lastmod: "2026-06-19"
+description: Pelajari cara menginstal Aspose.PDF for Reporting Services menggunakan penginstal MSI. Panduan sederhana untuk penyiapan cepat.
+lastmod: "2026-07-29"
 ---
 
-Anda dapat menginstal Aspose.Pdf for Reporting Services dengan menggunakan MSI installer. Jalankan Aspose.Pdf.ReportingServices.msi dan ikuti langkah-langkah yang disediakan oleh installer. Installer akan menyalin assembly dan file lainnya ke direktori yang ditentukan serta menginstal produk pada instance default Reporting Services. Anda tidak perlu menyalin atau memodifikasi file secara manual kecuali Anda ingin menambahkan parameter konfigurasi khusus seperti yang dijelaskan pada bagian 'Configure Aspose.Pdf for Reporting Services'.
+Anda dapat menginstal Aspose.PDF for Reporting Services dengan menggunakan penginstal MSI. Jalankan Aspose.Pdf.ReportingServices.msi dan ikuti langkah‑langkah yang ditawarkan oleh penginstal. Penginstal akan menyalin assembly dan file lain ke direktori yang ditentukan serta menginstal produk pada instance default Reporting Services. Anda tidak perlu menyalin atau memodifikasi file secara manual kecuali Anda ingin menambahkan parameter konfigurasi khusus seperti yang dijelaskan pada bagian 'Configure Aspose.PDF for Reporting Services'.
 
 Instalasi otomatis adalah opsi terbaik yang berfungsi dalam kebanyakan kasus. Namun, Anda mungkin perlu menginstal produk secara manual dalam beberapa situasi seperti:
  
 - Instalasi otomatis gagal karena masalah keamanan I/O.
 - Anda perlu menginstal produk pada instance bernama (bukan default) Reporting Services 2016 atau pada beberapa instance.
-- Anda memperbarui ke versi terbaru dan hanya ingin mengganti assembly alih-alih mencopot versi lama dan menginstal yang baru menggunakan penginstal MSI.
+- Anda memperbarui ke versi terbaru dan hanya ingin mengganti assembly alih-alih menghapus versi lama dan menginstal yang baru menggunakan installer MSI.
  
 {{% alert color="primary" %}}
 
-Catatan: Perlu diketahui bahwa dalam kasus terakhir Anda mungkin berakhir dengan komponen lain (seperti dokumentasi offline) tidak diperbarui ke versi yang sesuai.
+Catatan: Perhatikan bahwa dalam kasus terakhir Anda mungkin akan berakhir dengan komponen lain (seperti dokumentasi offline) yang tidak diperbarui ke versi yang sesuai.
 
 {{% /alert %}}
-

--- a/id/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
+++ b/id/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
@@ -1,23 +1,23 @@
 ---
-title: Instal dengan MSI Installer
-linktitle: Instal dengan MSI Installer
+title: Instal dengan Penginstal MSI
+linktitle: Install with MSI Installer
 type: docs
 weight: 10
-url: /id/reportingservices/install-with-msi-installer/
-description: Pelajari cara menginstal Aspose.PDF for Reporting Services menggunakan penginstal MSI. Panduan sederhana untuk penyiapan cepat.
-lastmod: "2026-07-29"
+url: /reportingservices/install-with-msi-installer/
+description: Pelajari cara menginstal Aspose.PDF untuk Layanan Pelaporan menggunakan penginstal MSI. Panduan sederhana untuk pengaturan cepat.
+lastmod: "2021-06-05"
 ---
 
-Anda dapat menginstal Aspose.PDF for Reporting Services dengan menggunakan penginstal MSI. Jalankan Aspose.Pdf.ReportingServices.msi dan ikuti langkah‑langkah yang ditawarkan oleh penginstal. Penginstal akan menyalin assembly dan file lain ke direktori yang ditentukan serta menginstal produk pada instance default Reporting Services. Anda tidak perlu menyalin atau memodifikasi file secara manual kecuali Anda ingin menambahkan parameter konfigurasi khusus seperti yang dijelaskan pada bagian 'Configure Aspose.PDF for Reporting Services'.
+Anda dapat menginstal Aspose.PDF untuk Layanan Pelaporan dengan menggunakan penginstal MSI. Jalankan Aspose.Pdf.ReportingServices.msi dan ikuti langkah-langkah yang ditawarkan oleh penginstal. Penginstal akan menyalin rakitan dan file lainnya ke direktori yang ditentukan dan menginstal produk pada mesin virtual default Layanan Pelaporan. Anda tidak perlu menyalin atau memodifikasi file apa pun secara manual kecuali Anda ingin menambahkan parameter konfigurasi khusus seperti yang dijelaskan di bagian 'Konfigurasi Aspose.PDF untuk Layanan Pelaporan'.
 
-Instalasi otomatis adalah opsi terbaik yang berfungsi dalam kebanyakan kasus. Namun, Anda mungkin perlu menginstal produk secara manual dalam beberapa situasi seperti:
- 
+Instalasi otomatis adalah pilihan terbaik yang berfungsi dalam banyak kasus. Namun, Anda mungkin perlu menginstal produk secara manual dalam beberapa situasi seperti:
+
 - Instalasi otomatis gagal karena masalah keamanan I/O.
-- Anda perlu menginstal produk pada instance bernama (bukan default) Reporting Services 2016 atau pada beberapa instance.
-- Anda memperbarui ke versi terbaru dan hanya ingin mengganti assembly alih-alih menghapus versi lama dan menginstal yang baru menggunakan installer MSI.
+- Anda perlu menginstal produk pada contoh bernama (bukan default) Reporting Services 2016 atau pada beberapa contoh.
+- Anda meningkatkan ke versi terbaru dan hanya ingin mengganti rakitan alih-alih menghapus instalan versi lama dan menginstal yang baru menggunakan penginstal MSI.
  
 {{% alert color="primary" %}}
 
-Catatan: Perhatikan bahwa dalam kasus terakhir Anda mungkin akan berakhir dengan komponen lain (seperti dokumentasi offline) yang tidak diperbarui ke versi yang sesuai.
+Catatan: Perhatikan bahwa dalam kasus terakhir, Anda mungkin mendapatkan komponen lain (seperti dokumentasi offline) yang tidak ditingkatkan ke versi yang sesuai.
 
 {{% /alert %}}

--- a/id/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
+++ b/id/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
@@ -1,52 +1,50 @@
 ---
-title: License
+title: Lisensi
 linktitle: License
 
 type: docs
 weight: 70
 url: /reportingservices/license-aspose-pdf-for-reporting-services/
-description: Understand licensing options for Aspose.PDF for Reporting Services. Find out how to activate your license and unlock full functionality.
+description: Memahami opsi lisensi untuk Aspose.PDF untuk Layanan Pelaporan. Cari tahu cara mengaktifkan lisensi Anda dan membuka fungsionalitas penuh.
 lastmod: "2021-06-05"
 ---
 
-**Aspose.PDF for Reporting Services** evaluation version provide the same set of features as present in Licensed version, except for the evaluation watermark in resultant PDF when using evaluation version. Please visit our website and download the product version and start exploring our product with complete set of features in an evaluation mode.
+**Aspose.PDF untuk Layanan Pelaporan** versi evaluasi menyediakan serangkaian fitur yang sama seperti yang ada dalam versi Berlisensi, kecuali untuk tanda air evaluasi dalam PDF yang dihasilkan saat menggunakan versi evaluasi. Silakan kunjungi situs web kami dan unduh versi produk dan mulailah menjelajahi produk kami dengan serangkaian fitur lengkap dalam mode evaluasi.
 
-When you are happy with your evaluation, [buy a license](https://purchase.aspose.com/buy). Before purchasing, make sure you understand and agree to the license subscription terms.
+Jika Anda puas dengan evaluasi Anda, [beli lisensi](https://purchase.aspose.com/buy). Sebelum membeli, pastikan Anda memahami dan menyetujui persyaratan berlangganan lisensi.
 
-The license will be available for download from the order page after the order is paid. The license is a clear text, digitally signed XML file. The license contains information such as the client's name, the purchased product and the type of the license. Do not modify the content of the license file as it will invalidate the license.
+Lisensi akan tersedia untuk diunduh dari halaman pemesanan setelah pesanan dibayar. Lisensinya berupa file XML teks yang jelas dan ditandatangani secara digital. Lisensi berisi informasi seperti nama klien, produk yang dibeli, dan jenis lisensi. Jangan mengubah konten file lisensi karena akan membatalkan lisensi.
 
-## Licensing a Server
+## Melisensikan Server
 
-Download the license file and copy it to the C:\Program Files\Microsoft SQL Server\```<Instance>``\Reporting Services\ReportServer\bin, or C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin, or C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin folder on the server (the same folder where the Aspose.Pdf.ReportingServices.dll is placed).
+Unduh file lisensi dan salin ke folder C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\bin, atau C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin, atau C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin di server (folder yang sama di mana Aspose.Pdf.ReportingServices.dll ditempatkan).
 
-```<Instance>``` is the subdirectory name that corresponds to the Microsoft SQL Server 2016 instance you want to license.
+`<Instance>` adalah nama subdirektori yang sesuai dengan instans Microsoft SQL Server 2016 yang ingin Anda lisensikan.
 
-The default instance directory for Microsoft SQL Server 2016 is MSRS13.MSSQLSERVER.
-For the Microsoft SQL Server 2017 and later the default instance path is C:\Program Files\Microsoft SQL Server\SSRS.
-For the Power BI Report Server the default instance path is C:\Program Files\Microsoft Power BI Report Server\PBIRS.
+Direktori instans default untuk Microsoft SQL Server 2016 adalah MSRS13.MSSQLSERVER.
+Untuk Microsoft SQL Server 2017 dan yang lebih baru, jalur instans default adalah C:\Program Files\Microsoft SQL Server\SSRS.
+Untuk Server Laporan Power BI, jalur instans default adalah C:\Program Files\Microsoft Power BI Report Server\PBIRS.
 
-**PDF generated using “Territory sales drilldown” report**
+**PDF dibuat menggunakan laporan "Penelusuran penjualan wilayah"**
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_1.png)
+![License-Territory sales drilldown](license-aspose-pdf-for-reporting-services_1.png)
 
+**PDF dibuat menggunakan laporan "Rincian Pesanan Penjualan"**
 
-**PDF generated using “Sales Order details” report**
+![License-Sales Order details](license-aspose-pdf-for-reporting-services_2.png)
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_2.png)
+Jika ada masalah saat menginisialisasi lisensi, tanda air evaluasi ditampilkan dalam dokumen PDF yang dihasilkan seperti yang ditentukan di bawah ini.
 
-If there is a problem while initializing the license, an evaluation watermark is displayed in the resultant PDF document as specified below.
+**Dokumen PDF dibuat menggunakan "Penelusuran Penjualan Wilayah" dengan tanda air**
 
-**PDF document generated using “Territory Sales Drilldown” with watermark**
+![License-Territory Sales Drilldown](license-aspose-pdf-for-reporting-services_3.png)
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_3.png)
+Harap perhatikan bahwa nama file lisensi yang didukung adalah Aspose.PDF.ReportingServices.lic, Aspose.Total.ReportingServices.lic dan Aspose.Total.Product.Family.lic. Jika file tersebut memiliki nama lain, silakan ganti namanya.
 
-Please note that that supported license file names are Aspose.PDF.ReportingServices.lic, Aspose.Total.ReportingServices.lic and Aspose.Total.Product.Family.lic. If the file has any other name, please rename it.
-
-
-## Temporary License
+## Lisensi Sementara
 
 {{% alert color="primary" %}}
 
-You may also request a 30 days temporary license to test the product. Please visit the following link for more information on how to get Temporary license. [Get a Temporary License](https://purchase.aspose.com/temporary-license).
+Anda juga dapat meminta lisensi sementara selama 30 hari untuk menguji produk. Silakan kunjungi tautan berikut untuk informasi lebih lanjut tentang cara mendapatkan lisensi Sementara. [Dapatkan Lisensi Sementara](https://purchase.aspose.com/temporary-license).
 
 {{% /alert %}}

--- a/id/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
+++ b/id/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
@@ -1,23 +1,23 @@
 ---
-title: Lisensi
-linktitle: Lisensi
+title: License
+linktitle: License
 
 type: docs
 weight: 70
-url: /id/reportingservices/license-aspose-pdf-for-reporting-services/
-description: Pahami opsi lisensi untuk Aspose.PDF for Reporting Services. Ketahui cara mengaktifkan lisensi Anda dan membuka semua fungsi.
-lastmod: "2026-06-19"
+url: /reportingservices/license-aspose-pdf-for-reporting-services/
+description: Understand licensing options for Aspose.PDF for Reporting Services. Find out how to activate your license and unlock full functionality.
+lastmod: "2021-06-05"
 ---
 
-**Aspose.Pdf for Reporting Services** versi evaluasi menyediakan serangkaian fitur yang sama dengan versi Berlisensi, kecuali watermark evaluasi pada PDF yang dihasilkan saat menggunakan versi evaluasi. Silakan kunjungi situs web kami dan unduh versi produk serta mulai menjelajahi produk kami dengan set lengkap fitur dalam mode evaluasi.
+**Aspose.PDF for Reporting Services** evaluation version provide the same set of features as present in Licensed version, except for the evaluation watermark in resultant PDF when using evaluation version. Please visit our website and download the product version and start exploring our product with complete set of features in an evaluation mode.
 
-Saat Anda puas dengan evaluasi Anda, [beli lisensi](https://purchase.aspose.com/buy). Sebelum membeli, pastikan Anda memahami dan menyetujui ketentuan langganan lisensi.
+When you are happy with your evaluation, [buy a license](https://purchase.aspose.com/buy). Before purchasing, make sure you understand and agree to the license subscription terms.
 
-Lisensi akan tersedia untuk diunduh dari halaman pesanan setelah pesanan dibayar. Lisensi adalah file XML teks jelas yang ditandatangani secara digital. Lisensi berisi informasi seperti nama klien, produk yang dibeli, dan jenis lisensi. Jangan mengubah isi file lisensi karena akan membuat lisensi tidak valid.
+The license will be available for download from the order page after the order is paid. The license is a clear text, digitally signed XML file. The license contains information such as the client's name, the purchased product and the type of the license. Do not modify the content of the license file as it will invalidate the license.
 
-## Melisensikan Server
+## Licensing a Server
 
-Unduh file lisensi dan salin ke C:\Program Files\Microsoft SQL Server\```<Instance>``\Reporting Services\ReportServer\bin, or C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin, or C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin folder on the server (the same folder where the Aspose.Pdf.ReportingServices.dll is placed).
+Download the license file and copy it to the C:\Program Files\Microsoft SQL Server\```<Instance>``\Reporting Services\ReportServer\bin, or C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin, or C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin folder on the server (the same folder where the Aspose.Pdf.ReportingServices.dll is placed).
 
 ```<Instance>``` is the subdirectory name that corresponds to the Microsoft SQL Server 2016 instance you want to license.
 
@@ -50,4 +50,3 @@ Please note that that supported license file names are Aspose.PDF.ReportingServi
 You may also request a 30 days temporary license to test the product. Please visit the following link for more information on how to get Temporary license. [Get a Temporary License](https://purchase.aspose.com/temporary-license).
 
 {{% /alert %}}
-

--- a/id/reportingservices/product-overview/_index.md
+++ b/id/reportingservices/product-overview/_index.md
@@ -4,8 +4,8 @@ linktitle: Ikhtisar Produk
 type: docs
 weight: 10
 url: /id/reportingservices/product-overview/
-description: Ikhtisar Aspose.PDF for Reporting Services – solusi komprehensif untuk merender laporan SSRS ke PDF dengan fitur tata letak lanjutan.
-lastmod: "2026-06-19"
+description: Ikhtisar tentang Aspose.PDF for Reporting Services – solusi komprehensif untuk merender laporan SSRS ke PDF dengan fitur tata letak lanjutan.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
@@ -16,16 +16,15 @@ lastmod: "2026-06-19"
 
 ## Selamat datang di Aspose.PDF for Reporting Services!
 
-Microsoft SQL Server Reporting Services memenuhi kebutuhan yang dihadapi banyak organisasi - kebutuhan untuk membangun solusi kecerdasan bisnis dan pelaporan. Sampai saat ini, pengembang harus menyematkan laporan ke dalam aplikasi mereka, atau organisasi harus membeli solusi pelaporan pihak ketiga yang mahal dan terkadang bermasalah. Sekarang, Microsoft SQL Server Reporting Services menawarkan solusi lengkap untuk mendistribusikan laporan di seluruh perusahaan; memungkinkan bisnis membuat keputusan yang lebih baik dan lebih cepat.
+Microsoft SQL Server Reporting Services memenuhi kebutuhan yang dihadapi banyak organisasi - kebutuhan untuk membangun solusi intelijen bisnis dan pelaporan. Sampai saat ini, pengembang diwajibkan untuk menyematkan laporan ke dalam aplikasi mereka, atau organisasi diwajibkan untuk membeli solusi pelaporan pihak ketiga yang mahal dan terkadang bermasalah. Sekarang, Microsoft SQL Server Reporting Services menawarkan solusi lengkap untuk mendistribusikan laporan di seluruh perusahaan; memungkinkan bisnis membuat keputusan yang lebih baik dan lebih cepat.
 
-**Aspose.Pdf for Reporting Services** adalah solusi unik lainnya dari Aspose, yang memungkinkan pembuatan laporan PDF di Microsoft SQL Server 2016/2017/2019/2022 Reporting Services dan Power BI Report Server. Semua fitur laporan RDL, termasuk tabel, matriks, diagram, dan gambar dikonversi dengan tingkat presisi tertinggi ke PDF.
+**Aspose.PDF for Reporting Services** adalah solusi unik lainnya dari Aspose, yang memungkinkan pembuatan laporan PDF di Microsoft SQL Server 2016/2017/2019/2022 Reporting Services dan Power BI Report Server. Semua fitur laporan RDL, termasuk tabel, matriks, grafik, dan gambar, dikonversi dengan tingkat presisi tertinggi ke PDF.
 
-Microsoft SQL Server Reporting Services memiliki kemampuan bawaan untuk mengekspor laporan sebagai dokumen PDF, tetapi tidak menyediakan dukungan teknis yang diperlukan bagi pengguna akhir. Aspose.Pdf berupaya memberikan dukungan teknis yang prima dan efisien.
+Microsoft SQL Server Reporting Services memiliki kemampuan bawaan untuk mengekspor laporan sebagai dokumen PDF, tetapi tidak menyediakan dukungan teknis yang diperlukan bagi pengguna akhir. Aspose.Pdf berupaya memberikan dukungan teknis yang unggul dan efisien.
 
-Aspose.Pdf for Reporting Services membuat dokumen di server tanpa menggunakan Adobe.Pdf SDK. Aspose.Pdf for Reporting Services secara internal menggunakan Aspose.Pdf for .NET – komponen kelas dunia untuk pemrosesan dan konversi dokumen sisi server.
+Aspose.PDF for Reporting Services membuat dokumen di server tanpa memanfaatkan Adobe.Pdf SDK. Aspose.PDF for Reporting Services secara internal menggunakan Aspose.PDF for .NET – komponen kelas dunia untuk pemrosesan dokumen sisi server dan konversi.
 
-## Aspose.PDF for Reporting Services memungkinkan mengekspor laporan apa pun dalam format PDF
+## Aspose.PDF for Reporting Services memungkinkan mengekspor laporan apa pun dalam format PDF.
 
 ![todo:image_alt_text](product-overview_2.png)
-
 

--- a/id/reportingservices/product-overview/_index.md
+++ b/id/reportingservices/product-overview/_index.md
@@ -1,11 +1,11 @@
 ---
 title: Ikhtisar Produk
-linktitle: Ikhtisar Produk
+linktitle: Product Overview
 type: docs
 weight: 10
-url: /id/reportingservices/product-overview/
-description: Ikhtisar tentang Aspose.PDF for Reporting Services – solusi komprehensif untuk merender laporan SSRS ke PDF dengan fitur tata letak lanjutan.
-lastmod: "2026-07-29"
+url: /reportingservices/product-overview/
+description: Ikhtisar Aspose.PDF untuk Layanan Pelaporan – solusi komprehensif untuk merender laporan SSRS ke PDF dengan fitur tata letak tingkat lanjut.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
@@ -14,17 +14,17 @@ lastmod: "2026-07-29"
 
 {{% /alert %}}
 
-## Selamat datang di Aspose.PDF for Reporting Services!
+## Selamat datang di Aspose.PDF untuk Layanan Pelaporan!
 
-Microsoft SQL Server Reporting Services memenuhi kebutuhan yang dihadapi banyak organisasi - kebutuhan untuk membangun solusi intelijen bisnis dan pelaporan. Sampai saat ini, pengembang diwajibkan untuk menyematkan laporan ke dalam aplikasi mereka, atau organisasi diwajibkan untuk membeli solusi pelaporan pihak ketiga yang mahal dan terkadang bermasalah. Sekarang, Microsoft SQL Server Reporting Services menawarkan solusi lengkap untuk mendistribusikan laporan di seluruh perusahaan; memungkinkan bisnis membuat keputusan yang lebih baik dan lebih cepat.
+Layanan Pelaporan Microsoft SQL Server memenuhi kebutuhan yang dihadapi banyak organisasi - kebutuhan untuk membangun intelijen bisnis dan solusi pelaporan. Hingga saat ini, pengembang diharuskan untuk menyematkan laporan ke dalam aplikasi mereka, atau organisasi diharuskan membeli solusi pelaporan pihak ketiga yang mahal dan terkadang bermasalah. Kini, Layanan Pelaporan Microsoft SQL Server menawarkan solusi lengkap untuk mendistribusikan laporan ke seluruh perusahaan; memungkinkan bisnis untuk membuat keputusan lebih baik dan lebih cepat.
 
-**Aspose.PDF for Reporting Services** adalah solusi unik lainnya dari Aspose, yang memungkinkan pembuatan laporan PDF di Microsoft SQL Server 2016/2017/2019/2022 Reporting Services dan Power BI Report Server. Semua fitur laporan RDL, termasuk tabel, matriks, grafik, dan gambar, dikonversi dengan tingkat presisi tertinggi ke PDF.
+**Aspose.PDF untuk Layanan Pelaporan** adalah solusi unik lainnya dari Aspose, yang memungkinkan pembuatan laporan PDF di Layanan Pelaporan Microsoft SQL Server 2016/2017/2019/2022 dan Server Laporan Power BI. Semua fitur laporan RDL, termasuk tabel, matriks, bagan, dan gambar dikonversi dengan tingkat presisi tertinggi ke PDF.
 
-Microsoft SQL Server Reporting Services memiliki kemampuan bawaan untuk mengekspor laporan sebagai dokumen PDF, tetapi tidak menyediakan dukungan teknis yang diperlukan bagi pengguna akhir. Aspose.Pdf berupaya memberikan dukungan teknis yang unggul dan efisien.
+Layanan Pelaporan Microsoft SQL Server memiliki kemampuan bawaan untuk mengekspor laporan sebagai dokumen PDF, namun kurang memberikan dukungan teknis yang diperlukan bagi pengguna akhir. Aspose.Pdf berusaha untuk memberikan dukungan teknis tertinggi dan efisien.
 
-Aspose.PDF for Reporting Services membuat dokumen di server tanpa memanfaatkan Adobe.Pdf SDK. Aspose.PDF for Reporting Services secara internal menggunakan Aspose.PDF for .NET – komponen kelas dunia untuk pemrosesan dokumen sisi server dan konversi.
+Aspose.PDF untuk Layanan Pelaporan membuat dokumen di server tanpa menggunakan Adobe.Pdf SDK. Aspose.PDF untuk Layanan Pelaporan secara internal menggunakan Aspose.PDF untuk .NET – komponen kelas dunia untuk pemrosesan dan konversi dokumen sisi server.
 
-## Aspose.PDF for Reporting Services memungkinkan mengekspor laporan apa pun dalam format PDF.
+## Aspose.PDF untuk Layanan Pelaporan memungkinkan untuk mengekspor laporan apa pun dalam format PDF
 
-![todo:image_alt_text](product-overview_2.png)
+![Product Overview](product-overview_2.png)
 

--- a/id/reportingservices/sample-reports-gallery/_index.md
+++ b/id/reportingservices/sample-reports-gallery/_index.md
@@ -1,24 +1,24 @@
 ---
-title: Galeri Laporan Contoh
-linktitle: Galeri Laporan Contoh
+title: Galeri Contoh Laporan
+linktitle: Sample Reports Gallery
 type: docs
 weight: 40
-url: /id/reportingservices/sample-reports-gallery/
-description: Jelajahi laporan contoh yang dihasilkan menggunakan Aspose.PDF for Reporting Services. Lihat bagaimana laporan SSRS Anda dapat diubah menjadi output PDF yang halus.
-lastmod: "2026-07-29"
+url: /reportingservices/sample-reports-gallery/
+description: Jelajahi contoh laporan yang dihasilkan menggunakan Aspose.PDF untuk Layanan Pelaporan. Lihat bagaimana laporan SSRS Anda dapat diubah menjadi keluaran PDF yang sempurna.
+lastmod: "2024-05-05"
 ---
 
 {{% alert color="primary" %}}
 
-Galeri ini menunjukkan laporan PDF yang diekspor oleh Aspose.PDF for Reporting Services.
+Galeri ini menunjukkan laporan PDF yang diekspor oleh Aspose.PDF untuk Layanan Pelaporan.
 
 {{% /alert %}}
 
-Sebagian besar laporan yang ditampilkan di sini berasal dari basis data Adventure Works. Adventure Works adalah basis data contoh untuk Microsoft SQL Server, tersedia untuk diunduh dari Microsoft [di sini](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
+Sebagian besar laporan yang ditampilkan di sini berasal dari database Adventure Works. Adventure Works adalah contoh database untuk Microsoft SQL Server, tersedia untuk diunduh dari Microsoft [Di Sini](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
 
 ## Penjualan Perusahaan
 
-![Penjualan Perusahaan  laporan dalam PDF](sample-reports-gallery_1.png)
+![Laporan Penjualan Perusahaan dalam PDF](sample-reports-gallery_1.png)
 
 ## Ringkasan Penjualan Karyawan
 

--- a/id/reportingservices/sample-reports-gallery/_index.md
+++ b/id/reportingservices/sample-reports-gallery/_index.md
@@ -4,17 +4,17 @@ linktitle: Galeri Laporan Contoh
 type: docs
 weight: 40
 url: /id/reportingservices/sample-reports-gallery/
-description: Jelajahi laporan contoh yang dihasilkan menggunakan Aspose.PDF untuk Reporting Services. Lihat bagaimana laporan SSRS Anda dapat diubah menjadi output PDF yang halus.
-lastmod: "2026-06-19"
+description: Jelajahi laporan contoh yang dihasilkan menggunakan Aspose.PDF for Reporting Services. Lihat bagaimana laporan SSRS Anda dapat diubah menjadi output PDF yang halus.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Galeri ini menunjukkan laporan PDF yang diekspor oleh Aspose.PDF untuk Reporting Services.
+Galeri ini menunjukkan laporan PDF yang diekspor oleh Aspose.PDF for Reporting Services.
 
 {{% /alert %}}
 
-Sebagian besar laporan yang ditampilkan di sini berasal dari basis data Adventure Works. Adventure Works adalah basis data contoh untuk Microsoft SQL Server, tersedia untuk diunduh dari Microsoft. [di sini](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
+Sebagian besar laporan yang ditampilkan di sini berasal dari basis data Adventure Works. Adventure Works adalah basis data contoh untuk Microsoft SQL Server, tersedia untuk diunduh dari Microsoft [di sini](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
 
 ## Penjualan Perusahaan
 
@@ -28,11 +28,10 @@ Sebagian besar laporan yang ditampilkan di sini berasal dari basis data Adventur
 
 ![Laporan Katalog Produk dalam PDF](sample-reports-gallery_3.png)
 
-## Penjualan Garis Produk
+## Penjualan Lini Produk
 
-![Laporan Penjualan Garis Produk dalam PDF](sample-reports-gallery_4.png)
+![Laporan Penjualan Lini Produk dalam PDF](sample-reports-gallery_4.png)
 
 ## Detail Pesanan Penjualan
 
 ![Laporan Detail Pesanan Penjualan dalam PDF](sample-reports-gallery_5.png)
-

--- a/id/reportingservices/supported-file-formats/_index.md
+++ b/id/reportingservices/supported-file-formats/_index.md
@@ -5,7 +5,7 @@ type: docs
 weight: 20
 url: /id/reportingservices/supported-file-formats/
 description: Lihat format file yang didukung oleh Aspose.PDF for Reporting Services. Render laporan SSRS Anda ke PDF, DOC, XLS, dan lainnya dengan mudah.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 ## Format Muat yang Didukung
@@ -15,16 +15,15 @@ Tabel berikut menunjukkan format file yang dapat dimuat oleh Aspose.PDF for Repo
 |**Format**|**Deskripsi**|
 | :- | :- |
 |RDL|Bahasa Definisi Laporan|
-|[HTML](https://docs.fileformat.com/web/html/)|Bahasa Markup Hiperteks|
+|[HTML](https://docs.fileformat.com/web/html/)|Bahasa Penanda Hiperteks|
 
-## Format Penyimpanan yang Didukung
+## Format Simpanan yang Didukung
 
-Tabel berikut menunjukkan format file di mana dokumen dapat disimpan menggunakan Aspose.PDF untuk Reporting Services. 
+Tabel berikut menunjukkan format file di mana dokumen dapat disimpan dengan menggunakan Aspose.PDF for Reporting Services. 
 
 |**Format**|**Deskripsi**|
 | :- | :- |
 |[PDF](https://docs.fileformat.com/pdf/)|Menyimpan dokumen dalam format PDF|
 |PDF/A |Menyimpan dokumen dalam format PDF/A|
 |[XPS](https://docs.fileformat.com/page-description-language/xps/)|Menyimpan dokumen dalam format XML Paper Specification|
-|EPUB|Menyimpan dokumen dalam Format File E-Book|
-
+|EPUB|Menyimpan dokumen dalam format file E-Book|

--- a/id/reportingservices/supported-file-formats/_index.md
+++ b/id/reportingservices/supported-file-formats/_index.md
@@ -1,29 +1,29 @@
 ---
 title: Format File yang Didukung
-linktitle: Format File yang Didukung
+linktitle: Supported File Formats
 type: docs
 weight: 20
-url: /id/reportingservices/supported-file-formats/
-description: Lihat format file yang didukung oleh Aspose.PDF for Reporting Services. Render laporan SSRS Anda ke PDF, DOC, XLS, dan lainnya dengan mudah.
-lastmod: "2026-07-29"
+url: /reportingservices/supported-file-formats/
+description: Lihat format file Aspose.PDF yang didukung untuk Layanan Pelaporan. Render laporan SSRS Anda ke PDF, DOC, XLS, dan lainnya dengan mudah.
+lastmod: "2021-06-05"
 ---
 
-## Format Muat yang Didukung
+## Format Beban yang Didukung
 
-Tabel berikut menunjukkan format file yang dapat dimuat oleh Aspose.PDF for Reporting Services.
+Tabel berikut menunjukkan format file yang dapat dimuat Aspose.PDF untuk Layanan Pelaporan.
 
-|**Format**|**Deskripsi**|
+|**Format**|**Keterangan**|
 | :- | :- |
 |RDL|Bahasa Definisi Laporan|
-|[HTML](https://docs.fileformat.com/web/html/)|Bahasa Penanda Hiperteks|
+|[HTML](https://docs.fileformat.com/web/html/)|Bahasa Markup Hiperteks|
 
-## Format Simpanan yang Didukung
+## Format Penyimpanan yang Didukung
 
-Tabel berikut menunjukkan format file di mana dokumen dapat disimpan dengan menggunakan Aspose.PDF for Reporting Services. 
+Tabel berikut menunjukkan format file di mana dokumen dapat disimpan dengan menggunakan Aspose.PDF untuk Layanan Pelaporan. 
 
-|**Format**|**Deskripsi**|
+|**Format**|**Keterangan**|
 | :- | :- |
 |[PDF](https://docs.fileformat.com/pdf/)|Menyimpan dokumen dalam format PDF|
 |PDF/A |Menyimpan dokumen dalam format PDF/A|
-|[XPS](https://docs.fileformat.com/page-description-language/xps/)|Menyimpan dokumen dalam format XML Paper Specification|
-|EPUB|Menyimpan dokumen dalam format file E-Book|
+|[XPS](https://docs.fileformat.com/page-description-language/xps/)|Menyimpan dokumen dalam format Spesifikasi Kertas XML|
+|EPUB|Menyimpan dokumen dalam Format File E-Book|

--- a/id/reportingservices/technical-articles/_index.md
+++ b/id/reportingservices/technical-articles/_index.md
@@ -5,10 +5,9 @@ type: docs
 weight: 120
 url: /id/reportingservices/technical-articles/
 description: Jelajahi artikel teknis untuk Aspose.PDF for Reporting Services. Dapatkan wawasan mendalam dan tip praktis untuk rendering PDF yang efektif.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 **Bagian ini mencakup topik berikut:**
-- [Migrasi dari SQL Reporting Services ke Aspose.Pdf for Reporting Services](/pdf/id/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
+- [Migrasi dari SQL Reporting Services ke Aspose.PDF for Reporting Services](/pdf/id/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
 - [Integrasi SQL Reporting Services dengan MS SharePoint](/pdf/id/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/)
-

--- a/id/reportingservices/technical-articles/_index.md
+++ b/id/reportingservices/technical-articles/_index.md
@@ -1,13 +1,14 @@
 ---
 title: Artikel Teknis
-linktitle: Artikel Teknis
+linktitle: Technical Articles
 type: docs
 weight: 120
-url: /id/reportingservices/technical-articles/
-description: Jelajahi artikel teknis untuk Aspose.PDF for Reporting Services. Dapatkan wawasan mendalam dan tip praktis untuk rendering PDF yang efektif.
-lastmod: "2026-07-29"
+url: /reportingservices/technical-articles/
+description: Jelajahi artikel teknis untuk Aspose.PDF untuk Layanan Pelaporan. Dapatkan wawasan mendalam dan tip praktis untuk rendering PDF yang efektif.
+lastmod: "2021-06-05"
 ---
 
 **Bagian ini mencakup topik berikut:**
-- [Migrasi dari SQL Reporting Services ke Aspose.PDF for Reporting Services](/pdf/id/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
-- [Integrasi SQL Reporting Services dengan MS SharePoint](/pdf/id/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/)
+
+- [Migrasi dari Layanan Pelaporan SQL ke Aspose.PDF untuk Layanan Pelaporan](/pdf/id/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
+- [Integrasi Layanan Pelaporan SQL dengan MS SharePoint](/pdf/id/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/)

--- a/id/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
+++ b/id/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
@@ -1,13 +1,13 @@
 ---
-title: Migrasi dari SQL Reporting Services ke Aspose.PDF for Reporting Services
-linktitle: Migrasi dari SQL Reporting Services ke Aspose.PDF for Reporting Services
+title: Migrasi dari Layanan Pelaporan SQL ke Aspose.PDF untuk Layanan Pelaporan
+linktitle: Migration from SQL Reporting Services to Aspose.PDF for Reporting Services
 type: docs
 weight: 10
-url: /id/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/
-description: Pelajari cara memigrasi dari SQL Reporting Services ke Aspose.PDF for Reporting Services. Tingkatkan proses pembuatan PDF Anda.
-lastmod: "2026-07-29"
+url: /reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/
+description: Pelajari cara bermigrasi dari SQL Reporting Services ke Aspose.PDF untuk Reporting Services. Tingkatkan proses pembuatan PDF Anda.
+lastmod: "2024-05-05"
 ---
 
 **Bagian ini mencakup topik berikut:**
 
-- [Mengapa memilih Aspose.PDF for Reporting Services](/pdf/id/reportingservices/why-choose-aspose-pdf-for-reporting-services/)
+- [Mengapa memilih Aspose.PDF untuk Layanan Pelaporan](/pdf/id/reportingservices/why-choose-aspose-pdf-for-reporting-services/)

--- a/id/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
+++ b/id/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
@@ -1,14 +1,13 @@
 ---
-title: Migrasi dari SQL Reporting Services ke Aspose.PDF untuk Reporting Services
-linktitle: Migrasi dari SQL Reporting Services ke Aspose.PDF untuk Reporting Services
+title: Migrasi dari SQL Reporting Services ke Aspose.PDF for Reporting Services
+linktitle: Migrasi dari SQL Reporting Services ke Aspose.PDF for Reporting Services
 type: docs
 weight: 10
 url: /id/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/
-description: Pelajari cara memigrasi dari SQL Reporting Services ke Aspose.PDF untuk Reporting Services. Tingkatkan proses pembuatan PDF Anda.
-lastmod: "2026-06-19"
+description: Pelajari cara memigrasi dari SQL Reporting Services ke Aspose.PDF for Reporting Services. Tingkatkan proses pembuatan PDF Anda.
+lastmod: "2026-07-29"
 ---
 
 **Bagian ini mencakup topik berikut:**
 
-- [Mengapa memilih Aspose.PDF untuk Reporting Services](/pdf/id/reportingservices/why-choose-aspose-pdf-for-reporting-services/)
-
+- [Mengapa memilih Aspose.PDF for Reporting Services](/pdf/id/reportingservices/why-choose-aspose-pdf-for-reporting-services/)

--- a/id/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
+++ b/id/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
@@ -1,36 +1,36 @@
 ---
-title: Mengapa memilih Aspose.Pdf untuk Reporting Services
-linktitle: Mengapa memilih Aspose.Pdf untuk Reporting Services
+title: Mengapa memilih Aspose.PDF for Reporting Services
+linktitle: Mengapa memilih Aspose.PDF for Reporting Services
 type: docs
 weight: 10
 url: /id/reportingservices/why-choose-aspose-pdf-for-reporting-services/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-**Aspose.Pdf for Reporting Services** adalah solusi .NET yang kuat yang memungkinkan Anda menghasilkan laporan PDF menggunakan Microsoft SQL Server 2016, 2017, 2019, dan 2022 Reporting Services, serta Microsoft Power BI Report Server. Aspose.Pdf for Reporting Services tidak beroperasi secara mandiri, melainkan merupakan ekstensi rendering untuk SQL Reporting Services. Tidak hanya mendukung elemen laporan dasar seperti tabel, diagram, gambar, Header/Footer, garis, dll, tetapi juga menyediakan kemampuan menambahkan properti khusus yang memberikan keunggulan tambahan pada SQL Reporting Services. Dengan menggunakan properti ini, Anda dapat menghasilkan List of Contents yang tidak didukung oleh Report Designer. Anda mungkin memiliki Footnotes/Endnotes dalam dokumen PDF yang dihasilkan yang secara native tidak didukung oleh Report Builder. Fitur menarik lainnya adalah memiliki Line Arrows yang juga tidak didukung oleh SQL Reporting Services, tetapi Aspose.Pdf for Reporting Services dapat menyediakan kemampuan menambahkan panah di awal atau akhir elemen garis. Selain itu, Aspose.Pdf for Reporting Services menyediakan fungsi untuk menentukan perataan teks (Justify atau FullJustify) yang tidak didukung oleh Report Designer. Mode teks ini membuat dokumen yang dihasilkan lebih terformat dengan baik dan mudah dibaca.
+**Aspose.PDF for Reporting Services** adalah solusi .NET yang kuat yang memungkinkan Anda menghasilkan laporan PDF menggunakan Microsoft SQL Server 2016, 2017, 2019, dan 2022 Reporting Services, serta Microsoft Power BI Report Server. Aspose.PDF for Reporting Services tidak beroperasi secara independen, melainkan merupakan ekstensi rendering untuk SQL Reporting Services. Tidak hanya mendukung elemen laporan dasar seperti tabel, diagram, gambar, Header/Footer, garis, dll, tetapi juga menyediakan kemampuan menambahkan properti khusus yang memberikan keunggulan tambahan pada SQL Reporting Services. Dengan menggunakan properti ini, Anda dapat menghasilkan Daftar Isi yang tidak didukung oleh Report Designer. Anda dapat memiliki Catatan Kaki/Catatan Akhir dalam dokumen PDF hasil yang secara native tidak didukung oleh Report Builder. Fitur menarik lainnya adalah memiliki Panah Garis yang juga tidak didukung oleh SQL Reporting Services, namun Aspose.PDF for Reporting Services dapat menyediakan kemampuan menambahkan panah di awal atau akhir elemen garis. Selain itu, Aspose.PDF for Reporting Services menyediakan fungsi untuk menentukan perataan teks (Justify atau FullJustify) yang tidak didukung oleh Report Designer. Mode teks ini membuat dokumen hasil lebih terformat dengan baik dan mudah dibaca.
 
-Selain fitur-fitur yang disebutkan sebelumnya, Anda juga dapat mengatur parameter konfigurasi lain untuk laporan, guna mendapatkan fitur yang tidak didukung secara native oleh SQL Reporting Services. Berikut adalah rangkuman singkat dari fitur-fitur tersebut yang ditawarkan oleh Aspose.Pdf for Reporting Services
+Selain fitur-fitur yang disebutkan sebelumnya, Anda juga dapat mengatur parameter konfigurasi lain untuk laporan, guna mendapatkan fitur yang tidak didukung secara native oleh SQL Reporting Services. Berikut ini ringkasan singkat tentang fitur-fitur tersebut yang ditawarkan oleh Aspose.PDF for Reporting Services
 
 ## Pengaturan Keamanan
 
-Terkadang Anda mungkin ingin mengekspor dokumen PDF yang dilindungi dengan kata sandi, dengan hak terbatas untuk menyalin teks dan mencetak. Sayangnya, Reporting Services tidak mendukung kemungkinan ini. Namun, Anda tetap dapat mengimplementasikannya menggunakan Aspose.Pdf for Reporting Services. Cukup tambahkan parameter keamanan yang sesuai ke laporan atau server laporan untuk memperoleh dokumen PDF yang aman dengan hak terbatas. Untuk informasi lebih lanjut, silakan merujuk ke bagian \u0027Security Setting\u0027.
+Terkadang Anda mungkin ingin mengekspor dokumen PDF yang dilindungi dengan kata sandi, dengan hak terbatas untuk menyalin teks dan mencetak. Sayangnya, Reporting Services tidak mendukung kemungkinan ini. Namun, Anda masih dapat mengimplementasikannya menggunakan Aspose.PDF for Reporting Services. Cukup tambahkan parameter keamanan yang sesuai ke laporan atau server laporan untuk memperoleh dokumen PDF yang aman dengan hak terbatas. Untuk informasi lebih lanjut, silakan lihat bagian 'Security Setting'.
 
 ## Penyematan Font Kustom
 
-Designer Reporting Services tidak mendukung font yang disematkan untuk teks; dengan Aspose.Pdf for Reporting Services Anda dapat dengan mudah menyematkan informasi font ke dalam dokumen PDF Anda. Untuk informasi lebih lanjut, silakan merujuk ke bagian \u0027IsFontEmbedded\u0027.
+Desainer Reporting Services tidak mendukung penyematan font untuk teks; dengan Aspose.PDF for Reporting Services Anda dapat dengan mudah menyematkan informasi font ke dalam dokumen PDF Anda. Untuk informasi lebih lanjut, silakan lihat bagian 'IsFontEmbedded'.
 
 ## Metadata XMP
 
-Desainer Reporting Services tidak mendukung penyematan metadata XMP. Aspose.Pdf for Reporting Services menyediakan empat parameter (CreationDate, ModifyDate, MetaDataDate, dan CreatorTool) untuk mengatur Metadata XMP yang sesuai. Untuk informasi lebih lanjut, silakan lihat bagian 'XMP Metadata'.
+Desainer Reporting Services tidak mendukung penyematan metadata XMP. Aspose.PDF for Reporting Services menyediakan empat parameter (CreationDate, ModifyDate, MetaDataDate, dan CreatorTool) untuk mengatur Metadata XMP yang bersesuaian. Untuk informasi lebih lanjut, silakan lihat bagian 'XMP Metadata'.
 
 ## PDF/A
 
-Saat menggunakan SQL Server Reporting Services, Anda hanya dapat menghasilkan dokumen PDF dalam format sederhana sementara pembuatan dokumen PDF/A tidak didukung. Namun Aspose.Pdf for Reporting Services menyediakan fitur untuk membuat dokumen yang mematuhi PDF/A dengan penambahan satu parameter konfigurasi. Untuk informasi lebih lanjut, silakan lihat bagian 'PDF Conformance'.
+Saat menggunakan SQL Server Reporting Services, Anda hanya dapat menghasilkan dokumen PDF dalam format sederhana, sementara pembuatan dokumen PDF/A tidak didukung. Namun Aspose.PDF for Reporting Services menyediakan fitur untuk membuat dokumen yang mematuhi PDF/A dengan penambahan satu parameter konfigurasi. Untuk informasi lebih lanjut, silakan lihat bagian 'PDF Conformance'.
 
 ## Sudut Rotasi Halaman
 
-Saat menggunakan Aspose.Pdf for Reporting Services, Anda dapat mengatur jumlah derajat di mana halaman harus diputar searah jarum jam saat ditampilkan atau dicetak. Untuk informasi lebih lanjut, silakan lihat bagian 'Page Rotating Angle'.
+Saat menggunakan Aspose.PDF for Reporting Services, Anda dapat mengatur jumlah derajat rotasi halaman searah jarum jam ketika ditampilkan atau dicetak. Untuk informasi lebih lanjut, silakan lihat bagian 'Page Rotating Angle'.
 
 ## Ukuran Margin Halaman
 
-Desainer Reporting Services tidak mendukung pengaturan ukuran margin halaman. Aspose.Pdf for Reporting Services, di sisi lain, menyediakan empat parameter untuk mengatur ukuran margin halaman yang sesuai. Mereka adalah PageMarginLeft, PageMarginRight, PageMarginTop, dan PageMarginBottom. Untuk informasi lebih lanjut, silakan merujuk ke bagian 'Page Margin Size'.
+Desainer Reporting Services tidak mendukung pengaturan ukuran margin halaman. Aspose.PDF for Reporting Services, di sisi lain, menyediakan empat parameter untuk mengatur ukuran margin halaman yang sesuai. Mereka adalah PageMarginLeft, PageMarginRight, PageMarginTop, dan PageMarginBottom. Untuk informasi lebih lanjut, silakan merujuk ke bagian 'Page Margin Size'.

--- a/id/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
+++ b/id/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
@@ -1,36 +1,36 @@
 ---
-title: Mengapa memilih Aspose.PDF for Reporting Services
-linktitle: Mengapa memilih Aspose.PDF for Reporting Services
+title: Mengapa memilih Aspose.PDF untuk Layanan Pelaporan
+linktitle: Why choose Aspose.PDF for Reporting Services
 type: docs
 weight: 10
-url: /id/reportingservices/why-choose-aspose-pdf-for-reporting-services/
-lastmod: "2026-07-29"
+url: /reportingservices/why-choose-aspose-pdf-for-reporting-services/
+lastmod: "2021-06-05"
 ---
 
-**Aspose.PDF for Reporting Services** adalah solusi .NET yang kuat yang memungkinkan Anda menghasilkan laporan PDF menggunakan Microsoft SQL Server 2016, 2017, 2019, dan 2022 Reporting Services, serta Microsoft Power BI Report Server. Aspose.PDF for Reporting Services tidak beroperasi secara independen, melainkan merupakan ekstensi rendering untuk SQL Reporting Services. Tidak hanya mendukung elemen laporan dasar seperti tabel, diagram, gambar, Header/Footer, garis, dll, tetapi juga menyediakan kemampuan menambahkan properti khusus yang memberikan keunggulan tambahan pada SQL Reporting Services. Dengan menggunakan properti ini, Anda dapat menghasilkan Daftar Isi yang tidak didukung oleh Report Designer. Anda dapat memiliki Catatan Kaki/Catatan Akhir dalam dokumen PDF hasil yang secara native tidak didukung oleh Report Builder. Fitur menarik lainnya adalah memiliki Panah Garis yang juga tidak didukung oleh SQL Reporting Services, namun Aspose.PDF for Reporting Services dapat menyediakan kemampuan menambahkan panah di awal atau akhir elemen garis. Selain itu, Aspose.PDF for Reporting Services menyediakan fungsi untuk menentukan perataan teks (Justify atau FullJustify) yang tidak didukung oleh Report Designer. Mode teks ini membuat dokumen hasil lebih terformat dengan baik dan mudah dibaca.
+**Aspose.PDF untuk Layanan Pelaporan** adalah solusi .NET tangguh yang memungkinkan Anda membuat laporan PDF menggunakan Layanan Pelaporan Microsoft SQL Server 2016, 2017, 2019, dan 2022, serta Server Laporan Microsoft Power BI. Aspose.PDF untuk Layanan Pelaporan tidak beroperasi secara independen, namun merupakan ekstensi rendering untuk Layanan Pelaporan SQL. Tidak hanya mendukung elemen laporan dasar seperti tabel, bagan, gambar, Header/Footer, garis dll, tetapi juga menyediakan kemampuan untuk menambahkan properti khusus yang memberikan pengaruh ekstra pada Layanan Pelaporan SQL. Saat menggunakan properti ini, Anda dapat membuat Daftar Isi yang tidak didukung oleh Perancang Laporan. Anda mungkin memiliki Catatan Kaki/Catatan Akhir dalam dokumen PDF yang dihasilkan yang secara asli tidak didukung oleh Pembuat Laporan. Fitur menarik lainnya adalah memiliki Line Arrows yang juga tidak didukung oleh SQL Reporting Services, namun Aspose.PDF for Reporting Services dapat memberikan kemampuan untuk menambahkan panah di awal atau akhir elemen garis. Selain itu, Aspose.PDF untuk Layanan Pelaporan menyediakan fungsionalitas untuk menentukan informasi perataan teks (Justify atau FullJustify) yang tidak didukung oleh Perancang Laporan. Mode teks ini membuat dokumen yang dihasilkan diformat lebih baik dan mudah dibaca.
 
-Selain fitur-fitur yang disebutkan sebelumnya, Anda juga dapat mengatur parameter konfigurasi lain untuk laporan, guna mendapatkan fitur yang tidak didukung secara native oleh SQL Reporting Services. Berikut ini ringkasan singkat tentang fitur-fitur tersebut yang ditawarkan oleh Aspose.PDF for Reporting Services
+Selain fitur yang disebutkan sebelumnya, Anda juga dapat mengatur parameter konfigurasi tertentu lainnya untuk laporan, untuk mendapatkan fitur yang tidak didukung secara asli oleh Layanan Pelaporan SQL. Berikut ini adalah ikhtisar singkat fitur-fitur yang ditawarkan oleh Aspose.PDF untuk Layanan Pelaporan
 
 ## Pengaturan Keamanan
 
-Terkadang Anda mungkin ingin mengekspor dokumen PDF yang dilindungi dengan kata sandi, dengan hak terbatas untuk menyalin teks dan mencetak. Sayangnya, Reporting Services tidak mendukung kemungkinan ini. Namun, Anda masih dapat mengimplementasikannya menggunakan Aspose.PDF for Reporting Services. Cukup tambahkan parameter keamanan yang sesuai ke laporan atau server laporan untuk memperoleh dokumen PDF yang aman dengan hak terbatas. Untuk informasi lebih lanjut, silakan lihat bagian 'Security Setting'.
+Terkadang Anda mungkin ingin mengekspor dokumen PDF yang dilindungi kata sandi, dengan hak istimewa penyalinan dan pencetakan teks terbatas. Sayangnya, Layanan Pelaporan tidak mendukung kemungkinan ini. Namun, Anda masih bisa menerapkannya menggunakan Aspose.PDF untuk Layanan Pelaporan. Cukup tambahkan parameter keamanan yang sesuai ke laporan atau server laporan untuk mendapatkan dokumen PDF aman dengan hak istimewa terbatas. Untuk informasi lebih lanjut, silakan lihat bagian 'Pengaturan Keamanan'.
 
 ## Penyematan Font Kustom
 
-Desainer Reporting Services tidak mendukung penyematan font untuk teks; dengan Aspose.PDF for Reporting Services Anda dapat dengan mudah menyematkan informasi font ke dalam dokumen PDF Anda. Untuk informasi lebih lanjut, silakan lihat bagian 'IsFontEmbedded'.
+Perancang Layanan Pelaporan tidak mendukung font yang disematkan untuk teks; dengan Aspose.PDF untuk Layanan Pelaporan Anda dapat dengan mudah menyematkan informasi font ke dalam dokumen PDF Anda. Untuk informasi lebih lanjut, silakan lihat bagian 'IsFontEmbedded'.
 
 ## Metadata XMP
 
-Desainer Reporting Services tidak mendukung penyematan metadata XMP. Aspose.PDF for Reporting Services menyediakan empat parameter (CreationDate, ModifyDate, MetaDataDate, dan CreatorTool) untuk mengatur Metadata XMP yang bersesuaian. Untuk informasi lebih lanjut, silakan lihat bagian 'XMP Metadata'.
+Perancang Layanan Pelaporan tidak mendukung penyematan metadata XMP. Aspose.PDF untuk Layanan Pelaporan menyediakan empat parameter (CreationDate, ModifyDate, MetaDataDate, dan CreatorTool) untuk mengatur Metadata XMP yang sesuai. Untuk informasi lebih lanjut, silakan lihat bagian 'Metadata XMP'.
 
 ## PDF/A
 
-Saat menggunakan SQL Server Reporting Services, Anda hanya dapat menghasilkan dokumen PDF dalam format sederhana, sementara pembuatan dokumen PDF/A tidak didukung. Namun Aspose.PDF for Reporting Services menyediakan fitur untuk membuat dokumen yang mematuhi PDF/A dengan penambahan satu parameter konfigurasi. Untuk informasi lebih lanjut, silakan lihat bagian 'PDF Conformance'.
+Saat menggunakan Layanan Pelaporan SQL Server, Anda hanya dapat membuat dokumen PDF dalam format sederhana sedangkan pembuatan dokumen PDF/A tidak didukung. Namun Aspose.PDF untuk Layanan Pelaporan menyediakan fitur untuk membuat dokumen yang sesuai dengan PDF/A dengan tambahan satu parameter konfigurasi. Untuk informasi lebih lanjut, silakan lihat bagian 'Kesesuaian PDF'.
 
 ## Sudut Rotasi Halaman
 
-Saat menggunakan Aspose.PDF for Reporting Services, Anda dapat mengatur jumlah derajat rotasi halaman searah jarum jam ketika ditampilkan atau dicetak. Untuk informasi lebih lanjut, silakan lihat bagian 'Page Rotating Angle'.
+Saat menggunakan Aspose.PDF untuk Layanan Pelaporan, Anda dapat mengatur jumlah derajat rotasi halaman searah jarum jam saat ditampilkan atau dicetak. Untuk informasi lebih lanjut, silakan lihat bagian 'Sudut Putar Halaman'.
 
 ## Ukuran Margin Halaman
 
-Desainer Reporting Services tidak mendukung pengaturan ukuran margin halaman. Aspose.PDF for Reporting Services, di sisi lain, menyediakan empat parameter untuk mengatur ukuran margin halaman yang sesuai. Mereka adalah PageMarginLeft, PageMarginRight, PageMarginTop, dan PageMarginBottom. Untuk informasi lebih lanjut, silakan merujuk ke bagian 'Page Margin Size'.
+Perancang Layanan Pelaporan tidak mendukung pengaturan ukuran margin halaman. Aspose.PDF untuk Layanan Pelaporan, di sisi lain, menyediakan empat parameter untuk mengatur ukuran margin halaman yang sesuai. Mereka adalah PageMarginLeft, PageMarginRight, PageMarginTop, dan PageMarginBottom. Untuk informasi lebih lanjut, silakan lihat bagian 'Ukuran Margin Halaman'.

--- a/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
+++ b/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
@@ -4,13 +4,12 @@ linktitle: Integrasi SQL Reporting Services dengan MS SharePoint
 type: docs
 weight: 20
 url: /id/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-**Bagian ini mencakup topik-topik berikut:**
+**Bagian ini mencakup topik berikut:**
 
 - [Pendahuluan](/pdf/id/reportingservices/introduction/)
 - [Menyiapkan Reporting Services](/pdf/id/reportingservices/setting-up-reporting-services/)
 - [Menyiapkan SharePoint pada Server Reporting Services](/pdf/id/reportingservices/setting-up-sharepoint-on-reporting-services-server/)
 - [Konfigurasi Reporting Services dan SharePoint](/pdf/id/reportingservices/reporting-services-and-sharepoint-configuration/)
-

--- a/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
+++ b/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
@@ -1,15 +1,15 @@
 ---
-title: Integrasi SQL Reporting Services dengan MS SharePoint
-linktitle: Integrasi SQL Reporting Services dengan MS SharePoint
+title: Integrasi Layanan Pelaporan SQL dengan MS SharePoint
+linktitle: SQL Reporting Services Integration with MS SharePoint
 type: docs
 weight: 20
-url: /id/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/
-lastmod: "2026-07-29"
+url: /reportingservices/sql-reporting-services-integration-with-ms-sharepoint/
+lastmod: "2021-06-05"
 ---
 
 **Bagian ini mencakup topik berikut:**
 
-- [Pendahuluan](/pdf/id/reportingservices/introduction/)
-- [Menyiapkan Reporting Services](/pdf/id/reportingservices/setting-up-reporting-services/)
-- [Menyiapkan SharePoint pada Server Reporting Services](/pdf/id/reportingservices/setting-up-sharepoint-on-reporting-services-server/)
-- [Konfigurasi Reporting Services dan SharePoint](/pdf/id/reportingservices/reporting-services-and-sharepoint-configuration/)
+- [Perkenalan](/pdf/id/reportingservices/introduction/)
+- [Menyiapkan Layanan Pelaporan](/pdf/id/reportingservices/setting-up-reporting-services/)
+- [Menyiapkan SharePoint di Server Layanan Pelaporan](/pdf/id/reportingservices/setting-up-sharepoint-on-reporting-services-server/)
+- [Layanan Pelaporan dan konfigurasi SharePoint](/pdf/id/reportingservices/reporting-services-and-sharepoint-configuration/)

--- a/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
+++ b/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
@@ -1,53 +1,53 @@
 ---
-title: Pendahuluan
-linktitle: Pendahuluan
+title: Perkenalan
+linktitle: Introduction
 type: docs
 weight: 10
-url: /id/reportingservices/introduction/
-lastmod: "2026-07-29"
+url: /reportingservices/introduction/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF for Reporting Services telah sangat luar biasa untuk pembuatan PDF melalui SQL Reporting Services selama bertahun‑tahun dan menyediakan beragam opsi konfigurasi serta parameterisasi yang tidak didukung secara default di SQL Reporting Services. Baru-baru ini kami menerima beberapa permintaan terkait Integrasi Aspose.PDF for Reporting Services dengan SharePoint. Untuk artikel ini, kami akan fokus pada MS SharePoint 2010. Sebelum kami melanjutkan lebih jauh, kami mengasumsikan bahwa Anda sudah memiliki setup SharePoint Farm. Dalam contoh ini kami akan menggunakan SharePoint Cloud penuh. Namun langkah‑langkahnya serupa untuk SharePoint Foundation Server.
+Aspose.PDF untuk Layanan Pelaporan telah sangat luar biasa untuk pembuatan PDF melalui Layanan Pelaporan SQL sejak bertahun-tahun dan menyediakan beragam opsi konfigurasi dan parameterisasi yang tidak didukung secara default di Layanan Pelaporan SQL. Baru-baru ini kami menerima beberapa permintaan mengenai Aspose.PDF untuk Integrasi Layanan Pelaporan dengan SharePoint. Untuk artikel ini, kami akan fokus pada MS SharePoint 2010. Sebelum melanjutkan lebih jauh, kami berasumsi bahwa Anda sudah memiliki pengaturan SharePoint Farm. Dalam contoh ini kita akan menggunakan SharePoint Cloud lengkap. Namun langkah-langkahnya serupa untuk SharePoint Foundation Server.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Sebelum kami melanjutkan lebih jauh, mari kita lihat topik referensi yang telah kami konsultasikan selama persiapan artikel ini.
+Sebelum melangkah lebih jauh, mari kita lihat topik referensi yang telah kita konsultasikan selama persiapan artikel ini.
 
-- [Gambaran Umum Integrasi Teknologi Reporting Services dan SharePoint](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
-- [Topologi Penempatan untuk Reporting Services dalam Mode Terintegrasi SharePoint](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
-- [Mengonfigurasi Reporting Services untuk Integrasi SharePoint 2010](http://msdn.microsoft.com/en-us/library/bb326356.aspx)
+- [Ikhtisar Layanan Pelaporan dan Integrasi Teknologi SharePoint](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
+- [Topologi Penerapan untuk Layanan Pelaporan dalam Mode Terintegrasi SharePoint](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
+- [Mengonfigurasi Layanan Pelaporan untuk Integrasi SharePoint 2010](http://msdn.microsoft.com/en-us/library/bb326356.aspx)
 
 {{% /alert %}}
 
-## Penyiapan Lingkungan
+## Pengaturan Lingkungan
 
-Penyiapan kami terdiri dari 4 server. Ini mencakup Domain Controller, SQL Server, Server SharePoint, dan server untuk Reporting Services. Anda dapat memilih untuk menempatkan SharePoint dan Reporting Services pada satu mesin yang sama, yang akan menyederhanakan ini sedikit dan saya akan menunjukkan beberapa perbedaan.
+Setup keluar terdiri dari 4 server. Ini mencakup Pengontrol Domain, SQL Server, SharePoint Server dan server untuk Layanan Pelaporan. Anda dapat memilih untuk memiliki SharePoint dan Layanan Pelaporan pada kotak yang sama, yang akan sedikit menyederhanakannya dan saya akan menunjukkan beberapa perbedaannya.
 
-## Pra-syarat Instalasi
+## Prasyarat Instalasi
 
 {{% alert color="primary" %}}
 
-Add‑In Reporting Services untuk SharePoint adalah salah satu komponen kunci agar Integrasi berfungsi dengan baik. Add‑In ini perlu diinstal pada setiap Web Front End (WFE) yang ada di farm SharePoint Anda bersama dengan server Central Admin. Salah satu perubahan baru dengan SQL 2008 R2 \u0026 SharePoint 2010 adalah bahwa Add‑In 2008 R2 kini menjadi pra‑syarat untuk Instalasi SharePoint. Ini berarti Add‑In RS akan dipasang ketika Anda menginstal SharePoint. Hal ini telah ditunjukkan dan disorot pada gambar di bawah. Hal ini sebenarnya menghindari banyak masalah yang kami temui dengan SP 2007 dan RS 2008 saat menginstal Add‑In.
+Add-In Layanan Pelaporan untuk SharePoint adalah salah satu komponen kunci agar Integrasi berfungsi dengan baik. Add-In harus diinstal di Web Front End (WFE) mana pun yang ada di farm SharePoint Anda bersama dengan server Admin Pusat. Salah satu perubahan baru pada SQL 2008 R2 & SharePoint 2010 adalah Add-In 2008 R2 kini menjadi prasyarat untuk Penginstalan SharePoint. Ini berarti RS Add-In akan dipasang saat Anda menginstal SharePoint. Itu telah ditunjukkan dan disorot pada gambar di bawah. Hal ini sebenarnya menghindari banyak masalah yang kita lihat dengan SP 2007 dan RS 2008 saat menginstal Add-In.
 
-![todo:image_alt_text](introduction_1.png)
+![Introduction](introduction_1.png)
 
-**Image1 :- Reporting Services Add-in untuk Share Point**
+**Gambar1 :- Add-in Layanan Pelaporan untuk Share Point**
 {{% /alert %}}
 
-## Autentikasi SharePoint
+## Otentikasi SharePoint
 
-**Sebelum kita melompat ke bagian Integrasi RS, ada satu hal yang ingin saya soroti tentang SharePoint Farm, yaitu bagaimana Anda menyiapkan Situs. Lebih khusus lagi, bagaimana Anda mengkonfigurasi autentikasi untuk situs tersebut. Apakah akan menggunakan Classic atau Claims. Pilihan ini penting di awal. Saya tidak percaya Anda dapat mengubah opsi ini setelah selesai. Jika Anda dapat mengubahnya, prosesnya tidak akan sederhana.**
+**Sebelum kita beralih ke bagian Integrasi RS, satu hal yang ingin saya tunjukkan tentang SharePoint Farm adalah cara Anda menyiapkan Situs. Lebih khusus lagi bagaimana Anda mengonfigurasi otentikasi untuk situs tersebut. Baik itu Klasik atau Klaim. Pilihan ini penting pada awalnya. Saya tidak yakin Anda dapat mengubah opsi ini setelah selesai. Jika Anda bisa mengubahnya, itu bukanlah proses yang sederhana.
 
-NOTE: ***Reporting Services 2008 R2 tidak mendukung Claims***
+CATATAN: ***Layanan Pelaporan 2008 R2 TIDAK mengetahui Klaim***
 
-Meskipun Anda memilih situs SharePoint Anda untuk menggunakan Claims, Reporting Services sendiri tidak mengenal Claims. Namun, hal ini memengaruhi cara otentikasi bekerja dengan Reporting Services. Jadi, apa perbedaannya dari perspektif Reporting Services? Itu tergantung pada apakah Anda ingin meneruskan Kredensial Pengguna ke sumber data. Classic:- Dapat menggunakan Kerberos dan meneruskan kredensial pengguna ke datasource backend Anda (akan memerlukan Kerberos untuk itu). Claims:- Token Claims digunakan dan bukan token Windows. RS akan selalu menggunakan Trusted Authentication dalam skenario ini dan hanya akan memiliki akses ke token SPUser. Anda perlu menyimpan kredensial Anda di dalam sumber data.
+Meskipun Anda memilih situs SharePoint untuk menggunakan Klaim, Layanan Pelaporan itu sendiri tidak mengetahui Klaim. Meskipun demikian, hal ini memengaruhi cara kerja autentikasi dengan Layanan Pelaporan. Lantas, apa bedanya dari perspektif Reporting Services? Tergantung apakah Anda ingin meneruskan Kredensial Pengguna ke sumber data. Klasik:- Dapat menggunakan Kerberos dan meneruskan kredensial pengguna ke sumber data back end Anda (perlu menggunakan Kerberos untuk itu). Klaim:- Token Klaim digunakan dan bukan token windows. RS akan selalu menggunakan Otentikasi Tepercaya dalam skenario ini dan hanya akan memiliki akses ke token SPUser. Anda perlu menyimpan kredensial Anda dalam sumber data Anda.
 
-Classic :- Dapat menggunakan Kerberos dan meneruskan kredensial pengguna ke datasource backend Anda (akan memerlukan Kerberos untuk itu.
+Klasik :- Dapat menggunakan Kerberos dan meneruskan kredensial pengguna ke sumber data back end Anda (perlu menggunakan Kerberos untuk itu.
 
-Claims :- Token Claims digunakan dan bukan token Windows. RS akan selalu menggunakan Trusted Authentication dalam skenario ini dan hanya akan memiliki akses ke token SPUser. Anda perlu menyimpan kredensial Anda di dalam sumber data.
+Klaim :- Token Klaim digunakan dan bukan token windows. RS akan selalu menggunakan Otentikasi Tepercaya dalam skenario ini dan hanya akan memiliki akses ke token SPUser. Anda perlu menyimpan kredensial Anda dalam sumber data Anda.
 
-Untuk saat ini kami hanya ingin fokus pada penyiapan RS. Pada titik ini SharePoint telah diinstal di SharePoint Box saya dan dikonfigurasi dengan Situs Autentikasi Klasik pada port 80. Di server RS saya baru saja menginstal Reporting Services dan itu saja.
+Untuk saat ini kami hanya ingin fokus pada setup RS. Pada titik ini SharePoint diinstal pada Kotak SharePoint saya dan diatur dengan Situs Auth Klasik pada port 80. Di Server RS ​​saya baru saja menginstal Layanan Pelaporan dan hanya itu.

--- a/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
+++ b/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
@@ -1,15 +1,15 @@
 ---
-title: Pengantar
-linktitle: Pengantar
+title: Pendahuluan
+linktitle: Pendahuluan
 type: docs
 weight: 10
 url: /id/reportingservices/introduction/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF for Reporting Services telah sangat luar biasa untuk pembuatan PDF melalui SQL Reporting Services selama bertahun‑tahun dan menyediakan opsi konfigurasi serta parametrisasi yang beragam yang tidak didukung secara default di SQL Reporting Services. Baru-baru ini kami menerima beberapa permintaan terkait Integrasi Aspose.PDF for Reporting Services dengan SharePoint. Untuk artikel ini, kami akan fokus pada MS SharePoint 2010. Sebelum kami melanjutkan, kami mengasumsikan Anda sudah memiliki setup SharePoint Farm. Dalam contoh ini kami akan menggunakan SharePoint Cloud penuh. Namun langkah‑langkahnya serupa untuk SharePoint Foundation Server.
+Aspose.PDF for Reporting Services telah sangat luar biasa untuk pembuatan PDF melalui SQL Reporting Services selama bertahun‑tahun dan menyediakan beragam opsi konfigurasi serta parameterisasi yang tidak didukung secara default di SQL Reporting Services. Baru-baru ini kami menerima beberapa permintaan terkait Integrasi Aspose.PDF for Reporting Services dengan SharePoint. Untuk artikel ini, kami akan fokus pada MS SharePoint 2010. Sebelum kami melanjutkan lebih jauh, kami mengasumsikan bahwa Anda sudah memiliki setup SharePoint Farm. Dalam contoh ini kami akan menggunakan SharePoint Cloud penuh. Namun langkah‑langkahnya serupa untuk SharePoint Foundation Server.
 
 {{% /alert %}}
 
@@ -17,38 +17,37 @@ Aspose.PDF for Reporting Services telah sangat luar biasa untuk pembuatan PDF me
 
 Sebelum kami melanjutkan lebih jauh, mari kita lihat topik referensi yang telah kami konsultasikan selama persiapan artikel ini.
 
-- [Gambaran Umum Integrasi Layanan Pelaporan dan Teknologi SharePoint](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
-- [Topologi Penyebaran untuk Reporting Services dalam Mode Terintegrasi SharePoint](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
+- [Gambaran Umum Integrasi Teknologi Reporting Services dan SharePoint](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
+- [Topologi Penempatan untuk Reporting Services dalam Mode Terintegrasi SharePoint](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
 - [Mengonfigurasi Reporting Services untuk Integrasi SharePoint 2010](http://msdn.microsoft.com/en-us/library/bb326356.aspx)
 
 {{% /alert %}}
 
 ## Penyiapan Lingkungan
 
-Penyiapan kami terdiri dari 4 server. Itu mencakup sebuah Domain Controller, sebuah SQL Server, sebuah SharePoint Server, dan sebuah server untuk Reporting Services. Anda dapat memilih untuk menempatkan SharePoint dan Reporting Services pada satu kotak yang sama, yang akan menyederhanakan ini sedikit dan saya akan menunjukkan beberapa perbedaannya.
+Penyiapan kami terdiri dari 4 server. Ini mencakup Domain Controller, SQL Server, Server SharePoint, dan server untuk Reporting Services. Anda dapat memilih untuk menempatkan SharePoint dan Reporting Services pada satu mesin yang sama, yang akan menyederhanakan ini sedikit dan saya akan menunjukkan beberapa perbedaan.
 
-## Prasyarat Instalasi
+## Pra-syarat Instalasi
 
 {{% alert color="primary" %}}
 
-Add-In Reporting Services untuk SharePoint adalah salah satu komponen utama untuk membuat Integrasi berfungsi dengan baik. Add-In harus diinstal pada salah satu Web Front Ends (WFE) yang berada di farm SharePoint Anda bersama dengan server Central Admin. Salah satu perubahan baru dengan SQL 2008 R2 & SharePoint 2010 adalah bahwa Add-In 2008 R2 kini menjadi prasyarat untuk Instalasi SharePoint. Ini berarti bahwa RS Add-In akan dipasang ketika Anda menginstal SharePoint. Hal ini telah ditampilkan dan disorot pada gambar di bawah. Ini sebenarnya menghindari banyak masalah yang kami temui dengan SP 2007 dan RS 2008 saat menginstal Add-In.
+Add‑In Reporting Services untuk SharePoint adalah salah satu komponen kunci agar Integrasi berfungsi dengan baik. Add‑In ini perlu diinstal pada setiap Web Front End (WFE) yang ada di farm SharePoint Anda bersama dengan server Central Admin. Salah satu perubahan baru dengan SQL 2008 R2 \u0026 SharePoint 2010 adalah bahwa Add‑In 2008 R2 kini menjadi pra‑syarat untuk Instalasi SharePoint. Ini berarti Add‑In RS akan dipasang ketika Anda menginstal SharePoint. Hal ini telah ditunjukkan dan disorot pada gambar di bawah. Hal ini sebenarnya menghindari banyak masalah yang kami temui dengan SP 2007 dan RS 2008 saat menginstal Add‑In.
 
 ![todo:image_alt_text](introduction_1.png)
 
-**Image1 :- Add-in Reporting Services untuk Share Point**
+**Image1 :- Reporting Services Add-in untuk Share Point**
 {{% /alert %}}
 
-## Otentikasi SharePoint
+## Autentikasi SharePoint
 
-**Sebelum kita melompat ke bagian Integrasi RS, ada satu hal yang ingin saya sampaikan tentang SharePoint Farm yaitu cara Anda menyiapkan Situs. Lebih spesifik lagi cara Anda mengonfigurasi otentikasi untuk situs tersebut. Apakah akan menggunakan Classic atau Claims. Pilihan ini penting di awal. Saya tidak percaya Anda dapat mengubah opsi ini setelah selesai. Jika dapat mengubahnya, prosesnya tidak akan sederhana.**
+**Sebelum kita melompat ke bagian Integrasi RS, ada satu hal yang ingin saya soroti tentang SharePoint Farm, yaitu bagaimana Anda menyiapkan Situs. Lebih khusus lagi, bagaimana Anda mengkonfigurasi autentikasi untuk situs tersebut. Apakah akan menggunakan Classic atau Claims. Pilihan ini penting di awal. Saya tidak percaya Anda dapat mengubah opsi ini setelah selesai. Jika Anda dapat mengubahnya, prosesnya tidak akan sederhana.**
 
-CATATAN: ***Reporting Services 2008 R2 tidak mendukung Claims***
+NOTE: ***Reporting Services 2008 R2 tidak mendukung Claims***
 
-Meskipun Anda memilih situs SharePoint Anda untuk menggunakan Claims, Reporting Services itu sendiri tidak mendukung Claims. Meski begitu, hal ini memengaruhi cara otentikasi bekerja dengan Reporting Services. Jadi, apa perbedaannya dari perspektif Reporting Services? Semua tergantung pada apakah Anda ingin meneruskan Kredensial Pengguna ke sumber data. Classic:- Dapat menggunakan Kerberos dan meneruskan kredensial pengguna ke datasource back‑end Anda (akan perlu menggunakan Kerberos untuk itu). Claims:- Token Claims yang digunakan, bukan token Windows. RS akan selalu menggunakan Trusted Authentication dalam skenario ini dan hanya akan memiliki akses ke token SPUser. Anda perlu menyimpan kredensial Anda di dalam sumber data.
+Meskipun Anda memilih situs SharePoint Anda untuk menggunakan Claims, Reporting Services sendiri tidak mengenal Claims. Namun, hal ini memengaruhi cara otentikasi bekerja dengan Reporting Services. Jadi, apa perbedaannya dari perspektif Reporting Services? Itu tergantung pada apakah Anda ingin meneruskan Kredensial Pengguna ke sumber data. Classic:- Dapat menggunakan Kerberos dan meneruskan kredensial pengguna ke datasource backend Anda (akan memerlukan Kerberos untuk itu). Claims:- Token Claims digunakan dan bukan token Windows. RS akan selalu menggunakan Trusted Authentication dalam skenario ini dan hanya akan memiliki akses ke token SPUser. Anda perlu menyimpan kredensial Anda di dalam sumber data.
 
-Classic :- Dapat menggunakan Kerberos dan meneruskan kredensial pengguna ke datasource back end Anda (akan perlu menggunakan Kerberos untuk itu.
+Classic :- Dapat menggunakan Kerberos dan meneruskan kredensial pengguna ke datasource backend Anda (akan memerlukan Kerberos untuk itu.
 
-Claims :- Token Claims yang digunakan, bukan token Windows. RS akan selalu menggunakan Trusted Authentication dalam skenario ini dan hanya akan memiliki akses ke token SPUser. Anda perlu menyimpan kredensial Anda di dalam sumber data.
+Claims :- Token Claims digunakan dan bukan token Windows. RS akan selalu menggunakan Trusted Authentication dalam skenario ini dan hanya akan memiliki akses ke token SPUser. Anda perlu menyimpan kredensial Anda di dalam sumber data.
 
-Untuk saat ini kami hanya ingin fokus pada pengaturan RS. Pada titik ini SharePoint telah terinstal di SharePoint Box saya dan diatur dengan Situs Autentikasi Klasik pada port 80. Di Server RS saya baru saja menginstal Reporting Services dan itu saja.
-
+Untuk saat ini kami hanya ingin fokus pada penyiapan RS. Pada titik ini SharePoint telah diinstal di SharePoint Box saya dan dikonfigurasi dengan Situs Autentikasi Klasik pada port 80. Di server RS saya baru saja menginstal Reporting Services dan itu saja.

--- a/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
+++ b/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
@@ -1,21 +1,21 @@
 ---
-title: Reporting Services and SharePoint configuration
-linktitle: Reporting Services and SharePoint configuration
+title: Konfigurasi Reporting Services dan SharePoint
+linktitle: Konfigurasi Reporting Services dan SharePoint
 type: docs
 weight: 40
 url: /id/reportingservices/reporting-services-and-sharepoint-configuration/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Sekarang setelah SharePoint terinstal dan dikonfigurasi pada server RS serta RS diatur melalui Reporting Services Configuration Manager, kita dapat melanjutkan ke konfigurasi di Central Admin. RS 2008 R2 benar‑benar menyederhanakan proses ini. Dulu kami harus melalui proses 3 langkah untuk membuatnya berfungsi. Sekarang hanya ada satu langkah.
+Sekarang, karena SharePoint telah diinstal dan dikonfigurasi pada server RS serta RS telah disiapkan melalui Reporting Services Configuration Manager, kita dapat beralih ke konfigurasi dalam Central Admin. RS 2008 R2 memang sangat menyederhanakan proses ini. Dulu kami harus menjalankan proses tiga langkah untuk membuatnya berfungsi. Sekarang hanya ada satu langkah.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Kami ingin pergi ke situs Central Administrator Web dan kemudian ke General Application Settings. Di bagian bawah kami akan melihat Reporting Services.
+Kami ingin pergi ke situs Web Administrator Pusat dan kemudian ke Pengaturan Aplikasi Umum. Di bagian bawah kami akan melihat Reporting Services.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_1.png)
 **Image1**:- dialog konfigurasi SharePoint
@@ -29,16 +29,16 @@ Pilih tautan "Reporting Services Integration". Layar berikut akan ditampilkan.
 
 ## URL Layanan Web:
 
-**Kami akan menyediakan URL untuk Report Server yang kami temukan di Reporting Services Configuration Manager.**
+**Kami akan menyediakan URL untuk Server Laporan yang kami temukan di Reporting Services Configuration Manager.**
 
 ## Mode Otentikasi:
 
-**Kami juga akan memilih Mode Otentikasi. Tautan MSDN berikut menjelaskan secara detail apa itu.
+**Kami juga akan memilih Mode Otentikasi. Tautan MSDN berikut menjelaskan secara rinci apa itu.**
 Ikhtisar Keamanan untuk Reporting Services dalam Mode Terintegrasi SharePoint**
 
 {{% alert color="primary" %}}
 
-**Singkatnya, jika situs Anda menggunakan Claims Authentication, Anda akan selalu menggunakan Trusted Authentication terlepas dari apa yang Anda pilih di sini. Jika Anda ingin mengirimkan kredensial Windows, Anda harus memilih Windows Authentication. Untuk Trusted Authentication, kami akan mengirim token SPUser dan tidak bergantung pada kredensial Windows. Anda juga ingin menggunakan Trusted Authentication jika Anda telah mengonfigurasi situs Mode Klasik Anda untuk NTLM dan RS diatur untuk NTLM. Kerberos diperlukan untuk menggunakan Windows Authentication dan untuk meneruskannya ke sumber data Anda.**
+**Singkatnya, jika situs Anda menggunakan Claims Authentication, Anda akan selalu menggunakan Trusted Authentication terlepas dari apa yang Anda pilih di sini. Jika Anda ingin meneruskan kredensial Windows, Anda harus memilih Windows Authentication. Untuk Trusted Authentication, kami akan meneruskan token SPUser dan tidak bergantung pada kredensial Windows. Anda juga sebaiknya menggunakan Trusted Authentication jika Anda telah mengonfigurasi situs Mode Klasik Anda untuk NTLM dan RS disetel untuk NTLM. Kerberos diperlukan untuk menggunakan Windows Authentication dan untuk meneruskannya ke sumber data Anda.**
 
 {{% /alert %}}
 
@@ -46,7 +46,7 @@ Ikhtisar Keamanan untuk Reporting Services dalam Mode Terintegrasi SharePoint**
 
 {{% alert color="primary" %}}
 
-**Ini memberi Anda opsi untuk mengaktifkan Reporting Services pada semua koleksi Situs, atau Anda dapat memilih mana yang ingin diaktifkan. Ini sebenarnya berarti situs mana yang akan dapat menggunakan Reporting Services. Setelah selesai, Anda akan melihat hasil berikut**
+**Ini memberi Anda opsi untuk mengaktifkan Reporting Services pada semua koleksi Situs, atau Anda dapat memilih mana yang ingin Anda aktifkan. Ini sebenarnya berarti situs mana yang akan dapat menggunakan Reporting Services. Setelah selesai, Anda akan melihat hasil berikut**
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_3.png)
 
@@ -55,24 +55,24 @@ Ikhtisar Keamanan untuk Reporting Services dalam Mode Terintegrasi SharePoint**
 
 {{% alert color="primary" %}}
 
-Kembali ke URL ReportServer, kita harus melihat sesuatu yang mirip dengan berikut
+Kembali ke URL ReportServer, kita harus melihat sesuatu yang mirip dengan berikut ini
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_4.png)
 
 **Image4:**- Reporting Services berhasil terhubung dengan lingkungan SharePoint
 
-**NOTE:** ***Jika situs SharePoint Anda dikonfigurasi untuk SSL, tidak akan muncul dalam daftar ini. Ini adalah masalah yang diketahui dan tidak berarti ada masalah. Laporan Anda tetap harus berfungsi.***
+**NOTE:** ***Jika situs SharePoint Anda dikonfigurasi untuk SSL, itu tidak akan muncul dalam daftar ini. Ini adalah masalah yang diketahui dan tidak berarti ada masalah. Laporan Anda seharusnya tetap berfungsi.***
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Sekarang setelah kami berhasil mengintegrasikan kedua produk, kami siap menggunakan Reporting Services di SharePoint 2010. Seperti versi sebelumnya, kami memiliki sebuah fitur (diaktifkan saat kami mengkonfigurasi Reporting Services Integration) di “Site Collection Feature”. Selain itu instalasi menambahkan 3 tipe konten ke situs kami. Pada Image 7 kami dapat melihat 2 tipe konten tersebut ditambahkan di perpustakaan dokumen untuk membuat laporan khusus us ing the, seperti yang dapat kami lihat pada Image5 di bawah.
+Sekarang setelah kami berhasil mengintegrasikan kedua produk, kami siap menggunakan Reporting Services di SharePoint 2010. Seperti versi sebelumnya, kami memiliki sebuah fitur (diaktifkan saat kami mengonfigurasi Reporting Services Integration) dalam “Site Collection Feature”. Selain itu, instalasi menambahkan 3 tipe konten ke situs kami. Pada Image 7 kami dapat melihat 2 tipe konten tersebut ditambahkan ke pustaka dokumen untuk membuat laporan khusus menggunakan, seperti yang dapat kami lihat di Image5 di bawah.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_5.png)
 
 **Image5:**- Report Builder
 
-“Reporter Builder” adalah kontrol ActiveX sehingga kami perlu mengunduhnya melalui server, seperti yang dapat kami lihat pada Image 6 di bawah.
+“Reporter Builder” adalah kontrol ActiveX jadi kami perlu mengunduhnya ke server, seperti yang dapat kami lihat pada Image 6 di bawah.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_6.png)
 
@@ -81,20 +81,19 @@ Sekarang setelah kami berhasil mengintegrasikan kedua produk, kami siap mengguna
 
 {{% alert color="primary" %}}
 
-Setelah proses pengunduhan selesai, muat kontrol “Report Builder”. Sekarang kami siap mendesain laporan pertama kami, seperti yang ditampilkan pada Image7 di bawah.
+Setelah proses pengunduhan selesai, muat kontrol “Report Builder”. Sekarang kami siap untuk merancang laporan pertama kami, seperti yang ditunjukkan pada Image7 di bawah.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_7.png)
 
-**Image7:**- Report Builder – Wizard pembuatan Laporan Baru
+**Image7:**- Report Builder – Wizard pembuatan Laporan baru
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Setelah membuat laporan kami, kami dapat menyimpannya di perpustakaan dokumen yang dibuat untuk menempatkan laporan di SharePoint 2010 kami. Tipe konten lain harus digunakan untuk membuat koneksi bersama sebagai sumber data dan menyimpannya di perpustakaan dokumen di SharePoint. Kami dapat membuat perpustakaan dokumen, menambahkan tipe konten ini, dan setelah itu kami dapat memiliki koneksi kami tersedia untuk mengubah sumber data laporan.
+Setelah membuat laporan kami, kami dapat menyimpannya di document library yang dibuat untuk menempatkan laporan di SharePoint 2010 kami. Tipe konten lainnya harus digunakan untuk membuat shared connection sebagai data source dan menyimpannya di document library di SharePoint. Kami dapat membuat document library, menambahkan tipe konten ini, dan setelah itu kami akan memiliki connections kami yang tersedia untuk mengubah data source laporan.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_8.png)
 
-**Image8:**- Integrasi Berhasil Aspose.PDF untuk Reporting Services dengan MS SharePoint
+**Image8:**- Integrasi Berhasil Aspose.PDF for Reporting Services dengan MS SharePoint
 {{% /alert %}}
-
 

--- a/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
+++ b/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
@@ -1,44 +1,44 @@
 ---
-title: Konfigurasi Reporting Services dan SharePoint
-linktitle: Konfigurasi Reporting Services dan SharePoint
+title: Layanan Pelaporan dan konfigurasi SharePoint
+linktitle: Reporting Services and SharePoint configuration
 type: docs
 weight: 40
-url: /id/reportingservices/reporting-services-and-sharepoint-configuration/
-lastmod: "2026-07-29"
+url: /reportingservices/reporting-services-and-sharepoint-configuration/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Sekarang, karena SharePoint telah diinstal dan dikonfigurasi pada server RS serta RS telah disiapkan melalui Reporting Services Configuration Manager, kita dapat beralih ke konfigurasi dalam Central Admin. RS 2008 R2 memang sangat menyederhanakan proses ini. Dulu kami harus menjalankan proses tiga langkah untuk membuatnya berfungsi. Sekarang hanya ada satu langkah.
+Sekarang SharePoint telah diinstal dan dikonfigurasi di server RS ​​dan RS telah disiapkan dan dikonfigurasi melalui Manajer Konfigurasi Layanan Pelaporan, kita dapat beralih ke konfigurasi dalam Admin Pusat. RS 2008 R2 benar-benar menyederhanakan proses ini. Kami dulu memiliki proses 3 langkah yang harus Anda lakukan agar ini berfungsi. Sekarang kita hanya punya satu langkah.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Kami ingin pergi ke situs Web Administrator Pusat dan kemudian ke Pengaturan Aplikasi Umum. Di bagian bawah kami akan melihat Reporting Services.
+Kami ingin pergi ke situs Web Administrator Pusat dan kemudian ke Pengaturan Aplikasi Umum. Di bagian bawah kita akan melihat Layanan Pelaporan.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_1.png)
-**Image1**:- dialog konfigurasi SharePoint
+![Configuration-step1](reporting-services-and-sharepoint-configuration_1.png)
+**Gambar1**:- Dialog konfigurasi SharePoint
 
-Pilih tautan "Reporting Services Integration". Layar berikut akan ditampilkan.
+Pilih tautan "Integrasi Layanan Pelaporan". Layar berikut akan ditampilkan.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_2.png)
-**Image2**:- Tentukan kredensial integrasi Reporting Services
+![Configuration-step2](reporting-services-and-sharepoint-configuration_2.png)
+**Gambar2**:- Tentukan kredensial integrasi Layanan Pelaporan
 
 {{% /alert %}}
 
 ## URL Layanan Web:
 
-**Kami akan menyediakan URL untuk Server Laporan yang kami temukan di Reporting Services Configuration Manager.**
+**Kami akan memberikan URL untuk Server Laporan yang kami temukan di Manajer Konfigurasi Layanan Pelaporan.**
 
 ## Mode Otentikasi:
 
-**Kami juga akan memilih Mode Otentikasi. Tautan MSDN berikut menjelaskan secara rinci apa itu.**
-Ikhtisar Keamanan untuk Reporting Services dalam Mode Terintegrasi SharePoint**
+**Kami juga akan memilih Mode Otentikasi. Tautan MSDN berikut menjelaskan secara rinci apa itu.
+Ikhtisar Keamanan untuk Layanan Pelaporan dalam Mode Terintegrasi SharePoint**
 
 {{% alert color="primary" %}}
 
-**Singkatnya, jika situs Anda menggunakan Claims Authentication, Anda akan selalu menggunakan Trusted Authentication terlepas dari apa yang Anda pilih di sini. Jika Anda ingin meneruskan kredensial Windows, Anda harus memilih Windows Authentication. Untuk Trusted Authentication, kami akan meneruskan token SPUser dan tidak bergantung pada kredensial Windows. Anda juga sebaiknya menggunakan Trusted Authentication jika Anda telah mengonfigurasi situs Mode Klasik Anda untuk NTLM dan RS disetel untuk NTLM. Kerberos diperlukan untuk menggunakan Windows Authentication dan untuk meneruskannya ke sumber data Anda.**
+**Singkatnya, jika situs Anda menggunakan Otentikasi Klaim, Anda akan selalu menggunakan Otentikasi Tepercaya apa pun yang Anda pilih di sini. Jika Anda ingin meneruskan kredensial windows, Anda dapat memilih Otentikasi Windows. Untuk Otentikasi Tepercaya, kami akan meneruskan token SPUser dan tidak bergantung pada kredensial Windows. Anda juga ingin menggunakan Otentikasi Tepercaya jika Anda telah mengonfigurasi situs Mode Klasik untuk NTLM dan RS disiapkan untuk NTLM. Kerberos diperlukan untuk menggunakan Autentikasi Windows dan meneruskannya ke sumber data Anda.**
 
 {{% /alert %}}
 
@@ -46,54 +46,54 @@ Ikhtisar Keamanan untuk Reporting Services dalam Mode Terintegrasi SharePoint**
 
 {{% alert color="primary" %}}
 
-**Ini memberi Anda opsi untuk mengaktifkan Reporting Services pada semua koleksi Situs, atau Anda dapat memilih mana yang ingin Anda aktifkan. Ini sebenarnya berarti situs mana yang akan dapat menggunakan Reporting Services. Setelah selesai, Anda akan melihat hasil berikut**
+**Ini memberi Anda pilihan untuk mengaktifkan Layanan Pelaporan di semua kumpulan Situs, atau Anda dapat memilih di mana Anda ingin mengaktifkannya. Ini berarti situs mana yang dapat menggunakan Layanan Pelaporan. Setelah selesai, Anda akan melihat hasil berikut**
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_3.png)
+![Configuration-step3](reporting-services-and-sharepoint-configuration_3.png)
 
-**Image3:**- Integrasi berhasil Reporting Services dengan lingkungan SharePoint
+**Gambar3:**- Integrasi Layanan Pelaporan yang berhasil dengan lingkungan SharePoint
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Kembali ke URL ReportServer, kita harus melihat sesuatu yang mirip dengan berikut ini
+Kembali ke URL ReportServer, kita akan melihat sesuatu yang mirip dengan yang berikut ini
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_4.png)
+![Configuration-step4](reporting-services-and-sharepoint-configuration_4.png)
 
-**Image4:**- Reporting Services berhasil terhubung dengan lingkungan SharePoint
+**Gambar4:**- Layanan Pelaporan berhasil terhubung dengan lingkungan SharePoint
 
-**NOTE:** ***Jika situs SharePoint Anda dikonfigurasi untuk SSL, itu tidak akan muncul dalam daftar ini. Ini adalah masalah yang diketahui dan tidak berarti ada masalah. Laporan Anda seharusnya tetap berfungsi.***
+**CATATAN:** ​​***Jika situs SharePoint Anda dikonfigurasi untuk SSL, situs tersebut tidak akan muncul dalam daftar ini. Ini adalah masalah yang diketahui dan bukan berarti ada masalah. Laporan Anda seharusnya tetap berfungsi.***
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Sekarang setelah kami berhasil mengintegrasikan kedua produk, kami siap menggunakan Reporting Services di SharePoint 2010. Seperti versi sebelumnya, kami memiliki sebuah fitur (diaktifkan saat kami mengonfigurasi Reporting Services Integration) dalam “Site Collection Feature”. Selain itu, instalasi menambahkan 3 tipe konten ke situs kami. Pada Image 7 kami dapat melihat 2 tipe konten tersebut ditambahkan ke pustaka dokumen untuk membuat laporan khusus menggunakan, seperti yang dapat kami lihat di Image5 di bawah.
+Kini setelah kami berhasil mengintegrasikan kedua produk, kami siap menggunakan Layanan Pelaporan di SharePoint 2010. Seperti versi sebelumnya, kami memiliki fitur (diaktifkan saat kami mengonfigurasi Integrasi Layanan Pelaporan) di “Fitur Kumpulan Situs”. Instalasi juga menambahkan 3 tipe konten untuk ditambahkan ke situs kami. Pada Gambar 7 kita dapat melihat 2 tipe konten ditambahkan di pustaka dokumen untuk membuat laporan khusus menggunakan, seperti yang dapat kita lihat pada Gambar 5 di bawah.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_5.png)
+![Configuration-step5](reporting-services-and-sharepoint-configuration_5.png)
 
-**Image5:**- Report Builder
+**Gambar5:**- Pembuat Laporan
 
-“Reporter Builder” adalah kontrol ActiveX jadi kami perlu mengunduhnya ke server, seperti yang dapat kami lihat pada Image 6 di bawah.
+"Reporter Builder" adalah kontrol ActiveX jadi kita perlu mendownloadnya melalui server, seperti yang bisa kita lihat pada Gambar 6 di bawah.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_6.png)
+![Configuration-step6](reporting-services-and-sharepoint-configuration_6.png)
 
-**Image6:**- Unduh dan instal Report Builder
+**Gambar6:**- Unduh dan instal Pembuat Laporan
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Setelah proses pengunduhan selesai, muat kontrol “Report Builder”. Sekarang kami siap untuk merancang laporan pertama kami, seperti yang ditunjukkan pada Image7 di bawah.
+Setelah proses pengunduhan selesai, muat kontrol “Pembuat Laporan”. Sekarang kita siap merancang laporan pertama kita, seperti yang ditunjukkan pada Gambar7 di bawah.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_7.png)
+![Configuration-step7](reporting-services-and-sharepoint-configuration_7.png)
 
-**Image7:**- Report Builder – Wizard pembuatan Laporan baru
+**Gambar7:**- Pembuat Laporan – Panduan pembuatan Laporan baru
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Setelah membuat laporan kami, kami dapat menyimpannya di document library yang dibuat untuk menempatkan laporan di SharePoint 2010 kami. Tipe konten lainnya harus digunakan untuk membuat shared connection sebagai data source dan menyimpannya di document library di SharePoint. Kami dapat membuat document library, menambahkan tipe konten ini, dan setelah itu kami akan memiliki connections kami yang tersedia untuk mengubah data source laporan.
+Setelah membuat laporan, kami dapat menyimpannya di pustaka dokumen yang dibuat untuk meletakkan laporan di SharePoint 2010. Tipe konten lainnya harus digunakan untuk membuat koneksi bersama sebagai sumber data dan menyimpannya di pustaka dokumen di SharePoint. Kita bisa membuat pustaka dokumen, menambahkan tipe konten ini dan setelah itu kita bisa menyediakan koneksi untuk mengubah sumber data laporan.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_8.png)
+![Configuration-step8](reporting-services-and-sharepoint-configuration_8.png)
 
-**Image8:**- Integrasi Berhasil Aspose.PDF for Reporting Services dengan MS SharePoint
+**Image8:**- Integrasi Aspose.PDF yang Berhasil untuk Layanan Pelaporan dengan MS SharePoint
 {{% /alert %}}
 

--- a/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
+++ b/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
@@ -4,18 +4,18 @@ linktitle: Menyiapkan Reporting Services
 type: docs
 weight: 20
 url: /id/reportingservices/setting-up-reporting-services/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Tahap pertama kami di Server Reporting Services adalah Reporting Services Configuration Manager.
+Pemberhentian pertama kami di Server Reporting Services adalah Reporting Services Configuration Manager.
 
 {{% /alert %}}
 
 ## Akun Layanan:
 
-**Pastikan Anda memahami akun layanan apa yang Anda gunakan untuk Reporting Services. Jika kita mengalami masalah, mungkin terkait dengan akun layanan yang Anda gunakan. Defaultnya adalah Network Service. Saat kami melakukan penyebaran build baru, kami selalu menggunakan Akun Domain, karena di situlah kemungkinan masalah muncul. Untuk instance server ini, kami telah menggunakan Akun Domain yang disebut RSService.**
+**Pastikan Anda mengerti akun layanan apa yang Anda gunakan untuk Reporting Services. Jika kami mengalami masalah, hal itu mungkin terkait dengan akun layanan yang Anda gunakan. Defaultnya adalah Network Service. Saat kami melakukan penyebaran build baru, kami selalu menggunakan Domain Account, karena di situlah kami cenderung mengalami masalah. Untuk instance server ini, kami menggunakan Domain Account yang disebut RSService.**
 
 ![todo:image_alt_text](setting-up-reporting-services_1.png)
 
@@ -25,37 +25,37 @@ Tahap pertama kami di Server Reporting Services adalah Reporting Services Config
 
 {{% alert color="primary" %}}
 
-**Kami perlu mengonfigurasi URL Layanan Web. Ini adalah direktori virtual ReportServer (vdir) yang menyimpan Web Services yang digunakan Reporting Services, dan yang akan berkomunikasi dengan SharePoint. Kecuali Anda ingin menyesuaikan properti vdir (mis. SSL, port, header host, dll…), Anda cukup dapat mengklik Terapkan di sini dan siap digunakan.**
+**Kami perlu mengkonfigurasi URL Layanan Web. Ini adalah direktori virtual ReportServer (vdir) yang menampung Layanan Web yang digunakan Reporting Services, dan yang akan berkomunikasi dengan SharePoint. Kecuali Anda ingin menyesuaikan properti vdir (mis. SSL, port, header host, dll…), Anda cukup dapat mengklik Apply di sini dan siap digunakan.**
 ![todo:image_alt_text](setting-up-reporting-services_2.png)
 
-**Image2:- Menyiapkan URL Layanan Web Setelah URL layanan web diatur, Anda harus dapat melihat hasil berikut**
+**Image2:- Menyiapkan URL Layanan Web Setelah URL layanan Web disiapkan, Anda seharusnya dapat melihat hasil berikut**
 
 ![todo:image_alt_text](setting-up-reporting-services_3.png)
 
-**Image3:- Penyiapan URL layanan web berhasil**
+**Image3:- Pengaturan URL layanan Web berhasil**
 {{% /alert %}}
 
 ## Database:
 
-**Kami perlu membuat Database Katalog Layanan Pelaporan. Ini dapat ditempatkan pada mesin Database SQL 2008 atau SQL 2008 R2 mana pun. SQL11 juga akan berfungsi dengan baik, tetapi masih dalam BETA. Tindakan ini secara default akan membuat dua basis data, ReportServer dan ReportServerTempDB.**
+**Kita perlu membuat Database Katalog Reporting Services. Ini dapat ditempatkan pada Mesin Database SQL 2008 atau SQL 2008 R2 mana saja. SQL11 juga akan berfungsi dengan baik, tetapi masih dalam BETA. Tindakan ini secara default akan membuat dua basis data, ReportServer dan ReportServerTempDB.**
 
 {{% alert color="primary" %}}
-**Langkah penting lainnya adalah memastikan Anda memilih SharePoint Integrated untuk jenis basis data. Setelah pilihan ini dibuat, tidak dapat diubah.**
+**Langkah penting lainnya adalah memastikan bahwa Anda memilih SharePoint Integrated untuk tipe basis data. Setelah pilihan ini dibuat, tidak dapat diubah.**
 
 ![todo:image_alt_text](setting-up-reporting-services_4.png)
 
-**Image4:- Membuat basis data server laporan**
+**Image4:- Membuat database server laporan**
 
 ![todo:image_alt_text](setting-up-reporting-services_5.png)
 
-**Image5:- Menyiapkan server basis data dan jenis autentikasi**
+**Image5:- Menyiapkan server basis data dan tipe otentikasi**
 
 ![todo:image_alt_text](setting-up-reporting-services_6.png)
 
 **Image6:- Menyiapkan nama basis data dan Mode**
 {{% /alert %}}
 
-**Untuk kredensial, begitulah cara Report Server akan berkomunikasi dengan SQL Server. Akun apa pun yang Anda pilih, akan diberikan hak tertentu dalam basis data Catalog serta beberapa basis data sistem melalui RSExecRole. MSDB adalah salah satu basis data ini untuk penggunaan Subscription karena kami menggunakan SQL Agent.**
+**Untuk kredensial, inilah cara Report Server berkomunikasi dengan SQL Server. Akun apa pun yang Anda pilih, akan diberikan hak tertentu dalam basis data Catalog serta beberapa basis data sistem melalui RSExecRole. MSDB adalah salah satu basis data ini untuk penggunaan Langganan karena kami menggunakan SQL Agent.**
 
 ![todo:image_alt_text](setting-up-reporting-services_7.png)
 
@@ -63,7 +63,7 @@ Tahap pertama kami di Server Reporting Services adalah Reporting Services Config
 
 {{% alert color="primary" %}}
 
-**Setelah kredensial basis data ditentukan, kita harus dapat memperoleh hasil seperti yang ditentukan di bawah ini.**
+**Setelah kredensial basis data ditentukan, kita seharusnya dapat memperoleh hasil sebagaimana dijelaskan di bawah ini.**
 
 ![todo:image_alt_text](setting-up-reporting-services_8.png)
 
@@ -76,12 +76,12 @@ Tahap pertama kami di Server Reporting Services adalah Reporting Services Config
 
 ## URL Report Manager:
 
-**Kita dapat melewatkan URL Report Manager karena tidak digunakan saat kami berada dalam mode Terintegrasi SharePoint. SharePoint adalah frontend kami. Report Manager tidak berfungsi.**
+**Kita dapat melewatkan URL Report Manager karena tidak digunakan ketika kita berada dalam mode Terintegrasi SharePoint. SharePoint adalah frontend kita. Report Manager tidak berfungsi.**
 
 ## Kunci Enkripsi:
 
 {{% alert color="primary" %}}
-**Cadangkan Kunci Enkripsi Anda dan pastikan Anda tahu di mana menyimpannya. Jika Anda berada dalam situasi di mana Anda perlu memigrasikan Database atau memulihkannya, Anda akan memerlukan ini.**
+**Cadangkan Kunci Enkripsi Anda dan pastikan Anda tahu di mana Anda menyimpannya. Jika Anda berada dalam situasi di mana Anda perlu memigrasi Database atau mengembalikannya, Anda akan memerlukan kunci ini.**
 
 ![todo:image_alt_text](setting-up-reporting-services_10.png)
 
@@ -89,13 +89,12 @@ Tahap pertama kami di Server Reporting Services adalah Reporting Services Config
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Selamat! Kami telah berhasil mengkonfigurasi Reporting Services menggunakan Configuration Manager. Jika Anda menelusuri ke URL pada tab Web Service URL, seharusnya akan muncul sesuatu yang mirip dengan berikut ini.**
+**Selamat! Kami telah berhasil mengkonfigurasi Reporting Services menggunakan Configuration Manager. Jika Anda membuka URL pada tab Web Service URL, itu akan menampilkan sesuatu yang mirip dengan berikut.**
 
 ![todo:image_alt_text](setting-up-reporting-services_11.png)
 
 **Image11:- Akses Report Server setelah instalasi**
 
-**Alasan kesalahan: SharePoint diinstal pada WFE kami dan kami telah menyelesaikan pengaturan Reporting Services. Dalam contoh ini, Reporting Services dan SharePoint berada di mesin yang berbeda. Jika mereka berada di mesin yang sama, Anda tidak akan melihat kesalahan ini. Secara teknis kami perlu menginstal SharePoint pada RS Box. Itu berarti IIS juga akan diaktifkan.**
+**Alasan kesalahan: SharePoint diinstal di WFE kami dan kami telah menyelesaikan penyiapan Reporting Services. Dalam contoh ini, Reporting Services dan SharePoint berada di mesin yang berbeda. Jika mereka berada pada mesin yang sama, Anda tidak akan melihat kesalahan ini. Secara teknis kami harus menginstal SharePoint pada RS Box. Itu berarti IIS juga akan diaktifkan.**
 {{% /alert %}}
-
 

--- a/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
+++ b/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
@@ -1,100 +1,100 @@
 ---
-title: Menyiapkan Reporting Services
-linktitle: Menyiapkan Reporting Services
+title: Menyiapkan Layanan Pelaporan
+linktitle: Setting up Reporting Services
 type: docs
 weight: 20
-url: /id/reportingservices/setting-up-reporting-services/
-lastmod: "2026-07-29"
+url: /reportingservices/setting-up-reporting-services/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Pemberhentian pertama kami di Server Reporting Services adalah Reporting Services Configuration Manager.
+Perhentian pertama kami di Server Layanan Pelaporan adalah Manajer Konfigurasi Layanan Pelaporan.
 
 {{% /alert %}}
 
 ## Akun Layanan:
 
-**Pastikan Anda mengerti akun layanan apa yang Anda gunakan untuk Reporting Services. Jika kami mengalami masalah, hal itu mungkin terkait dengan akun layanan yang Anda gunakan. Defaultnya adalah Network Service. Saat kami melakukan penyebaran build baru, kami selalu menggunakan Domain Account, karena di situlah kami cenderung mengalami masalah. Untuk instance server ini, kami menggunakan Domain Account yang disebut RSService.**
+**Pastikan untuk memahami akun layanan apa yang Anda gunakan untuk Layanan Pelaporan. Jika kami mengalami masalah, mungkin terkait dengan akun layanan yang Anda gunakan. Standarnya adalah Layanan Jaringan. Saat kami akan menerapkan versi baru, kami selalu menggunakan Akun Domain, karena di sanalah kemungkinan besar kami akan menemui masalah. Untuk server contoh ini, kami telah menggunakan Akun Domain yang disebut RSService.**
 
-![todo:image_alt_text](setting-up-reporting-services_1.png)
+![Set Up](setting-up-reporting-services_1.png)
 
-**Image1:- Menyiapkan akun layanan**
+**Gambar1:- Menyiapkan akun layanan**
 
 ## URL Layanan Web:
 
 {{% alert color="primary" %}}
 
-**Kami perlu mengkonfigurasi URL Layanan Web. Ini adalah direktori virtual ReportServer (vdir) yang menampung Layanan Web yang digunakan Reporting Services, dan yang akan berkomunikasi dengan SharePoint. Kecuali Anda ingin menyesuaikan properti vdir (mis. SSL, port, header host, dll…), Anda cukup dapat mengklik Apply di sini dan siap digunakan.**
-![todo:image_alt_text](setting-up-reporting-services_2.png)
+**Kita perlu mengonfigurasi URL Layanan Web. Ini adalah direktori virtual ReportServer (vdir) yang menghosting Layanan Pelaporan Layanan Web yang digunakan, dan dengan apa SharePoint akan berkomunikasi. Kecuali Anda ingin menyesuaikan properti vdir (yaitu SSL, port, header host, dll…), Anda cukup mengeklik Terapkan di sini dan siap melakukannya.**
+![Web Service URL](setting-up-reporting-services_2.png)
 
-**Image2:- Menyiapkan URL Layanan Web Setelah URL layanan Web disiapkan, Anda seharusnya dapat melihat hasil berikut**
+**Gambar2:- Menyiapkan URL Layanan Web Setelah URL layanan Web disiapkan, Anda akan melihat hasil berikut**
 
-![todo:image_alt_text](setting-up-reporting-services_3.png)
+![Web Service URL Results](setting-up-reporting-services_3.png)
 
-**Image3:- Pengaturan URL layanan Web berhasil**
+**Gambar3:- Penyiapan URL layanan Web berhasil**
 {{% /alert %}}
 
-## Database:
+## Basis Data:
 
-**Kita perlu membuat Database Katalog Reporting Services. Ini dapat ditempatkan pada Mesin Database SQL 2008 atau SQL 2008 R2 mana saja. SQL11 juga akan berfungsi dengan baik, tetapi masih dalam BETA. Tindakan ini secara default akan membuat dua basis data, ReportServer dan ReportServerTempDB.**
+**Kita perlu membuat Database Katalog Layanan Pelaporan. Ini dapat ditempatkan pada Mesin Database SQL 2008 atau SQL 2008 R2 apa pun. SQL11 juga akan berfungsi dengan baik, tapi itu masih dalam BETA. Tindakan ini akan membuat dua database, ReportServer dan ReportServerTempDB, secara default.**
 
 {{% alert color="primary" %}}
-**Langkah penting lainnya adalah memastikan bahwa Anda memilih SharePoint Integrated untuk tipe basis data. Setelah pilihan ini dibuat, tidak dapat diubah.**
+**Langkah penting lainnya dalam hal ini adalah memastikan Anda memilih SharePoint Integrated untuk tipe database. Setelah pilihan ini dibuat, pilihan ini tidak dapat diubah.**
 
-![todo:image_alt_text](setting-up-reporting-services_4.png)
+![Creating Report Server Database](setting-up-reporting-services_4.png)
 
-**Image4:- Membuat database server laporan**
+**Gambar4:- Membuat database server laporan**
 
-![todo:image_alt_text](setting-up-reporting-services_5.png)
+![Setting up Database Server and Authentication Type](setting-up-reporting-services_5.png)
 
-**Image5:- Menyiapkan server basis data dan tipe otentikasi**
+**Gambar5:- Menyiapkan server database dan jenis otentikasi**
 
-![todo:image_alt_text](setting-up-reporting-services_6.png)
+![Setting up Database Name and Mode](setting-up-reporting-services_6.png)
 
-**Image6:- Menyiapkan nama basis data dan Mode**
+**Gambar6:- Menyiapkan nama dan Mode database**
 {{% /alert %}}
 
-**Untuk kredensial, inilah cara Report Server berkomunikasi dengan SQL Server. Akun apa pun yang Anda pilih, akan diberikan hak tertentu dalam basis data Catalog serta beberapa basis data sistem melalui RSExecRole. MSDB adalah salah satu basis data ini untuk penggunaan Langganan karena kami menggunakan SQL Agent.**
+**Untuk kredensial, ini adalah cara Server Laporan berkomunikasi dengan SQL Server. Akun apa pun yang Anda pilih, akan diberikan hak tertentu dalam database Katalog serta beberapa database sistem melalui RSExecRole. MSDB adalah salah satu database untuk penggunaan Berlangganan saat kami menggunakan Agen SQL.**
 
-![todo:image_alt_text](setting-up-reporting-services_7.png)
+![Setting up Report Server database credentials](setting-up-reporting-services_7.png)
 
-**Image7:- Menyiapkan kredensial basis data Report Server**
+**Gambar7:- Menyiapkan kredensial database Server Laporan**
 
 {{% alert color="primary" %}}
 
-**Setelah kredensial basis data ditentukan, kita seharusnya dapat memperoleh hasil sebagaimana dijelaskan di bawah ini.**
+**Setelah kredensial database ditentukan, kita seharusnya bisa mendapatkan hasil seperti yang ditentukan di bawah ini.**
 
-![todo:image_alt_text](setting-up-reporting-services_8.png)
+![Report Server database creation progress](setting-up-reporting-services_8.png)
 
-**Image8:- Progres pembuatan basis data Report Server**
+**Gambar8:- Laporkan kemajuan pembuatan database Server**
 
-![todo:image_alt_text](setting-up-reporting-services_9.png)
+![Report Server database completion summary](setting-up-reporting-services_9.png)
 
-**Image9:- Ringkasan penyelesaian basis data Report Server**
+**Gambar9:- Ringkasan penyelesaian database Server Laporan**
 {{% /alert %}}
 
-## URL Report Manager:
+## URL Pengelola Laporan:
 
-**Kita dapat melewatkan URL Report Manager karena tidak digunakan ketika kita berada dalam mode Terintegrasi SharePoint. SharePoint adalah frontend kita. Report Manager tidak berfungsi.**
+**Kita dapat melewati URL Manajer Laporan karena tidak digunakan saat kita berada dalam mode SharePoint Terintegrasi. SharePoint adalah antarmuka kami. Manajer Laporan tidak berfungsi.**
 
 ## Kunci Enkripsi:
 
 {{% alert color="primary" %}}
-**Cadangkan Kunci Enkripsi Anda dan pastikan Anda tahu di mana Anda menyimpannya. Jika Anda berada dalam situasi di mana Anda perlu memigrasi Database atau mengembalikannya, Anda akan memerlukan kunci ini.**
+**Cadangkan Kunci Enkripsi Anda dan pastikan Anda tahu di mana Anda menyimpannya. Jika Anda mengalami situasi di mana Anda perlu memigrasikan Database atau memulihkannya, Anda memerlukan ini.**
 
-![todo:image_alt_text](setting-up-reporting-services_10.png)
+![Report Server Encryption key backup](setting-up-reporting-services_10.png)
 
-**Image10:- Cadangan kunci enkripsi Report Server**
+**Gambar10:- Laporkan cadangan kunci Enkripsi Server**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Selamat! Kami telah berhasil mengkonfigurasi Reporting Services menggunakan Configuration Manager. Jika Anda membuka URL pada tab Web Service URL, itu akan menampilkan sesuatu yang mirip dengan berikut.**
+**Selamat! Kami telah berhasil mengonfigurasi Layanan Pelaporan menggunakan Manajer Konfigurasi. Jika Anda menelusuri URL di tab URL Layanan Web, URL tersebut akan menampilkan tampilan seperti berikut.**
 
-![todo:image_alt_text](setting-up-reporting-services_11.png)
+![Report Server access after installation](setting-up-reporting-services_11.png)
 
-**Image11:- Akses Report Server setelah instalasi**
+**Gambar11:- Laporkan akses Server setelah instalasi**
 
-**Alasan kesalahan: SharePoint diinstal di WFE kami dan kami telah menyelesaikan penyiapan Reporting Services. Dalam contoh ini, Reporting Services dan SharePoint berada di mesin yang berbeda. Jika mereka berada pada mesin yang sama, Anda tidak akan melihat kesalahan ini. Secara teknis kami harus menginstal SharePoint pada RS Box. Itu berarti IIS juga akan diaktifkan.**
+**Alasan kesalahan: SharePoint diinstal di WFE kami dan kami selesai menyiapkan Layanan Pelaporan. Dalam contoh ini, Layanan Pelaporan dan SharePoint berada di mesin yang berbeda. Jika mereka berada di mesin yang sama, Anda tidak akan melihat kesalahan ini. Secara teknis kami perlu menginstal SharePoint di RS Box. Itu berarti IIS juga akan diaktifkan.**
 {{% /alert %}}
 

--- a/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
+++ b/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
@@ -1,49 +1,49 @@
 ---
-title: Menyiapkan SharePoint di Server Reporting Services
-linktitle: Menyiapkan SharePoint di Server Reporting Services
+title: Menyiapkan SharePoint di Server Layanan Pelaporan
+linktitle: Setting up SharePoint on Reporting Services Server
 type: docs
 weight: 30
-url: /id/reportingservices/setting-up-sharepoint-on-reporting-services-server/
-lastmod: "2026-07-29"
+url: /reportingservices/setting-up-sharepoint-on-reporting-services-server/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Sekarang kita perlu melakukan langkah serupa seperti yang kita lakukan untuk SharePoint WFE. Hal pertama adalah menjalani instalasi Prereq uisites dan setelah selesai, memulai penyiapan SharePoint.
+Sekarang kita perlu melakukan langkah serupa seperti yang kita lakukan untuk SharePoint WFE. Hal pertama adalah melalui instalasi Prereq uisites dan setelah selesai, mulai pengaturan SharePoint.
 
 {{% /alert %}}
 
-Untuk pengaturan, saya memilih Server Farm dan instalasi lengkap untuk mencocokkan SharePoint Box saya, karena saya tidak menginginkan instalasi mandiri untuk SharePoint.
+Untuk pengaturan saya memilih Server Farm dan instalasi lengkap agar sesuai dengan SharePoint Box saya, karena saya tidak ingin instalasi mandiri untuk SharePoint.
 
 ## Konfigurasi SharePoint
 
 {{% alert color="primary" %}}
 
-**Dalam SharePoint Configuration Wizard, kami ingin terhubung ke farm yang ada.**
+**Di Wizard Konfigurasi SharePoint, kami ingin menyambungkan ke farm yang sudah ada.**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_1.png)
+![Panduan Konfigurasi SharePoint](setting-up-sharepoint-on-reporting-services-server_1.png)
 
-**Gambar1:- wizard konfigurasi SharePoint**
+**Gambar1:- Wizard konfigurasi SharePoint**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**Kami kemudian akan mengarahkannya ke basis data SharePoint_Config yang digunakan oleh farm kami. Jika Anda tidak tahu di mana letaknya, Anda dapat menemukannya melalui Central Admin melalui System Settings -> Manager Servers di farm ini.**
+**Kami kemudian akan mengarahkannya ke database SharePoint_Config yang digunakan peternakan kami. Jika belum tahu ini dimana, bisa mengetahuinya melalui Admin Pusat melalui Pengaturan Sistem -> Server Manajer di peternakan ini.**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_2.png)
+![Basis Data Konfigurasi SharePoint](setting-up-sharepoint-on-reporting-services-server_2.png)
 
-**Gambar2:- Tentukan pengaturan konfigurasi basis data**
+**Gambar2:- Tentukan pengaturan konfigurasi database**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_3.png)
+![Panduan Konfigurasi SharePoint](setting-up-sharepoint-on-reporting-services-server_3.png)
 
-**Gambar3:- wizard konfigurasi SharePoint**
+**Gambar3:- Wizard konfigurasi SharePoint**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**Setelah wizard selesai, itu semua yang perlu kita lakukan pada kotak Report Server untuk saat ini. Kembali ke URL ReportServer, kita akan melihat kesalahan lain, tetapi itu karena kita belum mengkonfigurasinya melalui Central Administrator.**
+**Setelah wizard selesai, hanya itu yang perlu kita lakukan pada Kotak Server Laporan untuk saat ini. Kembali ke URL ReportServer, kita akan melihat kesalahan lain, tapi itu karena kita belum mengkonfigurasinya melalui Administrator Pusat.**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_4.png)
+![Kesalahan Konfigurasi SharePoint](setting-up-sharepoint-on-reporting-services-server_4.png)
 
-**Image4:- Kesalahan server laporan**
+**Gambar4:- Laporkan kesalahan server**
 {{% /alert %}}

--- a/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
+++ b/id/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
@@ -1,50 +1,49 @@
 ---
-title: Menyiapkan SharePoint pada Server Reporting Services
-linktitle: Menyiapkan SharePoint pada Server Reporting Services
+title: Menyiapkan SharePoint di Server Reporting Services
+linktitle: Menyiapkan SharePoint di Server Reporting Services
 type: docs
 weight: 30
 url: /id/reportingservices/setting-up-sharepoint-on-reporting-services-server/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Sekarang kami perlu melakukan langkah-langkah serupa seperti yang kami lakukan untuk SharePoint WFE. Hal pertama adalah melalui instalasi Prereq uisites dan setelah selesai, memulai pengaturan SharePoint.
+Sekarang kita perlu melakukan langkah serupa seperti yang kita lakukan untuk SharePoint WFE. Hal pertama adalah menjalani instalasi Prereq uisites dan setelah selesai, memulai penyiapan SharePoint.
 
 {{% /alert %}}
 
-Untuk pengaturan, saya memilih Server Farm dan instalasi lengkap untuk menyesuaikan SharePoint Box saya, karena saya tidak menginginkan instalasi terpisah untuk SharePoint.
+Untuk pengaturan, saya memilih Server Farm dan instalasi lengkap untuk mencocokkan SharePoint Box saya, karena saya tidak menginginkan instalasi mandiri untuk SharePoint.
 
 ## Konfigurasi SharePoint
 
 {{% alert color="primary" %}}
 
-**Dalam Wizard Konfigurasi SharePoint, kami ingin terhubung ke farm yang sudah ada.**
+**Dalam SharePoint Configuration Wizard, kami ingin terhubung ke farm yang ada.**
 
 ![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_1.png)
 
-**Image1:- Panduan konfigurasi SharePoint**
+**Gambar1:- wizard konfigurasi SharePoint**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**Kemudian kami akan mengarahkannya ke basis data SharePoint_Config yang digunakan oleh farm kami. Jika Anda tidak tahu di mana letaknya, Anda dapat menemukannya melalui Central Admin lewat System Settings -> Manager Servers di farm ini.**
+**Kami kemudian akan mengarahkannya ke basis data SharePoint_Config yang digunakan oleh farm kami. Jika Anda tidak tahu di mana letaknya, Anda dapat menemukannya melalui Central Admin melalui System Settings -> Manager Servers di farm ini.**
 
 ![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_2.png)
 
-**Image2:- Tentukan pengaturan konfigurasi basis data**
+**Gambar2:- Tentukan pengaturan konfigurasi basis data**
 
 ![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_3.png)
 
-**Image3:- Panduan konfigurasi SharePoint**
+**Gambar3:- wizard konfigurasi SharePoint**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**Setelah wizard selesai, itu saja yang perlu kita lakukan di Report Server Box untuk saat ini. Kembali ke URL ReportServer, kita akan melihat error lain, tetapi itu karena kita belum mengkonfigurasikannya melalui Central Administrator.**
+**Setelah wizard selesai, itu semua yang perlu kita lakukan pada kotak Report Server untuk saat ini. Kembali ke URL ReportServer, kita akan melihat kesalahan lain, tetapi itu karena kita belum mengkonfigurasinya melalui Central Administrator.**
 
 ![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_4.png)
 
 **Image4:- Kesalahan server laporan**
 {{% /alert %}}
-


### PR DESCRIPTION
## Summary
- rebuild id/reportingservices from en/reportingservices
- regenerate Markdown translations with the Hugo translation CLI
- preserve the locale asset set and backfill five CLI restoration failures from the existing Indonesian pages to keep the folder complete

## Validation
- matched English eportingservices file and Markdown counts
- checked that no @@DOC_TRANSLATE_ placeholders remain
