### PR TITLE
Translate reportingservices to Korean

### DIFF
--- a/ko/reportingservices/_index.md
+++ b/ko/reportingservices/_index.md
@@ -1,47 +1,47 @@
 ---
-title: 문서
-linktitle:  Aspose.PDF for Reporting Services
+title: 선적 서류 비치
+linktitle:  보고 서비스용 Aspose.PDF
 second_title: Aspose.PDF for Reporting Services
 type: docs
 weight: 120
-url: /ko/reportingservices/
-description: Aspose.PDF for Reporting Services를 발견하십시오. 고급 맞춤 기능을 사용하여 SQL Server Reporting Services(SSRS)에서 직접 PDF 보고서를 생성합니다.
+url: /reportingservices/
+description: 보고 서비스용 Aspose.PDF를 찾아보세요. 고급 사용자 지정을 통해 SSRS(SQL Server Reporting Services)에서 직접 PDF 보고서를 생성하세요.
 is_root: true
-lastmod: "2026-07-29"
+lastmod: "2024-05-05"
 ---
 
 {{% alert color="primary" %}}
 
-![Aspose.PDF for Reporting Services 로고](home_5.png)
+![보고 서비스 로고용 Aspose.PDF](home_5.png)
 
-## Aspose.PDF for Reporting Services에 오신 것을 환영합니다
+## 보고 서비스를 위한 Aspose.PDF에 오신 것을 환영합니다.
 
-Microsoft SQL Server Reporting Services는 많은 조직이 가지고 있는 요구 사항, 즉 비즈니스 인텔리전스 및 보고 솔루션을 구축해야 하는 필요성을 충족합니다. 지금까지 개발자는 보고서를 애플리케이션에 포함시켜야 했고, 조직은 비용이 많이 들고 때로는 문제가 있는 서드파티 보고 솔루션을 구매해야 했습니다. 이제 Microsoft SQL Server Reporting Services는 기업 전체에 보고서를 배포하기 위한 완전한 솔루션을 제공하여 비즈니스가 더 나은 결정을 더 빠르게 내릴 수 있도록 합니다.
+Microsoft SQL Server 보고 서비스는 많은 조직이 갖고 있는 비즈니스 인텔리전스 및 보고 솔루션 구축 요구 사항을 충족합니다. 지금까지 개발자는 애플리케이션에 보고서를 포함해야 했고, 조직은 비싸고 때로는 문제가 있는 타사 보고 솔루션을 구입해야 했습니다. 이제 Microsoft SQL Server 보고 서비스는 기업 전체에 보고서를 배포하기 위한 완벽한 솔루션을 제공합니다. 기업이 더 나은 의사결정을 더 빠르게 내릴 수 있도록 지원합니다.
 
 {{% /alert %}}
 
 ## 주제
 
-- [제품 개요](/pdf/ko/reportingservices/product-overview/)
+- [제품개요](/pdf/ko/reportingservices/product-overview/)
 - [지원되는 파일 형식](/pdf/ko/reportingservices/supported-file-formats/)
-- [기능](/pdf/ko/reportingservices/features/)
+- [특징](/pdf/ko/reportingservices/features/)
 - [샘플 보고서 갤러리](/pdf/ko/reportingservices/sample-reports-gallery/)
-- [Aspose.PDF for Reporting Services 설치](/pdf/ko/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [Aspose.PDF for Reporting Services 라이선스](/pdf/ko/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [Aspose.PDF for Reporting Services 구성](/pdf/ko/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [보고 서비스용 Aspose.PDF 설치](/pdf/ko/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [보고 서비스용 라이선스 Aspose.PDF](/pdf/ko/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [보고 서비스를 위한 Aspose.PDF 구성](/pdf/ko/reportingservices/configure-aspose-pdf-for-reporting-services/)
 - [보고서 항목 속성 확장](/pdf/ko/reportingservices/expand-report-items-properties/)
-- [Aspose.PDF for Reporting Services 평가](/pdf/ko/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
+- [보고 서비스를 위한 Aspose.PDF 평가](/pdf/ko/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
 
-## Aspose.PDF for Reporting Services 리소스
+## 보고 서비스 리소스를 위한 Aspose.PDF
 
-- [Aspose.PDF for Reporting Services 제품 개요](/pdf/ko/reportingservices/product-overview/)
-- [Aspose.PDF for Reporting Services 지원되는 파일 형식](/pdf/ko/reportingservices/supported-file-formats/)
-- [Aspose.PDF for Reporting Services 기능](/pdf/ko/reportingservices/features/)
-- [Aspose.PDF for Reporting Services 릴리스 노트](https://releases.aspose.com/pdf/reportingservices/release-notes/)
-- [Aspose.PDF for Reporting Services 다운로드](https://releases.aspose.com/pdf/reportingservices/)
-- [샘플 보고서 갤러리 Aspose.PDF for Reporting Services](/pdf/ko/reportingservices/sample-reports-gallery/)
-- [Aspose.PDF for Reporting Services 설치](/pdf/ko/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [Aspose.PDF for Reporting Services 라이선스](/pdf/ko/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [Aspose.PDF for Reporting Services 구성](/pdf/ko/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [보고 서비스 제품 개요를 위한 Aspose.PDF](/pdf/ko/reportingservices/product-overview/)
+- [Reporting Services 지원 파일 형식용 Aspose.PDF](/pdf/ko/reportingservices/supported-file-formats/)
+- [보고 서비스 기능을 위한 Aspose.PDF](/pdf/ko/reportingservices/features/)
+- [보고 서비스용 Aspose.PDF 릴리스 정보](https://releases.aspose.com/pdf/reportingservices/release-notes/)
+- [보고 서비스용 Aspose.PDF 다운로드](https://releases.aspose.com/pdf/reportingservices/)
+- [보고 서비스용 샘플 보고서 갤러리 Aspose.PDF](/pdf/ko/reportingservices/sample-reports-gallery/)
+- [보고 서비스용 Aspose.PDF 설치](/pdf/ko/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [보고 서비스용 라이선스 Aspose.PDF](/pdf/ko/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [보고 서비스를 위한 Aspose.PDF 구성](/pdf/ko/reportingservices/configure-aspose-pdf-for-reporting-services/)
 - [보고서 항목 속성 확장](/pdf/ko/reportingservices/expand-report-items-properties/)
-- [Aspose.PDF for Reporting Services 평가](/pdf/ko/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
+- [보고 서비스를 위한 Aspose.PDF 평가](/pdf/ko/reportingservices/evaluate-aspose-pdf-for-reporting-services/)

--- a/ko/reportingservices/_index.md
+++ b/ko/reportingservices/_index.md
@@ -5,18 +5,18 @@ second_title: Aspose.PDF for Reporting Services
 type: docs
 weight: 120
 url: /ko/reportingservices/
-description: Aspose.PDF for Reporting Services를 찾아보세요. 고급 맞춤화를 통해 SQL Server Reporting Services(SSRS)에서 직접 PDF 보고서를 생성합니다.
+description: Aspose.PDF for Reporting Services를 발견하십시오. 고급 맞춤 기능을 사용하여 SQL Server Reporting Services(SSRS)에서 직접 PDF 보고서를 생성합니다.
 is_root: true
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
 ![Aspose.PDF for Reporting Services 로고](home_5.png)
 
-## Aspose.PDF for Reporting Services에 오신 것을 환영합니다.
+## Aspose.PDF for Reporting Services에 오신 것을 환영합니다
 
-Microsoft SQL Server Reporting Services는 많은 조직이 가지고 있는 요구, 즉 비즈니스 인텔리전스와 보고 솔루션을 구축해야 한다는 요구를 충족합니다. 지금까지 개발자는 보고서를 애플리케이션에 삽입해야 했고, 조직은 비싸고 때로는 문제를 일으키는 타사 보고 솔루션을 구매해야 했습니다. 이제 Microsoft SQL Server Reporting Services는 기업 전체에 보고서를 배포하기 위한 완전한 솔루션을 제공하여 비즈니스가 더 좋고 빠르게 의사 결정을 내릴 수 있게 합니다.
+Microsoft SQL Server Reporting Services는 많은 조직이 가지고 있는 요구 사항, 즉 비즈니스 인텔리전스 및 보고 솔루션을 구축해야 하는 필요성을 충족합니다. 지금까지 개발자는 보고서를 애플리케이션에 포함시켜야 했고, 조직은 비용이 많이 들고 때로는 문제가 있는 서드파티 보고 솔루션을 구매해야 했습니다. 이제 Microsoft SQL Server Reporting Services는 기업 전체에 보고서를 배포하기 위한 완전한 솔루션을 제공하여 비즈니스가 더 나은 결정을 더 빠르게 내릴 수 있도록 합니다.
 
 {{% /alert %}}
 
@@ -26,11 +26,11 @@ Microsoft SQL Server Reporting Services는 많은 조직이 가지고 있는 요
 - [지원되는 파일 형식](/pdf/ko/reportingservices/supported-file-formats/)
 - [기능](/pdf/ko/reportingservices/features/)
 - [샘플 보고서 갤러리](/pdf/ko/reportingservices/sample-reports-gallery/)
-- [Reporting Services용 Aspose.Pdf 설치](/pdf/ko/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [Reporting Services용 Aspose.Pdf 라이선스](/pdf/ko/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [Reporting Services용 Aspose.Pdf 구성](/pdf/ko/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [Aspose.PDF for Reporting Services 설치](/pdf/ko/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [Aspose.PDF for Reporting Services 라이선스](/pdf/ko/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [Aspose.PDF for Reporting Services 구성](/pdf/ko/reportingservices/configure-aspose-pdf-for-reporting-services/)
 - [보고서 항목 속성 확장](/pdf/ko/reportingservices/expand-report-items-properties/)
-- [Reporting Services용 Aspose.Pdf 평가](/pdf/ko/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
+- [Aspose.PDF for Reporting Services 평가](/pdf/ko/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
 
 ## Aspose.PDF for Reporting Services 리소스
 
@@ -38,12 +38,10 @@ Microsoft SQL Server Reporting Services는 많은 조직이 가지고 있는 요
 - [Aspose.PDF for Reporting Services 지원되는 파일 형식](/pdf/ko/reportingservices/supported-file-formats/)
 - [Aspose.PDF for Reporting Services 기능](/pdf/ko/reportingservices/features/)
 - [Aspose.PDF for Reporting Services 릴리스 노트](https://releases.aspose.com/pdf/reportingservices/release-notes/)
-- [다운로드 Aspose.PDF for Reporting Services](https://releases.aspose.com/pdf/reportingservices/)
+- [Aspose.PDF for Reporting Services 다운로드](https://releases.aspose.com/pdf/reportingservices/)
 - [샘플 보고서 갤러리 Aspose.PDF for Reporting Services](/pdf/ko/reportingservices/sample-reports-gallery/)
-- [Reporting Services용 Aspose.Pdf 설치](/pdf/ko/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [Reporting Services용 Aspose.Pdf 라이선스](/pdf/ko/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [Reporting Services용 Aspose.Pdf 구성](/pdf/ko/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [Aspose.PDF for Reporting Services 설치](/pdf/ko/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [Aspose.PDF for Reporting Services 라이선스](/pdf/ko/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [Aspose.PDF for Reporting Services 구성](/pdf/ko/reportingservices/configure-aspose-pdf-for-reporting-services/)
 - [보고서 항목 속성 확장](/pdf/ko/reportingservices/expand-report-items-properties/)
-- [Reporting Services용 Aspose.Pdf 평가](/pdf/ko/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
-
-
+- [Aspose.PDF for Reporting Services 평가](/pdf/ko/reportingservices/evaluate-aspose-pdf-for-reporting-services/)

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
@@ -5,13 +5,11 @@ linktitle: 구성
 type: docs
 weight: 80
 url: /ko/reportingservices/configure-aspose-pdf-for-reporting-services/
-description: Aspose.PDF for Reporting Services를 구성하는 방법을 배우고 SSRS 보고서에 대한 PDF 출력 설정을 효율적으로 사용자 지정하는 방법을 알아보세요.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services를 구성하여 SSRS 보고서의 PDF 출력 설정을 효율적으로 사용자 지정하는 방법을 알아봅니다.
+lastmod: "2026-07-29"
 ---
 
-## 이 섹션에는 다음 항목이 포함됩니다:
+## 이 섹션에는 다음 주제가 포함됩니다:
 
 - [매개변수 설정](/pdf/ko/reportingservices/setting-parameters/)
 - [지원되는 매개변수](/pdf/ko/reportingservices/supported-parameters/)
-
-

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
@@ -4,12 +4,12 @@ linktitle: 구성
 
 type: docs
 weight: 80
-url: /ko/reportingservices/configure-aspose-pdf-for-reporting-services/
-description: Aspose.PDF for Reporting Services를 구성하여 SSRS 보고서의 PDF 출력 설정을 효율적으로 사용자 지정하는 방법을 알아봅니다.
-lastmod: "2026-07-29"
+url: /reportingservices/configure-aspose-pdf-for-reporting-services/
+description: SSRS 보고서에 대한 PDF 출력 설정을 효율적으로 사용자 지정하기 위해 Reporting Services용 Aspose.PDF를 구성하는 방법을 알아보세요.
+lastmod: "2021-06-05"
 ---
 
-## 이 섹션에는 다음 주제가 포함됩니다:
+## 이 섹션에는 다음 항목이 포함됩니다.
 
-- [매개변수 설정](/pdf/ko/reportingservices/setting-parameters/)
-- [지원되는 매개변수](/pdf/ko/reportingservices/supported-parameters/)
+- [파라미터 설정](/pdf/reportingservices/setting-parameters/)
+- [지원되는 매개변수](/pdf/reportingservices/supported-parameters/)

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
@@ -1,22 +1,22 @@
 ---
-title: 매개변수 설정
-linktitle: 매개변수 설정
+title: Setting Parameters
+linktitle: Setting Parameters
 type: docs
 weight: 10
-url: /ko/reportingservices/setting-parameters/
-description: Aspose.PDF for Reporting Services에서 PDF 렌더링에 대한 매개변수를 설정하는 방법을 확인하십시오. 출력에 대한 정확한 제어를 달성합니다.
-lastmod: "2026-06-19"
+url: /reportingservices/setting-parameters/
+description: Find out how to set parameters for PDF rendering in Aspose.PDF for Reporting Services. Achieve precise control over output.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF for Reporting Services가 문서를 생성하는 방식에 영향을 주는 특정 구성 매개변수를 지정할 수 있습니다. 이 섹션에서는 이 과정을 설명합니다.
+You can specify certain configuration parameters that affect how Aspose.PDF for Reporting Services generates documents. This section describes this process.
 
 {{% /alert %}}
 
-Aspose.Pdf for Reporting Services를 구성하려면 C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config 파일을 편집해야 합니다. 이 파일은 XML 파일이며 렌더러 구성은 내부에 ```<Extension>``` Aspose.PDF 렌더러에 해당하는 요소.
+To configure Aspose.PDF for Reporting Services, you need to edit the C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config file. This is an XML file and the renderer configuration is inside the ```<Extension>``` element corresponding to the Aspose.PDF renderer.
 
-**예시**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -35,16 +35,14 @@ For PageOrientation -->
 
 {{% alert color="primary" %}}
 
-특정 보고서 파일에 대한 매개변수를 설정하고 서버의 모든 보고서에 적용하고 싶지 않다면, 다음 단계와 같이 Report Builder에서 해당 보고서를 위한 보고서 매개변수를 추가할 수 있습니다(예: 앞에서 표시한 ‘IsLandscape’ 매개변수를 추가합니다):
+If you want to set parameters for specific report file but not for every report on the server, you can add a report parameter for the specific report in the Report Builder as the following steps (for example, we’ll add an 'IsLandscape' parameter shown earlier):
 
-1. Report Designer에서 보고서를 연 후, ‘Report Data’ 창의 ‘Parameters’ 폴더를 마우스 오른쪽 버튼으로 클릭하고 ‘Add Parameter…’를 선택합니다(또는 ‘New’ 목록을 내려 ‘Parameter…’를 선택할 수도 있습니다).
+1. Open the report in the Report Designer, right-click on the 'Parameters' folder in the 'Report Data' pane, and select 'Add Parameter…' (or, alternately, pull down the 'New' list and select 'Parameter…').
  
 ![todo:image_alt_text](setting-parameters_1.png)
 
-1. ‘Report Parameter Properties’ 대화 상자에서 ‘IsLandscape’라는 이름의 매개변수를 만들고, 데이터 유형을 Boolean으로 지정한 뒤 ‘Default Values’ 탭에 값 True를 추가합니다.
+1. In the 'Report Parameter Properties' dialog, create the parameter named 'IsLandscape', with the data type of Boolean, and add the value True in the 'Default Values' tab.
 
 ![todo:image_alt_text](setting-parameters_2.png)
 
 {{% /alert %}}
-
-

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
@@ -1,27 +1,26 @@
 ---
-title: Setting Parameters
-linktitle: Setting Parameters
+title: 매개변수 설정
+linktitle: 매개변수 설정
 type: docs
 weight: 10
-url: /ko/reportingservices/setting-parameters/
-description: Aspose.PDF for Reporting Services에서 PDF 렌더링 매개변수를 설정하여 출력 결과를 정밀하게 제어하는 방법을 알아보세요.
-lastmod: "2026-07-29"
+url: /reportingservices/setting-parameters/
+description: Reporting Services용 Aspose.PDF에서 PDF 렌더링을 위한 매개변수를 설정하는 방법을 알아보세요. 출력을 정밀하게 제어할 수 있습니다.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-You can specify certain configuration parameters that affect how Aspose.PDF for Reporting Services generates documents. This section describes this process.
+Reporting Services용 Aspose.PDF가 문서를 생성하는 방법에 영향을 미치는 특정 구성 매개 변수를 지정할 수 있습니다. 이 섹션에서는 이 프로세스에 대해 설명합니다.
 
 {{% /alert %}}
 
-Aspose.PDF for Reporting Services를 구성하려면 `C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config` 파일을 편집해야 합니다. 이 파일은 XML 파일이며, 렌더러 구성은 Aspose.PDF 렌더러에 해당하는 ```<Extension>``` 요소 안에 있습니다.
+Reporting Services에 대해 Aspose.Pdf를 구성하려면 `C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config` 파일을 편집해야 합니다. 이것은 XML 파일이며 렌더러 구성은 Aspose.PDF 렌더러에 해당하는 `<Extension>` 요소 내부에 있습니다.
 
-**Example**
+## 예
 
-{{< highlight csharp >}}
-
+```xml
 <Render>
-...
+…
 <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
 <!--Insert configuration elements for exporting to PDF here. The following is an example
 For PageOrientation -->
@@ -30,19 +29,18 @@ For PageOrientation -->
     </Configuration>
 </Extension>
 </Render>
-
-{{< /highlight >}}
+```
 
 {{% alert color="primary" %}}
 
-특정 보고서 파일에만 매개변수를 설정하고 서버의 모든 보고서에는 적용하지 않으려면, 다음 단계에 따라 Report Builder에서 해당 보고서에 보고서 매개변수를 추가할 수 있습니다. 여기서는 앞에서 보여 준 `IsLandscape` 매개변수를 추가하는 예를 사용합니다.
+서버의 모든 보고서가 아닌 특정 보고서 파일에 대한 매개변수를 설정하려는 경우 다음 단계에 따라 보고서 작성기에서 특정 보고서에 대한 보고서 매개변수를 추가할 수 있습니다(예를 들어 앞서 표시된 'IsLandscape' 매개변수를 추가합니다).
 
-1. Report Designer에서 보고서를 열고 `Report Data` 창의 `Parameters` 폴더를 마우스 오른쪽 버튼으로 클릭한 다음 `Add Parameter...`를 선택합니다. 또는 `New` 목록을 열고 `Parameter...`를 선택해도 됩니다.
- 
-![todo:image_alt_text](setting-parameters_1.png)
+1. 보고서 디자이너에서 보고서를 열고 '보고서 데이터' 창에서 '매개변수' 폴더를 마우스 오른쪽 버튼으로 클릭한 다음 '매개변수 추가…'를 선택합니다(또는 '새' 목록을 풀다운하고 '매개변수…' 선택).
 
-1. `Report Parameter Properties` 대화 상자에서 `IsLandscape`라는 이름의 매개변수를 만들고, 데이터 형식을 Boolean으로 설정한 뒤, `Default Values` 탭에 True 값을 추가합니다.
+![Parameters set up. Step 1](setting-parameters_1.png)
 
-![todo:image_alt_text](setting-parameters_2.png)
+1. '보고서 매개변수 속성' 대화 상자에서 데이터 유형이 부울인 'IsLandscape'라는 매개변수를 생성하고 '기본값' 탭에 True 값을 추가합니다.
+
+![Parameters set up. Step 2](setting-parameters_2.png)
 
 {{% /alert %}}

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
@@ -4,11 +4,11 @@ linktitle: 지원되는 매개변수
 type: docs
 weight: 20
 url: /ko/reportingservices/supported-parameters/
-description: Aspose.PDF for Reporting Services에서 지원되는 매개변수를 탐색하여 PDF 렌더링을 손쉽게 제어하고 맞춤화하십시오.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services에서 지원되는 매개변수를 살펴보고 손쉽게 PDF 렌더링을 제어하고 사용자 지정하세요.
+lastmod: "2026-07-29"
 ---
 
-매개변수화된 보고서는 보고서 처리에 사용되는 입력 값을 허용하는 보고서입니다. 매개변수화된 보고서를 사용하면 보고서 실행 시 설정되는 값에 따라 보고서의 출력을 다양하게 할 수 있습니다. Aspose.Pdf for Reporting Services는 두 종류의 매개변수를 지원합니다: 보고서 서버 매개변수와 보고서 매개변수. 보고서 서버 매개변수는 보고서 서버의 모든 보고서에 사용됩니다. 특정 보고서에 적합한 매개변수를 만들고 싶다면 보고서 매개변수를 사용해야 합니다.
+파라미터화된 보고서는 보고서 처리에 사용되는 입력 값을 허용하는 보고서입니다. 파라미터화된 보고서를 사용하면 보고서 실행 시 설정된 값에 따라 보고서 출력물을 다양하게 만들 수 있습니다. Aspose.PDF for Reporting Services는 두 종류의 매개변수를 지원합니다: 보고서 서버 매개변수와 보고서 매개변수. 보고서 서버 매개변수는 보고서 서버의 모든 보고서에 사용됩니다. 특정 보고서에 적합한 매개변수를 만들고 싶다면 보고서 매개변수를 사용해야 합니다.
 
 현재 Aspose.Pdf 렌더러는 다음과 같은 다양한 매개변수를 지원합니다:
 
@@ -22,8 +22,6 @@ lastmod: "2026-06-19"
 - [페이지 여백 크기](/pdf/ko/reportingservices/page-margin-size/)
 - [XMP 메타데이터](/pdf/ko/reportingservices/xmp-metadata/)
 - [디버그 정보](/pdf/ko/reportingservices/debug-information/)
-- [PDF_A 호환성](/pdf/ko/reportingservices/pdf_a-conformance/)
-
-
+- [PDF_A 적합성](/pdf/ko/reportingservices/pdf_a-conformance/)
 
 

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
@@ -3,25 +3,23 @@ title: 지원되는 매개변수
 linktitle: 지원되는 매개변수
 type: docs
 weight: 20
-url: /ko/reportingservices/supported-parameters/
-description: Aspose.PDF for Reporting Services에서 지원되는 매개변수를 살펴보고 손쉽게 PDF 렌더링을 제어하고 사용자 지정하세요.
-lastmod: "2026-07-29"
+url: /reportingservices/supported-parameters/
+description: Reporting Services용 Aspose.PDF에서 지원되는 매개변수를 탐색하여 PDF 렌더링을 쉽게 제어하고 사용자 정의하세요.
+lastmod: "2021-06-05"
 ---
 
-파라미터화된 보고서는 보고서 처리에 사용되는 입력 값을 허용하는 보고서입니다. 파라미터화된 보고서를 사용하면 보고서 실행 시 설정된 값에 따라 보고서 출력물을 다양하게 만들 수 있습니다. Aspose.PDF for Reporting Services는 두 종류의 매개변수를 지원합니다: 보고서 서버 매개변수와 보고서 매개변수. 보고서 서버 매개변수는 보고서 서버의 모든 보고서에 사용됩니다. 특정 보고서에 적합한 매개변수를 만들고 싶다면 보고서 매개변수를 사용해야 합니다.
+매개변수화된 보고서는 보고서 처리에 사용되는 입력 값을 받아들이는 보고서입니다. 매개 변수가 있는 보고서를 사용하면 보고서가 실행될 때 설정되는 값을 기반으로 보고서 출력을 다양화할 수 있습니다. Reporting Services용 Aspose.PDF는 보고서 서버 매개 변수와 보고서 매개 변수라는 두 가지 매개 변수를 지원합니다. 보고서 서버 매개 변수는 보고서 서버의 모든 보고서에 사용됩니다. 일부 매개변수를 특정 보고서에 적합하게 만들려면 보고서 매개변수를 사용해야 합니다.
 
-현재 Aspose.Pdf 렌더러는 다음과 같은 다양한 매개변수를 지원합니다:
+현재 Aspose.Pdf 렌더러는 다음과 같은 광범위한 매개변수를 지원합니다.
 
-**이 섹션에는 다음 주제가 포함됩니다:**
+**이 섹션에는 다음 주제가 포함됩니다.**
 
-- [페이지 방향](/pdf/ko/reportingservices/page-orientation/)
-- [HTML 서식](/pdf/ko/reportingservices/html-formatting/)
-- [보안 설정](/pdf/ko/reportingservices/security-setting/)
-- [폰트 포함 여부](/pdf/ko/reportingservices/isfontembedded/)
-- [페이지 크기](/pdf/ko/reportingservices/pagesize/)
-- [페이지 여백 크기](/pdf/ko/reportingservices/page-margin-size/)
-- [XMP 메타데이터](/pdf/ko/reportingservices/xmp-metadata/)
-- [디버그 정보](/pdf/ko/reportingservices/debug-information/)
-- [PDF_A 적합성](/pdf/ko/reportingservices/pdf_a-conformance/)
-
-
+- [페이지 방향](/pdf/reportingservices/page-orientation/)
+- [HTML 형식](/pdf/reportingservices/html-formatting/)
+- [보안설정](/pdf/reportingservices/security-setting/)
+- [IsFontEmbedded](/pdf/reportingservices/isfontembedded/)
+- [페이지 크기](/pdf/reportingservices/pagesize/)
+- [페이지 여백 크기](/pdf/reportingservices/page-margin-size/)
+- [XMP 메타데이터](/pdf/reportingservices/xmp-metadata/)
+- [디버그 정보](/pdf/reportingservices/debug-information/)
+- [PDF_A 규격](/pdf/reportingservices/pdf_a-conformance/)

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
@@ -4,19 +4,19 @@ linktitle: 디버그 정보
 type: docs
 weight: 90
 url: /ko/reportingservices/debug-information/
-description: Aspose.PDF for Reporting Services에서 PDF 렌더링에 대한 디버그 정보를 액세스하고 분석하여 문제를 효과적으로 해결합니다.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services에서 PDF 렌더링에 대한 디버그 정보를 액세스하고 분석하여 문제를 효과적으로 해결하십시오.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-렌더링이나 렌더링 결과에 문제가 발생하는 것은 피할 수 없습니다. 비밀 유지나 개인 정보 보호와 같은 이유로 사용자의 보고서에서 사용된 데이터 소스를 얻을 수 없어서 보고서 오류를 재현할 수 없었습니다. 고객과 개발자 간의 의사소통을 보다 쉽고 원활하게 하기 위해 이 매개변수를 추가했습니다. Aspose.PDF for Reporting Services로 보고서를 렌더링할 때 문제가 발생하면 이 보고서 매개변수를 설정하십시오. 그러면 XML 형식의 렌더링된 문서를 얻을 수 있습니다. 이후 해당 XML 파일을 제품 포럼에 게시해 주세요.
+렌더링이나 렌더링 결과에 문제가 있는 것은 불가피합니다. 기밀성이나 프라이버시와 같은 이유로 사용자의 보고서에 사용된 데이터 소스를 얻을 수 없어서 보고서에서 오류를 재현할 수 없었습니다. 고객과 개발자 간의 커뮤니케이션을 더 쉽고 원활하게 만들기 위해 이 매개변수를 추가했습니다. Aspose.PDF for Reporting Services로 보고서를 렌더링할 때 문제가 발생하면 이 보고서 매개변수를 설정하십시오. 그러면 XML 형식의 렌더링된 문서를 받을 수 있습니다. 그 후, 제품 포럼에 XML 파일을 게시해 주세요.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 **매개변수 이름**: SavingXmlFormat  
-**날짜 유형**: Boolean  
+**데이터 형식**: Boolean  
 **지원되는 값**: True, False (default)  
 
 **예시**
@@ -26,7 +26,7 @@ lastmod: "2026-06-19"
 ...
 <Extension Name="APPDF" Type=" Aspose.PDF.ReportingServices.Renderer,Aspose.PDF.ReportingServices">
 <Configuration>
-<SavingXmlFormat > True </SavingXmlFormat>
+<SavingXmlFormat > 참 </SavingXmlFormat>
 </Configuration>
 </Extension>
 </Render>
@@ -34,5 +34,3 @@ lastmod: "2026-06-19"
 {{< /highlight >}}
 
 {{% /alert %}}
-
-

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
@@ -3,34 +3,36 @@ title: 디버그 정보
 linktitle: 디버그 정보
 type: docs
 weight: 90
-url: /ko/reportingservices/debug-information/
-description: Aspose.PDF for Reporting Services에서 PDF 렌더링에 대한 디버그 정보를 액세스하고 분석하여 문제를 효과적으로 해결하십시오.
-lastmod: "2026-07-29"
+url: /reportingservices/debug-information/
+description: Reporting Services용 Aspose.PDF에서 PDF 렌더링에 대한 디버그 정보에 액세스하고 분석하여 문제를 효과적으로 해결합니다.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-렌더링이나 렌더링 결과에 문제가 있는 것은 불가피합니다. 기밀성이나 프라이버시와 같은 이유로 사용자의 보고서에 사용된 데이터 소스를 얻을 수 없어서 보고서에서 오류를 재현할 수 없었습니다. 고객과 개발자 간의 커뮤니케이션을 더 쉽고 원활하게 만들기 위해 이 매개변수를 추가했습니다. Aspose.PDF for Reporting Services로 보고서를 렌더링할 때 문제가 발생하면 이 보고서 매개변수를 설정하십시오. 그러면 XML 형식의 렌더링된 문서를 받을 수 있습니다. 그 후, 제품 포럼에 XML 파일을 게시해 주세요.
+렌더링이나 렌더링 결과에 문제가 있는 것은 불가피합니다. 보안이나 개인 정보 보호 등의 이유로 인해 사용자의 보고서에 사용된 데이터 소스를 얻을 수 없어 보고서에서 오류를 재현할 수 없었습니다. 고객과 개발자 간의 커뮤니케이션을 보다 쉽고 원활하게 하기 위해 이 매개변수를 추가합니다. Reporting Services용 Aspose.PDF를 사용하여 보고서를 렌더링할 때 문제가 발생하는 경우 이 보고서 매개 변수를 설정하면 XML 형식으로 렌더링된 문서를 받게 됩니다. 그런 다음 제품 포럼에 XML 파일을 게시해 주세요.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**매개변수 이름**: SavingXmlFormat  
-**데이터 형식**: Boolean  
-**지원되는 값**: True, False (default)  
 
-**예시**
-{{< highlight csharp >}}
+```txt
+Parameter Name: SavingXmlFormat
+Date Type: Boolean  
+Values supported**: True, False (default)
+```
 
+## 예
+
+```xml
 <Render>
 ...
 <Extension Name="APPDF" Type=" Aspose.PDF.ReportingServices.Renderer,Aspose.PDF.ReportingServices">
 <Configuration>
-<SavingXmlFormat > 참 </SavingXmlFormat>
+<SavingXmlFormat > True </SavingXmlFormat>
 </Configuration>
 </Extension>
 </Render>
-
-{{< /highlight >}}
+```
 
 {{% /alert %}}

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
@@ -1,39 +1,40 @@
 ---
-title: HTML Formatting
-linktitle: HTML Formatting
+title: HTML 형식화
+linktitle: HTML 형식화
 type: docs
 weight: 20
 url: /reportingservices/html-formatting/
-description: Enable HTML formatting in PDF reports using Aspose.PDF for Reporting Services. Add styles and structure with ease.
+description: Reporting Services용 Aspose.PDF를 사용하여 PDF 보고서에서 HTML 형식을 활성화합니다. 스타일과 구조를 쉽게 추가하세요.
 lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Sometimes you might wish to export text in textboxes with formatting. Unfortunately, Reporting Services does not support this. However, you still can implement it using Aspose.PDF for Reporting Services. Just enable a special mode in which all text in textboxes is treated as HTML and put the necessary HTML tags to format the text in the output document. For example, to have normal, bold and italic text in the same textbox, enter the following textbox value:
+때로는 서식을 적용하여 텍스트 상자의 텍스트를 내보내고 싶을 수도 있습니다. 안타깝게도 Reporting Services는 이를 지원하지 않습니다. 그러나 Reporting Services용 Aspose.PDF를 사용하여 구현할 수 있습니다. 텍스트 상자의 모든 텍스트가 HTML로 처리되는 특수 모드를 활성화하고 필요한 HTML 태그를 넣어 출력 문서의 텍스트 형식을 지정하기만 하면 됩니다. 예를 들어, 동일한 텍스트 상자에 일반, 굵게 및 기울임꼴 텍스트를 포함하려면 다음 텍스트 상자 값을 입력하십시오.
 
-Some of this text is ```<b>bold</b>``` and other text is ```<i>italic</i>```.
+이 텍스트 중 일부는 `<b>bold</b>`이고 다른 텍스트는 `<i>italic</i>`입니다.
 
-When exported, the text will look like as some of this text is **bold** and other text is *italic*.
+내보내면 텍스트 중 일부는 **굵게**, 다른 텍스트는 *기울임꼴*로 표시됩니다.
 
-Please note that this approach has some limitations
+이 접근 방식에는 몇 가지 제한 사항이 있습니다.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-- The formatting isn’t visible in design time (in the Report Builder, Reporting Services web portal etc.). Instead, you will see the HTML text in form of plain text with tags.
-- Aspose.PDF for Reporting Services rendering extension recognizes and properly formats HTML code in textboxes. The default PDF renderer of Reporting Services will export this markup as plain text.
+- 서식은 디자인 타임(보고서 작성기, 보고 서비스 웹 포털 등)에 표시되지 않습니다. 대신 태그가 포함된 일반 텍스트 형식의 HTML 텍스트가 표시됩니다.
+- Reporting Services 렌더링 확장 프로그램용 Aspose.PDF는 텍스트 상자의 HTML 코드를 인식하고 적절한 형식을 지정합니다. Reporting Services의 기본 PDF 렌더러는 이 마크업을 일반 텍스트로 내보냅니다.
 
-**Parameter Name**: IsHtmlTagSupported  
-**Date Type**: Boolean  
-**Values supported**: True, False (default)   
+```text
+Parameter Name: IsHtmlTagSupported  
+Date Type: Boolean  
+Values supported: True, False (default)   
+```
 
-**Example**
+## 예
 
-{{< highlight csharp >}}
-
- <Render>
+```xml
+<Render>
 ...
     <Extension Name="APPDF" Type=" Aspose.PDF.ReportingServices.Renderer,Aspose.PDF.ReportingServices ">
     <Configuration>
@@ -41,12 +42,10 @@ Please note that this approach has some limitations
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
+보고서 디자이너에 이 매개 변수를 추가하려면 `Boolean` 데이터 유형을 사용하세요.
 
-If you want to add this parameter in the Report Designer, use the 'Boolean' data type.
-
- 
-Currently Aspose.PDF for Reporting Services supports a subset of all the HTML tags. You may find more information in the Aspose.PDF [Documentation](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
+현재 Reporting Services용 Aspose.Pdf는 모든 HTML 태그의 하위 집합을 지원합니다. Aspose.PDF [문서](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom)에서 자세한 내용을 확인할 수 있습니다.
 
 {{% /alert %}}

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
@@ -1,35 +1,35 @@
 ---
-title: HTML 서식
-linktitle: HTML 서식
+title: HTML Formatting
+linktitle: HTML Formatting
 type: docs
 weight: 20
-url: /ko/reportingservices/html-formatting/
-description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에서 HTML 서식을 활성화합니다. 스타일과 구조를 손쉽게 추가합니다.
-lastmod: "2026-06-19"
+url: /reportingservices/html-formatting/
+description: Enable HTML formatting in PDF reports using Aspose.PDF for Reporting Services. Add styles and structure with ease.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-때때로 텍스트 상자에서 서식이 적용된 텍스트를 내보내고 싶을 수 있습니다. 불행히도 Reporting Services는 이를 지원하지 않습니다. 그러나 여전히 Aspose.PDF for Reporting Services를 사용하여 구현할 수 있습니다. 텍스트 상자 내 모든 텍스트를 HTML로 처리하고 필요한 HTML 태그를 넣어 출력 문서에서 텍스트를 서식 지정하는 특수 모드를 활성화하기만 하면 됩니다. 예를 들어, 동일한 텍스트 상자에 일반, 굵게 및 기울임 텍스트를 표시하려면 다음 텍스트 상자 값을 입력하세요:
+Sometimes you might wish to export text in textboxes with formatting. Unfortunately, Reporting Services does not support this. However, you still can implement it using Aspose.PDF for Reporting Services. Just enable a special mode in which all text in textboxes is treated as HTML and put the necessary HTML tags to format the text in the output document. For example, to have normal, bold and italic text in the same textbox, enter the following textbox value:
 
-이 텍스트 중 일부는 ```<b>bold</b>``` 그리고 다른 텍스트는 ```<i>italic</i>```.
+Some of this text is ```<b>bold</b>``` and other text is ```<i>italic</i>```.
 
-내보낸 후에는 이 텍스트 중 일부는 **bold**, 다른 텍스트는 *italic*처럼 보입니다.
+When exported, the text will look like as some of this text is **bold** and other text is *italic*.
 
-이 접근 방식에는 몇 가지 제한 사항이 있음을 참고하십시오.
+Please note that this approach has some limitations
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-- 디자인 시간(Report Builder, Reporting Services 웹 포털 등)에서는 서식이 표시되지 않습니다. 대신 HTML 텍스트가 태그가 포함된 일반 텍스트 형태로 보입니다.
-- Aspose.PDF for Reporting Services 렌더링 확장 기능은 텍스트 상자에서 HTML 코드를 인식하고 올바르게 서식 지정합니다. Reporting Services의 기본 PDF 렌더러는 이 마크업을 일반 텍스트로 내보냅니다.
+- The formatting isn’t visible in design time (in the Report Builder, Reporting Services web portal etc.). Instead, you will see the HTML text in form of plain text with tags.
+- Aspose.PDF for Reporting Services rendering extension recognizes and properly formats HTML code in textboxes. The default PDF renderer of Reporting Services will export this markup as plain text.
 
-**매개변수 이름**: IsHtmlTagSupported  
-**날짜 유형**: Boolean  
-**지원되는 값**: True, False (default)   
+**Parameter Name**: IsHtmlTagSupported  
+**Date Type**: Boolean  
+**Values supported**: True, False (default)   
 
-**예제**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -44,11 +44,9 @@ lastmod: "2026-06-19"
 
 {{< /highlight >}}
 
-Report Designer에 이 매개변수를 추가하려면 'Boolean' 데이터 유형을 사용하십시오.
+If you want to add this parameter in the Report Designer, use the 'Boolean' data type.
 
  
-현재 Aspose.Pdf for Reporting Services는 모든 HTML 태그 중 일부만 지원합니다. 자세한 정보는 Aspose.PDF에서 찾을 수 있습니다. [문서](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
+Currently Aspose.PDF for Reporting Services supports a subset of all the HTML tags. You may find more information in the Aspose.PDF [Documentation](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
 
 {{% /alert %}}
-
-

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
@@ -4,18 +4,18 @@ linktitle: IsFontEmbedded
 type: docs
 weight: 50
 url: /ko/reportingservices/isfontembedded/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-RS 디자이너는 텍스트에 대한 임베디드 폰트를 지원하지 않습니다; Aspose.PDF for Reporting Services를 사용하면 PDF 문서에 폰트 정보를 쉽게 삽입할 수 있습니다.
+RS 디자이너는 텍스트에 대한 내장 폰트를 지원하지 않습니다; Aspose.PDF for Reporting Services를 사용하면 PDF 문서에 폰트 정보를 쉽게 삽입할 수 있습니다.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 **매개변수 이름**: IsFontEmbedded  
-**데이터 유형**: Boolean  
+**날짜 유형**: Boolean  
 **지원되는 값**: True, False (default)  
 
 **예시**
@@ -25,7 +25,7 @@ RS 디자이너는 텍스트에 대한 임베디드 폰트를 지원하지 않�
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsFontEmbedded>True</IsFontEmbedded>
+    <IsFontEmbedded>참</IsFontEmbedded>
     </Configuration>
     </Extension>
 </Render>
@@ -33,5 +33,3 @@ RS 디자이너는 텍스트에 대한 임베디드 폰트를 지원하지 않�
 {{< /highlight >}}
 
 {{% /alert %}}
-
-

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
@@ -1,35 +1,33 @@
 ---
-title: IsFontEmbedded
-linktitle: IsFontEmbedded
+title: IsFont임베디드
+linktitle: IsFont임베디드
 type: docs
 weight: 50
-url: /ko/reportingservices/isfontembedded/
-lastmod: "2026-07-29"
+url: /reportingservices/isfontembedded/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-RS 디자이너는 텍스트에 대한 내장 폰트를 지원하지 않습니다; Aspose.PDF for Reporting Services를 사용하면 PDF 문서에 폰트 정보를 쉽게 삽입할 수 있습니다.
+RS 디자이너는 텍스트에 포함된 글꼴을 지원하지 않습니다. Reporting Services용 Aspose.PDF를 사용하면 PDF 문서에 글꼴 정보를 쉽게 포함할 수 있습니다.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**매개변수 이름**: IsFontEmbedded  
-**날짜 유형**: Boolean  
-**지원되는 값**: True, False (default)  
+```txt
+Parameter Name: IsFontEmbedded  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**예시**
-{{< highlight csharp >}}
+## 예
 
+```xml
 <Render>
-…
+...
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsFontEmbedded>참</IsFontEmbedded>
+    <IsFontEmbedded>True</IsFontEmbedded>
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
@@ -3,42 +3,44 @@ title: 페이지 여백 크기
 linktitle: 페이지 여백 크기
 type: docs
 weight: 70
-url: /ko/reportingservices/page-margin-size/
-description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서의 페이지 여백 크기를 조정하여 가독성과 레이아웃을 개선합니다.
-lastmod: "2026-07-29"
+url: /reportingservices/page-margin-size/
+description: 향상된 가독성과 레이아웃을 위해 Reporting Services용 Aspose.PDF를 사용하여 PDF 보고서의 페이지 여백 크기를 조정하세요.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Reporting Services 보고서 디자이너는 페이지 여백 크기 설정을 지원하지 않습니다. Aspose.PDF for Reporting Services는 해당 페이지 여백 크기를 설정하기 위한 네 가지 매개변수를 제공하며, 이는 다음과 같습니다:
+Reporting Services 보고서 디자이너는 페이지 여백 크기 설정을 지원하지 않습니다. Reporting Services용 Aspose.PDF는 해당 페이지 여백 크기를 설정하는 네 가지 매개 변수를 제공합니다.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-1)  
-**매개변수 이름**: PageMarginLeft  
-**날짜 형식**: Float  
-**지원되는 값**:  Any positive number or zero
+```text
+Parameter Name: PageMarginLeft  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-2)  
-**매개변수 이름**: PageMarginRight  
-**날짜 형식**: Float  
-**지원되는 값**:  Any positive number or zero
+```text
+Parameter Name: PageMarginRight  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-3)  
-**매개변수 이름**: PageMarginTop  
-**날짜 형식**: Float  
-**지원되는 값**:  Any positive number or zero
+```text
+Parameter Name: PageMarginTop  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-4)  
-**매개변수 이름**: PageMarginBottom  
-**날짜 형식**: Float  
-**지원되는 값**:  Any positive number or zero
+```text
+Parameter Name: PageMarginBottom  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-**예제**
+## 예
 
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type=" Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices ">
@@ -50,7 +52,4 @@ Reporting Services 보고서 디자이너는 페이지 여백 크기 설정을 �
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
@@ -4,38 +4,38 @@ linktitle: 페이지 여백 크기
 type: docs
 weight: 70
 url: /ko/reportingservices/page-margin-size/
-description: PDF 보고서에서 Aspose.PDF for Reporting Services를 사용하여 페이지 여백 크기를 조정하면 가독성과 레이아웃이 개선됩니다.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서의 페이지 여백 크기를 조정하여 가독성과 레이아웃을 개선합니다.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Reporting Services 보고서 디자이너는 페이지 여백 크기 설정을 지원하지 않습니다. Aspose.PDF for Reporting Services는 해당 페이지 여백 크기를 설정하기 위한 네 가지 매개변수를 제공하며, 그들은 다음과 같습니다:
+Reporting Services 보고서 디자이너는 페이지 여백 크기 설정을 지원하지 않습니다. Aspose.PDF for Reporting Services는 해당 페이지 여백 크기를 설정하기 위한 네 가지 매개변수를 제공하며, 이는 다음과 같습니다:
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 1)  
 **매개변수 이름**: PageMarginLeft  
-**날짜 유형**: Float  
-**지원되는 값**:  양수 또는 0
+**날짜 형식**: Float  
+**지원되는 값**:  Any positive number or zero
 
 2)  
 **매개변수 이름**: PageMarginRight  
-**날짜 유형**: Float  
-**지원되는 값**:  양수 또는 0
+**날짜 형식**: Float  
+**지원되는 값**:  Any positive number or zero
 
 3)  
 **매개변수 이름**: PageMarginTop  
-**날짜 유형**: Float  
-**지원되는 값**:  양수 또는 0
+**날짜 형식**: Float  
+**지원되는 값**:  Any positive number or zero
 
 4)  
 **매개변수 이름**: PageMarginBottom  
-**날짜 유형**: Float  
-**지원되는 값**:  양수 또는 0
+**날짜 형식**: Float  
+**지원되는 값**:  Any positive number or zero
 
-**예시**
+**예제**
 
 {{< highlight csharp >}}
 
@@ -54,5 +54,3 @@ Reporting Services 보고서 디자이너는 페이지 여백 크기 설정을 �
 {{< /highlight >}}
 
 {{% /alert %}}
-
-

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
@@ -4,13 +4,13 @@ linktitle: 페이지 방향
 type: docs
 weight: 10
 url: /ko/reportingservices/page-orientation/
-description: Aspose.PDF for Reporting Services의 PDF 보고서에 대한 페이지 방향을 구성합니다. 더욱 나은 표시를 위해 레이아웃을 사용자 지정합니다.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services에서 PDF 보고서의 페이지 방향을 구성합니다. 더 나은 표시를 위해 레이아웃을 사용자 지정합니다.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Report Definition Language는 보고서에서 페이지 방향을 명시적으로 지정하는 것을 허용하지 않습니다. Aspose.Pdf for Reporting Services를 사용하면 내보내기 프로그램에 가로 페이지 방향의 PDF 문서를 생성하도록 쉽게 지시할 수 있습니다. 기본 방향은 세로입니다.
+Report Definition Language는 보고서에서 페이지 방향을 명시적으로 지정하는 것을 허용하지 않습니다. Aspose.PDF for Reporting Services를 사용하면 내보내기 도구에 가로 페이지 방향으로 PDF 문서를 생성하도록 쉽게 지시할 수 있습니다. 기본 방향은 세로입니다.
 
 {{% /alert %}}
 
@@ -18,7 +18,7 @@ Report Definition Language는 보고서에서 페이지 방향을 명시적으�
 
 기본 방향은 세로입니다.
 **매개변수 이름**: IsLandscape
-**데이터 유형**: Boolean
+**날짜 유형**: Boolean
 **지원되는 값**: True, False (default)
 
 **예시**
@@ -27,7 +27,7 @@ Report Definition Language는 보고서에서 페이지 방향을 명시적으�
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsLandscape>True</IsLandscape>
+    <IsLandscape>참</IsLandscape>
     </Configuration>
     </Extension>
 </Render>
@@ -35,5 +35,3 @@ Report Definition Language는 보고서에서 페이지 방향을 명시적으�
 {{< /highlight >}}
 
 {{% /alert %}}
-
-

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
@@ -3,35 +3,34 @@ title: 페이지 방향
 linktitle: 페이지 방향
 type: docs
 weight: 10
-url: /ko/reportingservices/page-orientation/
-description: Aspose.PDF for Reporting Services에서 PDF 보고서의 페이지 방향을 구성합니다. 더 나은 표시를 위해 레이아웃을 사용자 지정합니다.
-lastmod: "2026-07-29"
+url: /reportingservices/page-orientation/
+description: Reporting Services용 Aspose.PDF에서 PDF 보고서의 페이지 방향을 구성합니다. 더 나은 프레젠테이션을 위해 레이아웃을 사용자 정의하세요.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Definition Language는 보고서에서 페이지 방향을 명시적으로 지정하는 것을 허용하지 않습니다. Aspose.PDF for Reporting Services를 사용하면 내보내기 도구에 가로 페이지 방향으로 PDF 문서를 생성하도록 쉽게 지시할 수 있습니다. 기본 방향은 세로입니다.
+보고서 정의 언어에서는 보고서의 페이지 방향을 명시적으로 지정할 수 없습니다. Reporting Services용 Aspose.PDF를 사용하면 수출자에게 가로 페이지 방향의 PDF 문서를 생성하도록 쉽게 지시할 수 있습니다. 기본 방향은 세로입니다.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+The default orientation is portrait.
+Parameter Name: IsLandscape
+Date Type: Boolean
+Values supported: True, False (default)
+```
 
-기본 방향은 세로입니다.
-**매개변수 이름**: IsLandscape
-**날짜 유형**: Boolean
-**지원되는 값**: True, False (default)
+## 예
 
-**예시**
-{{< highlight csharp >}}
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
-    <IsLandscape>참</IsLandscape>
+    <IsLandscape>True</IsLandscape>
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
-
-{{% /alert %}}

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
@@ -4,20 +4,20 @@ linktitle: 페이지 크기
 type: docs
 weight: 60
 url: /ko/reportingservices/pagesize/
-description: Aspose.PDF for Reporting Services의 PDF 보고서에 대해 특정 문서 요구사항을 충족하도록 페이지 크기를 사용자 지정합니다.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services에서 PDF 보고서의 페이지 크기를 사용자 지정하여 특정 문서 요구 사항을 충족합니다.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Reporting Services 보고서 디자이너는 A4, B5, Letter 등과 같은 일반적인 페이지 크기를 지원하지 않습니다. Aspose.Pdf for Reporting Services를 사용하면 다음 예시와 같이 사용할 수 있습니다.
+Reporting Services 보고서 디자이너는 A4, B5, Letter 등 일반적인 페이지 크기를 지원하지 않습니다. Aspose.PDF for Reporting Services를 사용하면 다음 예시와 같이 사용할 수 있습니다.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
 **매개변수 이름**: PageSize  
-**날짜 유형**: String  
+**날짜 형식**: 문자열  
 **지원되는 값**: A0, A1, A2, A3, A4, A5, A6, B5, Letter, Legal, Ledger, P11x17  
 
 **예시**
@@ -36,5 +36,3 @@ Reporting Services 보고서 디자이너는 A4, B5, Letter 등과 같은 일반
 {{< /highlight >}}
 
 {{% /alert %}}
-
-

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
@@ -3,27 +3,26 @@ title: 페이지 크기
 linktitle: 페이지 크기
 type: docs
 weight: 60
-url: /ko/reportingservices/pagesize/
-description: Aspose.PDF for Reporting Services에서 PDF 보고서의 페이지 크기를 사용자 지정하여 특정 문서 요구 사항을 충족합니다.
-lastmod: "2026-07-29"
+url: /reportingservices/pagesize/
+description: 특정 문서 요구 사항을 충족하려면 Reporting Services용 Aspose.PDF에서 PDF 보고서의 페이지 크기를 사용자 지정하세요.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Reporting Services 보고서 디자이너는 A4, B5, Letter 등 일반적인 페이지 크기를 지원하지 않습니다. Aspose.PDF for Reporting Services를 사용하면 다음 예시와 같이 사용할 수 있습니다.
+Reporting Services 보고서 디자이너는 A4, B5, Letter 등과 같은 일반적인 페이지 크기를 지원하지 않습니다. Reporting Services용 Aspose.PDF를 사용하면 다음 예와 같이 얻을 수 있습니다.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+Parameter Name: PageSize  
+Date Type: String  
+Values supported: A0, A1, A2, A3, A4, A5, A6, B5, Letter, Legal, Ledger, P11x17  
+```
 
-**매개변수 이름**: PageSize  
-**날짜 형식**: 문자열  
-**지원되는 값**: A0, A1, A2, A3, A4, A5, A6, B5, Letter, Legal, Ledger, P11x17  
+## 예
 
-**예시**
-
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
@@ -32,7 +31,4 @@ Reporting Services 보고서 디자이너는 A4, B5, Letter 등 일반적인 페
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
@@ -3,29 +3,28 @@ title: PDF_A 적합성
 linktitle: PDF_A 적합성
 type: docs
 weight: 100
-url: /ko/reportingservices/pdf_a-conformance/
-description: Aspose.PDF for Reporting Services에서 PDF/A 적합성을 활성화합니다. 아카이브 요구 사항을 충족하는 문서를 손쉽게 생성합니다.
-lastmod: "2026-07-29"
+url: /reportingservices/pdf_a-conformance/
+description: Reporting Services에 대해 Aspose.PDF에서 PDF/A 규격을 활성화합니다. 보관 규정을 준수하는 문서를 손쉽게 생성하세요.
+lastmod: "2025-05-22"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF 문서에서 PDF/A(아카이브 가능한 PDF) 적합성에 대한 소개를 확인할 수 있습니다.
+Aspose.PDF 문서에서 PDF/A(보관 가능 PDF) 적합성에 대한 소개를 얻을 수 있습니다.
 
-PDF/A 문서를 만들고 싶다면, 다음 보고서 매개변수를 추가하십시오.
+PDF/A 문서를 생성하려면 다음 보고서 매개변수를 추가하세요.
 
 {{% /alert %}}
 
+```text
+Parameter Name: PdfConformance  
+Date Type: String  
+Values supported: PdfA1A, PdfA1B, PdfA2A, PdfA2B, PdfA2U, PdfA3A, PdfA3B, PdfA3U, PdfA4, PdfA4E, PdfA4F  
+```
 
-{{% alert color="primary" %}}
+## 예
 
-**매개변수 이름**: PdfConformance  
-**데이터 유형**: 문자열  
-**지원되는 값**: PdfA1A, PdfA1B, PdfA2A, PdfA2B, PdfA2U, PdfA3A, PdfA3B, PdfA3U, PdfA4, PdfA4E, PdfA4F  
-
-**예시**
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
@@ -34,6 +33,4 @@ PDF/A 문서를 만들고 싶다면, 다음 보고서 매개변수를 추가하�
     </Configuration>
     </Extension>
 </Render>
-{{< /highlight >}}
-
-{{% /alert %}}
+```

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
@@ -4,15 +4,15 @@ linktitle: PDF_A 적합성
 type: docs
 weight: 100
 url: /ko/reportingservices/pdf_a-conformance/
-description: Aspose.PDF for Reporting Services에서 PDF/A 적합성을 활성화합니다. 손쉽게 보관용 문서를 만들 수 있습니다.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services에서 PDF/A 적합성을 활성화합니다. 아카이브 요구 사항을 충족하는 문서를 손쉽게 생성합니다.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF 문서에서 PDF/A(보관용 PDF) 적합성에 대한 소개를 확인할 수 있습니다.
+Aspose.PDF 문서에서 PDF/A(아카이브 가능한 PDF) 적합성에 대한 소개를 확인할 수 있습니다.
 
-PDF/A 문서를 만들려면 다음 보고서 매개변수를 추가하십시오.
+PDF/A 문서를 만들고 싶다면, 다음 보고서 매개변수를 추가하십시오.
 
 {{% /alert %}}
 
@@ -20,10 +20,10 @@ PDF/A 문서를 만들려면 다음 보고서 매개변수를 추가하십시오
 {{% alert color="primary" %}}
 
 **매개변수 이름**: PdfConformance  
-**날짜 유형**: String  
+**데이터 유형**: 문자열  
 **지원되는 값**: PdfA1A, PdfA1B, PdfA2A, PdfA2B, PdfA2U, PdfA3A, PdfA3B, PdfA3U, PdfA4, PdfA4E, PdfA4F  
 
-**예제**
+**예시**
 {{< highlight csharp >}}
 
 <Render>
@@ -37,5 +37,3 @@ PDF/A 문서를 만들려면 다음 보고서 매개변수를 추가하십시오
 {{< /highlight >}}
 
 {{% /alert %}}
-
-

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
@@ -4,30 +4,30 @@ linktitle: 보안 설정
 type: docs
 weight: 30
 url: /ko/reportingservices/security-setting/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-보안은 네트워크 보호이든 PDF 문서이든 모든 분야에서 항상 가장 중요한 문제였습니다. 문서는 다양한 이유로 안전하게 보호됩니다: 문서 작성자는 문서의 내용을 안전하게 유지하고 싶으며, 다른 사람이 변경하지 못하도록 하기를 원합니다 등.
+보안은 네트워크 보호이든 PDF 문서 보호이든 모든 분야에서 언제나 가장 중요한 문제였습니다. 문서는 다양한 이유로 보안이 적용됩니다: 문서 작성자가 문서 내용을 안전하게 보관하고 싶으며 다른 사람이 변경하도록 허용하고 싶지 않을 수 있습니다, 등.
 
-Aspose.Pdf for Reporting Services는 PDF 문서를 보호하는 데 유용한 기능들을 개발자에게 제공함으로써 이러한 보안 측면을 충분히 고려했습니다. 따라서, PDF 문서에 다양한 보안 조치를 적용할 수 있는 여러 매개 변수를 포함하고 있습니다.
+Aspose.PDF for Reporting Services는 이러한 보안 측면을 충분히 고려하여 개발자가 PDF 문서를 보호하는 데 유용한 기능을 제공합니다. 따라서 다양한 보안 조치를 PDF 문서에 적용할 수 있는 여러 매개변수를 포함하고 있습니다.
 
-이러한 조치 중 하나는 암호화 과정에서 PDF 문서를 비밀번호로 보호하는 것입니다. 또한 내용 수정, 내용 복사, 문서 인쇄를 제한하거나 허용하고, 양식 채우기를 허용하거나 비활성화할 수 있습니다. 이러한 기능은 현재 기본 SQL Reporting Services PDF 내보내기에서는 지원되지 않지만, Aspose.Pdf for Reporting Services를 사용하여 구현할 수 있습니다. 보고서 또는 보고서 서버 구성 파일에 해당 보안 매개변수를 추가하기만 하면 제한된 권한으로 보안이 강화된 PDF 문서를 만들 수 있습니다.
+이러한 조치 중 하나는 암호화 시 PDF 문서를 비밀번호로 보호하는 것입니다. 또한 내용 수정, 콘텐츠 복사, 문서 인쇄를 제한하거나 허용하거나 양식 입력을 허용/비활성화할 수 있습니다. 이러한 기능은 현재 기본 SQL Reporting Services PDF Exporter에서는 지원되지 않지만 Aspose.PDF for Reporting Services를 사용하면 구현할 수 있습니다. 보고서 또는 보고서 서버 구성 파일에 해당 보안 매개변수를 추가하기만 하면 제한된 권한으로 보안된 PDF 문서를 생성할 수 있습니다.
 
-현재 Aspose.Pdf for Reporting Services 렌더러는 다음 보안 속성을 지원합니다:
+현재 Aspose.PDF for Reporting Services 렌더러는 다음 보안 속성을 지원합니다:
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**Parameter Name**: 사용자 비밀번호  
-**Date Type**: 문자열  
-**Values supported**: 모든 일반 텍스트
+**매개변수 이름**: 사용자 비밀번호  
+**데이터 유형**: 문자열  
+**지원되는 값**: 모든 일반 텍스트
 
-**Parameter Name**: 마스터 비밀번호  
-**Date Type**: 문자열  
-**Values supported**: 모든 일반 텍스트 
+**매개변수 이름**: 마스터 비밀번호  
+**데이터 유형**: 문자열  
+**지원되는 값**: 모든 일반 텍스트 
 
 **매개변수 이름**: IsCopyingAllowed  
 **데이터 유형**: Boolean  
@@ -54,8 +54,8 @@ Aspose.Pdf for Reporting Services는 PDF 문서를 보호하는 데 유용한 �
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
     <UserPassword>aspose</UserPassword>
-    <IsCopyingAllowed>False</IsCopyingAllowed>
-    <IsPrintingAllowed>False</IsPrintingAllowed>
+    <IsCopyingAllowed>거짓</IsCopyingAllowed>
+    <IsPrintingAllowed>거짓</IsPrintingAllowed>
     </Configuration>
     </Extension>
 </Render>
@@ -63,5 +63,3 @@ Aspose.Pdf for Reporting Services는 PDF 문서를 보호하는 데 유용한 �
 {{< /highlight >}}
 
 {{% /alert %}}
-
-

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
@@ -3,63 +3,70 @@ title: 보안 설정
 linktitle: 보안 설정
 type: docs
 weight: 30
-url: /ko/reportingservices/security-setting/
-lastmod: "2026-07-29"
+url: /reportingservices/security-setting/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-보안은 네트워크 보호이든 PDF 문서 보호이든 모든 분야에서 언제나 가장 중요한 문제였습니다. 문서는 다양한 이유로 보안이 적용됩니다: 문서 작성자가 문서 내용을 안전하게 보관하고 싶으며 다른 사람이 변경하도록 허용하고 싶지 않을 수 있습니다, 등.
+네트워크 보호, PDF 문서 보호 등 모든 분야에서 보안은 항상 가장 중요한 문제였습니다. 문서는 여러 가지 이유로 안전하게 만들어집니다. 문서 작성자는 문서의 내용을 안전하게 유지하고 다른 사람이 이를 변경하는 것을 허용하지 않기를 원할 수 있습니다.
 
-Aspose.PDF for Reporting Services는 이러한 보안 측면을 충분히 고려하여 개발자가 PDF 문서를 보호하는 데 유용한 기능을 제공합니다. 따라서 다양한 보안 조치를 PDF 문서에 적용할 수 있는 여러 매개변수를 포함하고 있습니다.
+Reporting Services용 Aspose.PDF는 개발자에게 PDF 문서를 보호하는 데 유용할 수 있는 이러한 기능을 제공함으로써 이러한 보안 측면에 많은 관심을 기울였습니다. 따라서 여기에는 개발자가 PDF 문서에 다양한 보안 조치를 적용할 수 있는 다양한 매개변수가 포함되어 있습니다.
 
-이러한 조치 중 하나는 암호화 시 PDF 문서를 비밀번호로 보호하는 것입니다. 또한 내용 수정, 콘텐츠 복사, 문서 인쇄를 제한하거나 허용하거나 양식 입력을 허용/비활성화할 수 있습니다. 이러한 기능은 현재 기본 SQL Reporting Services PDF Exporter에서는 지원되지 않지만 Aspose.PDF for Reporting Services를 사용하면 구현할 수 있습니다. 보고서 또는 보고서 서버 구성 파일에 해당 보안 매개변수를 추가하기만 하면 제한된 권한으로 보안된 PDF 문서를 생성할 수 있습니다.
+이러한 조치 중 하나는 암호화 중에 PDF 문서를 암호로 보호하는 것입니다. 또한 콘텐츠 수정, 콘텐츠 복사, 문서 인쇄를 제한하거나 허용하거나 양식 작성을 허용/비활성화할 수 있습니다. 이러한 기능은 현재 기본 SQL Reporting Services PDF 내보내기에서 지원되지 않지만 Reporting Services용 Aspose.PDF를 사용하여 이러한 기능을 구현할 수 있습니다. 해당 보안 매개변수를 보고서 또는 보고서 서버 구성 파일에 추가하기만 하면 제한된 권한으로 안전한 PDF 문서를 만들 수 있습니다.
 
-현재 Aspose.PDF for Reporting Services 렌더러는 다음 보안 속성을 지원합니다:
+현재 Reporting Services 렌더러용 Aspose.PDF는 다음 보안 속성을 지원합니다.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+Parameter Name: User Password  
+Date Type: String  
+Values supported: Any plain text
+```
 
-**매개변수 이름**: 사용자 비밀번호  
-**데이터 유형**: 문자열  
-**지원되는 값**: 모든 일반 텍스트
+```text
+Parameter Name: Master Password  
+Date Type: String  
+Values supported: Any plain text 
+```
 
-**매개변수 이름**: 마스터 비밀번호  
-**데이터 유형**: 문자열  
-**지원되는 값**: 모든 일반 텍스트 
+```text
+Parameter Name: IsCopyingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default) 
+```
 
-**매개변수 이름**: IsCopyingAllowed  
-**데이터 유형**: Boolean  
-**지원되는 값**: True, False (기본값)  
+```text
+Parameter Name: IsPrintingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**매개변수 이름**: IsPrintingAllowed  
-**데이터 유형**: Boolean  
-**지원되는 값**: True, False (기본값)  
+```text
+Parameter Name: IsContentsModifyingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default) 
+```
 
-**매개변수 이름**: IsContentsModifyingAllowed  
-**데이터 유형**: Boolean  
-**지원되는 값**: True, False (기본값)  
+```text
+Parameter Name: IsFormFillingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**매개변수 이름**: IsFormFillingAllowed  
-**데이터 유형**: Boolean  
-**지원되는 값**: True, False (기본값)  
+## 예
 
-**예시**
-
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
     <UserPassword>aspose</UserPassword>
-    <IsCopyingAllowed>거짓</IsCopyingAllowed>
-    <IsPrintingAllowed>거짓</IsPrintingAllowed>
+    <IsCopyingAllowed>False</IsCopyingAllowed>
+    <IsPrintingAllowed>False</IsPrintingAllowed>
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
-
-{{% /alert %}}

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
@@ -4,32 +4,32 @@ linktitle: XMP 메타데이터
 type: docs
 weight: 80
 url: /ko/reportingservices/xmp-metadata/
-description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에서 XMP 메타데이터를 관리하는 방법을 배우세요. 문서 메타데이터 처리를 향상시킵니다.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에서 XMP 메타데이터를 관리하는 방법을 학습하십시오. 문서 메타데이터 처리를 향상시킵니다.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Reporting Services 보고서 디자이너는 문서에 XMP 메타데이터를 삽입하는 것을 지원하지 않습니다. Aspose.Pdf for Reporting Services는 해당 XMP 메타데이터를 설정하기 위한 네 가지 매개변수를 제공하며, 이들은 다음과 같습니다:
+Reporting Services 보고서 디자이너는 문서에 XMP 메타데이터를 삽입하는 것을 지원하지 않습니다. Aspose.PDF for Reporting Services는 해당 XMP 메타데이터를 설정하기 위한 네 가지 매개변수를 제공합니다. 이들은 다음과 같습니다:
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 **매개변수 이름**: CreationDate  
 **Date Type**: 문자열  
-**Values supported**: 날짜 형식 중 하나에 해당하는 날짜
+**Values supported**: 날짜 형식 중 하나의 날짜
 
-**매개변수 이름**: ModifyDate  
+**Parameter Name**: ModifyDate  
 **Date Type**: 문자열  
-**Values supported**: 날짜 형식 중 하나에 해당하는 날짜 
+**Values supported**: 날짜 형식 중 하나의 날짜 
 
-**매개변수 이름**: MetaDataDate  
+**Parameter Name**: MetaDataDate  
 **Date Type**: 문자열  
-**Values supported**: 날짜 형식 중 하나에 해당하는 날짜 
+**Values supported**: 날짜 형식 중 하나의 날짜 
 
-**매개변수 이름**: CreatorTool  
+**Parameter Name**: CreatorTool  
 **Date Type**: 문자열  
-**Values supported**: 어떤 일반 텍스트든  
+**Values supported**: 임의의 일반 텍스트  
 
 **예시**
 {{< highlight csharp >}}
@@ -41,7 +41,7 @@ Reporting Services 보고서 디자이너는 문서에 XMP 메타데이터를 �
     <CreationDate>2017-12-10</CreationDate>
     <ModifyDate>2018-1-12</ModifyDate>
     <MetaDataDate>2018-3-7</MetaDataDate>
-    <CreatorTool>Aspose.Pdf for Reporting Services</CreatorTool>
+    <CreatorTool>Aspose.PDF for Reporting Services</CreatorTool>
     </Configuration>
     </Extension>
 </Render>
@@ -49,6 +49,4 @@ Reporting Services 보고서 디자이너는 문서에 XMP 메타데이터를 �
 {{< /highlight >}}
 
 {{% /alert %}}
-
-
 

--- a/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
+++ b/ko/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
@@ -3,37 +3,44 @@ title: XMP 메타데이터
 linktitle: XMP 메타데이터
 type: docs
 weight: 80
-url: /ko/reportingservices/xmp-metadata/
-description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에서 XMP 메타데이터를 관리하는 방법을 학습하십시오. 문서 메타데이터 처리를 향상시킵니다.
-lastmod: "2026-07-29"
+url: /reportingservices/xmp-metadata/
+description: Reporting Services용 Aspose.PDF를 사용하여 PDF 보고서의 XMP 메타데이터를 관리하는 방법을 알아보세요. 문서 메타데이터 처리를 강화합니다.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Reporting Services 보고서 디자이너는 문서에 XMP 메타데이터를 삽입하는 것을 지원하지 않습니다. Aspose.PDF for Reporting Services는 해당 XMP 메타데이터를 설정하기 위한 네 가지 매개변수를 제공합니다. 이들은 다음과 같습니다:
+Reporting Services 보고서 디자이너는 문서에 XMP 메타데이터를 포함하는 것을 지원하지 않습니다. Reporting Services용 Aspose.PDF는 해당 XMP 메타데이터를 설정하는 네 가지 매개 변수를 제공합니다.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**매개변수 이름**: CreationDate  
-**Date Type**: 문자열  
-**Values supported**: 날짜 형식 중 하나의 날짜
+```text
+**Parameter Name: CreationDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats
+```
 
-**Parameter Name**: ModifyDate  
-**Date Type**: 문자열  
-**Values supported**: 날짜 형식 중 하나의 날짜 
+```text
+**Parameter Name: ModifyDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats 
+```
 
-**Parameter Name**: MetaDataDate  
-**Date Type**: 문자열  
-**Values supported**: 날짜 형식 중 하나의 날짜 
+```text
+**Parameter Name: MetaDataDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats 
+```
 
-**Parameter Name**: CreatorTool  
-**Date Type**: 문자열  
-**Values supported**: 임의의 일반 텍스트  
+```text
+**Parameter Name: CreatorTool  
+**Date Type: String  
+**Values supported: Any plain text  
+```
 
-**예시**
-{{< highlight csharp >}}
+## 예
 
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer, Aspose.Pdf.ReportingServices">
@@ -45,8 +52,6 @@ Reporting Services 보고서 디자이너는 문서에 XMP 메타데이터를 �
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
-
-{{% /alert %}}
 

--- a/ko/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
+++ b/ko/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
@@ -4,24 +4,22 @@ linktitle: Aspose.Pdf 평가
 type: docs
 weight: 110
 url: /ko/reportingservices/evaluate-aspose-pdf-for-reporting-services/
-description: Aspose.PDF for Reporting Services를 무료로 체험해 보세요. 구매 결정을 내리기 전에 기능을 평가하는 방법을 알아보세요.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services를 무료로 사용해 보세요. 구매 결정을 내리기 전에 기능을 평가하는 방법을 알아보세요.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-이 페이지에서는 Aspose.PDF for Reporting Services의 정식 라이선스 버전과 평가 버전의 차이점을 설명합니다.
+이 페이지는 Aspose.PDF for Reporting Services의 라이선스 버전과 평가 버전 간의 차이점을 설명합니다.
 
 {{% /alert %}}
 
-쉽게 다운로드할 수 있습니다. [Aspose.PDF for Reporting Services](https://downloads.aspose.com/pdf/reportingservices) 평가용입니다. 평가용 다운로드는 구매용 다운로드와 동일합니다. 라이선스 파일을 Aspose.PDF.ReportingServices.dll이 들어 있는 폴더에 넣거나 로컬 모드에서 Report Viewer와 함께 컴포넌트를 사용할 때 라이선스를 초기화하는 몇 줄의 코드를 추가하면 평가 버전이 간단히 정식 라이선스로 전환됩니다. 라이선스가 지정되지 않은 Aspose.PDF for Reporting Services의 평가 버전은 전체 제품 기능을 제공하지만, .RDL 파일을 PDF 형식으로 변환할 때 문서 상단에 평가 워터마크를 삽입합니다. 자세한 안내는 다음 페이지를 방문하십시오. [Aspose.PDF for Reporting Services 라이선스 부여 방법](/pdf/ko/reportingservices/license-aspose-pdf-for-reporting-services/)
+쉽게 다운로드할 수 있습니다. [Aspose.PDF for Reporting Services](https://downloads.aspose.com/pdf/reportingservices) 평가용입니다. 평가용 다운로드는 구매용 다운로드와 동일합니다. 평가 버전은 Aspose.PDF.ReportingServices.dll이 포함된 폴더에 라이선스 파일을 배치하거나 로컬 모드에서 Report Viewer와 함께 구성 요소를 사용할 때 라이선스를 초기화하는 몇 줄의 코드를 추가하면 라이선스가 적용됩니다. 라이선스가 지정되지 않은 Aspose.PDF for Reporting Services의 평가 버전은 전체 제품 기능을 제공하지만 .RDL 파일을 PDF 형식으로 렌더링할 때 문서 상단에 평가 워터마크를 삽입합니다. 추가 지침은 다음 페이지를 방문하십시오. [how to License Aspose.PDF for Reporting Services](/pdf/ko/reportingservices/license-aspose-pdf-for-reporting-services/)
 
 ![todo:image_alt_text](evaluate-aspose-pdf-for-reporting-services_1.png)
 
 {{% alert color="primary" %}}
 
-평가 버전 제한 없이 Aspose.PDF for Reporting Services를 테스트하려면 30일 임시 라이선스를 요청할 수도 있습니다. 자세한 내용은 [임시 라이선스를 받는 방법은?](<https://about.aspose.com/>)
+Aspose.PDF for Reporting Services를 평가 버전 제한 없이 테스트하고 싶다면, 30일 임시 라이선스를 요청할 수도 있습니다. 자세한 내용은 다음을 참조하십시오. [How to get a Temporary License?](<https://about.aspose.com/>)
 
 {{% /alert %}}
-
-

--- a/ko/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
+++ b/ko/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
@@ -3,23 +3,23 @@ title: Aspose.Pdf 평가
 linktitle: Aspose.Pdf 평가
 type: docs
 weight: 110
-url: /ko/reportingservices/evaluate-aspose-pdf-for-reporting-services/
-description: Aspose.PDF for Reporting Services를 무료로 사용해 보세요. 구매 결정을 내리기 전에 기능을 평가하는 방법을 알아보세요.
-lastmod: "2026-07-29"
+url: /reportingservices/evaluate-aspose-pdf-for-reporting-services/
+description: 보고 서비스용 Aspose.PDF를 무료로 사용해 보세요. 구매 결정을 내리기 전에 기능을 평가하는 방법을 알아보세요.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-이 페이지는 Aspose.PDF for Reporting Services의 라이선스 버전과 평가 버전 간의 차이점을 설명합니다.
+이 페이지에는 Reporting Services용 Aspose.PDF의 라이선스 버전과 평가판 간의 차이점이 설명되어 있습니다.
 
 {{% /alert %}}
 
-쉽게 다운로드할 수 있습니다. [Aspose.PDF for Reporting Services](https://downloads.aspose.com/pdf/reportingservices) 평가용입니다. 평가용 다운로드는 구매용 다운로드와 동일합니다. 평가 버전은 Aspose.PDF.ReportingServices.dll이 포함된 폴더에 라이선스 파일을 배치하거나 로컬 모드에서 Report Viewer와 함께 구성 요소를 사용할 때 라이선스를 초기화하는 몇 줄의 코드를 추가하면 라이선스가 적용됩니다. 라이선스가 지정되지 않은 Aspose.PDF for Reporting Services의 평가 버전은 전체 제품 기능을 제공하지만 .RDL 파일을 PDF 형식으로 렌더링할 때 문서 상단에 평가 워터마크를 삽입합니다. 추가 지침은 다음 페이지를 방문하십시오. [how to License Aspose.PDF for Reporting Services](/pdf/ko/reportingservices/license-aspose-pdf-for-reporting-services/)
+쉽게 다운로드할 수 있습니다. [보고 서비스용 Aspose.PDF](https://downloads.aspose.com/pdf/reportingservices) 평가를 위해. 평가판 다운로드는 구매한 다운로드와 동일합니다. Aspose.PDF.ReportingServices.dll이 포함된 폴더에 라이센스 파일을 넣거나 로컬 모드에서 보고서 뷰어와 함께 구성 요소를 사용할 때 라이센스를 초기화하는 몇 줄의 코드를 넣으면 평가판에 라이센스가 부여됩니다. Reporting Services용 Aspose.PDF 평가판(라이선스가 지정되지 않음)은 전체 제품 기능을 제공하지만 .RDL 파일을 PDF 형식으로 렌더링할 때 문서 상단에 평가판 워터마크를 삽입합니다. 다음 페이지를 방문하여 자세한 지침을 확인하세요. [보고 서비스용 Aspose.PDF 라이선스를 취득하는 방법](/pdf/ko/reportingservices/license-aspose-pdf-for-reporting-services/)
 
-![todo:image_alt_text](evaluate-aspose-pdf-for-reporting-services_1.png)
+![평가](evaluate-aspose-pdf-for-reporting-services_1.png)
 
 {{% alert color="primary" %}}
 
-Aspose.PDF for Reporting Services를 평가 버전 제한 없이 테스트하고 싶다면, 30일 임시 라이선스를 요청할 수도 있습니다. 자세한 내용은 다음을 참조하십시오. [How to get a Temporary License?](<https://about.aspose.com/>)
+평가판 제한 없이 Reporting Services용 Aspose.PDF를 테스트하려는 경우 30일 임시 라이선스를 요청할 수도 있습니다. 참고하세요 [임시 면허증을 얻는 방법은 무엇입니까?](<https://about.aspose.com/>)
 
 {{% /alert %}}

--- a/ko/reportingservices/expand-report-items-properties/_index.md
+++ b/ko/reportingservices/expand-report-items-properties/_index.md
@@ -4,13 +4,11 @@ linktitle: 보고서 항목 속성 확장
 type: docs
 weight: 90
 url: /ko/reportingservices/expand-report-items-properties/
-description: Aspose.PDF를 사용하여 SSRS 보고서를 향상시킵니다. 자세한 PDF 사용자 지정을 위해 보고서 항목 속성을 확장하는 방법을 알아보세요.
-lastmod: "2026-06-19"
+description: Aspose.PDF를 사용하여 SSRS 보고서를 향상시키십시오. 자세한 PDF 맞춤화를 위해 보고서 항목 속성을 확장하는 방법을 알아보세요.
+lastmod: "2026-07-29"
 ---
 
 **이 섹션에는 다음 주제가 포함됩니다:**
 
-- [사용자 정의 속성 추가](/pdf/ko/reportingservices/adding-custom-properties/)
-- [지원되는 사용자 정의 속성](/pdf/ko/reportingservices/custom-properties-supported/)
-
-
+- [사용자 지정 속성 추가](/pdf/ko/reportingservices/adding-custom-properties/)
+- [지원되는 사용자 지정 속성](/pdf/ko/reportingservices/custom-properties-supported/)

--- a/ko/reportingservices/expand-report-items-properties/_index.md
+++ b/ko/reportingservices/expand-report-items-properties/_index.md
@@ -1,14 +1,14 @@
 ---
-title: 보고서 항목 속성 확장
-linktitle: 보고서 항목 속성 확장
+title: 보고서 항목 소품 확장
+linktitle: 보고서 항목 소품 확장
 type: docs
 weight: 90
-url: /ko/reportingservices/expand-report-items-properties/
-description: Aspose.PDF를 사용하여 SSRS 보고서를 향상시키십시오. 자세한 PDF 맞춤화를 위해 보고서 항목 속성을 확장하는 방법을 알아보세요.
-lastmod: "2026-07-29"
+url: /reportingservices/expand-report-items-properties/
+description: Aspose.PDF로 SSRS 보고서를 강화하세요. 자세한 PDF 사용자 정의를 위해 보고서 항목 속성을 확장하는 방법을 알아보세요.
+lastmod: "2021-06-05"
 ---
 
-**이 섹션에는 다음 주제가 포함됩니다:**
+**이 섹션에는 다음 주제가 포함됩니다.**
 
-- [사용자 지정 속성 추가](/pdf/ko/reportingservices/adding-custom-properties/)
-- [지원되는 사용자 지정 속성](/pdf/ko/reportingservices/custom-properties-supported/)
+- [사용자 정의 속성 추가](/pdf/ko/reportingservices/adding-custom-properties/)
+- [지원되는 사용자 정의 속성](/pdf/ko/reportingservices/custom-properties-supported/)

--- a/ko/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
+++ b/ko/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
@@ -1,32 +1,32 @@
 ---
-title: 사용자 정의 속성 추가
-linktitle: 사용자 정의 속성 추가
+title: 맞춤 속성 추가
+linktitle: 맞춤 속성 추가
 type: docs
 weight: 10
 url: /ko/reportingservices/adding-custom-properties/
-description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에 사용자 정의 속성을 추가하는 방법을 알아보세요. 문서를 효율적으로 맞춤 설정하십시오.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에 맞춤 속성을 추가하는 방법을 알아보세요. 문서를 효율적으로 맞춤 설정하십시오.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-목차(ToC), 선 화살표 등과 같이 일부 보고서 항목에 대해 사용자 정의 속성을 추가하여 사용 범위를 확장할 수 있습니다. 이 섹션에서는 해당 과정을 설명합니다.
+보고서 항목 중 일부에 맞춤 속성을 추가하여 사용 범위를 확장할 수 있습니다(예: ToC, 선 화살표 등). 이 섹션에서는 이 과정을 설명합니다.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-목차, 선 화살표 등과 같이 일부 보고서 항목에 대해 사용자 정의 속성을 추가하여 사용 범위를 확장할 수 있습니다. 이 섹션에서는 해당 과정을 설명합니다.
+보고서 항목 중 일부에 맞춤 속성을 추가하여 사용 범위를 확장할 수 있습니다(예: 목차, 선 화살표 등). 이 섹션에서는 이 과정을 설명합니다.
 
-사용자 지정 속성을 추가하려면 다음 단계에 따라 RDL 문서의 코드 파일을 편집해야 합니다:
+사용자 정의 속성을 추가하려면, 다음 단계에 따라 RDL 문서의 코드 파일을 편집해야 합니다:
 
-1. 다음 그림과 같이 프로젝트를 열고, 솔루션 탐색기로 이동한 다음 선택한 보고서 파일을 마우스 오른쪽 버튼으로 클릭하고, 'View Code' 메뉴 항목을 선택합니다.
+1. 아래 그림과 같이 프로젝트를 열고, 솔루션 탐색기로 이동한 뒤 선택한 보고서 파일을 오른쪽 클릭하고, ‘View Code’ 메뉴 항목을 선택합니다.
 
 ![todo:image_alt_text](adding-custom-properties_1.png)
 
-2. XML 코드 파일을 편집합니다. 예를 들어 차트 보고서 항목에 대한 사용자 지정 속성을 추가하려면 다음 예제의 빨간색 텍스트와 유사한 코드를 추가해야 합니다.
+2. XML 코드 파일을 편집합니다. 예를 들어 차트 보고서 항목에 대한 사용자 정의 속성을 추가하려면, 아래 예시의 빨간색 텍스트와 유사한 코드를 추가해야 합니다.
 
-**예제**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -39,16 +39,14 @@ lastmod: "2026-06-19"
     </style>     
     <CustomProperties>
       <CustomProperty>
-        <Name>IsInList</Name>
-        <Value>True</Value>
+        <Name>목록에 있는지</Name>
+        <Value>참</Value>
       </CustomProperty>
     </CustomProperties>
 </chart> 
 
 {{< /highlight >}}
 
-이 코드 조각 예제에서 사용자 지정 속성 이름은 IsInList이고 값은 'True'입니다.
+이 코드 조각 예제에서 사용자 지정 속성 이름은 IsInList이며, 값은 'True'입니다.
 
 {{% /alert %}}
-
-

--- a/ko/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
+++ b/ko/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
@@ -1,35 +1,32 @@
 ---
-title: 맞춤 속성 추가
-linktitle: 맞춤 속성 추가
+title: 사용자 정의 속성 추가
+linktitle: 사용자 정의 속성 추가
 type: docs
 weight: 10
-url: /ko/reportingservices/adding-custom-properties/
-description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에 맞춤 속성을 추가하는 방법을 알아보세요. 문서를 효율적으로 맞춤 설정하십시오.
-lastmod: "2026-07-29"
+url: /reportingservices/adding-custom-properties/
+description: Reporting Services용 Aspose.PDF를 사용하여 PDF 보고서에 사용자 정의 속성을 추가하는 방법을 알아보세요. 문서를 효율적으로 사용자 정의하세요.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-보고서 항목 중 일부에 맞춤 속성을 추가하여 사용 범위를 확장할 수 있습니다(예: ToC, 선 화살표 등). 이 섹션에서는 이 과정을 설명합니다.
+일부 보고서 항목에 대한 사용자 정의 속성을 추가하여 ToC, 선 화살표 등과 같은 용도를 확장할 수 있습니다. 이 섹션에서는 이 프로세스에 대해 설명합니다.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+일부 보고서 항목에 대한 사용자 정의 속성을 추가하여 목차, 선 화살표 등과 같은 용도를 확장할 수 있습니다. 이 섹션에서는 이 프로세스에 대해 설명합니다.
 
-보고서 항목 중 일부에 맞춤 속성을 추가하여 사용 범위를 확장할 수 있습니다(예: 목차, 선 화살표 등). 이 섹션에서는 이 과정을 설명합니다.
+사용자 정의 속성을 추가하려면 다음 단계에 따라 RDL 문서의 코드 파일을 편집해야 합니다.
 
-사용자 정의 속성을 추가하려면, 다음 단계에 따라 RDL 문서의 코드 파일을 편집해야 합니다:
+1. 다음 그림과 같이 프로젝트를 열고 솔루션 탐색기로 이동하여 선택한 보고서 파일을 마우스 오른쪽 버튼으로 클릭한 다음 '코드 보기' 메뉴 항목을 선택합니다.
 
-1. 아래 그림과 같이 프로젝트를 열고, 솔루션 탐색기로 이동한 뒤 선택한 보고서 파일을 오른쪽 클릭하고, ‘View Code’ 메뉴 항목을 선택합니다.
+![Add Custom Properties](adding-custom-properties_1.png)
 
-![todo:image_alt_text](adding-custom-properties_1.png)
+2. XML 코드 파일을 편집합니다. 예를 들어 차트 보고서 항목에 대한 사용자 정의 속성을 추가하려면 다음 예의 빨간색 텍스트와 유사한 코드를 추가해야 합니다.
 
-2. XML 코드 파일을 편집합니다. 예를 들어 차트 보고서 항목에 대한 사용자 정의 속성을 추가하려면, 아래 예시의 빨간색 텍스트와 유사한 코드를 추가해야 합니다.
+## 예
 
-**Example**
-
-{{< highlight csharp >}}
-
+```xml
 <chart Name="chart1">
     <Left>5.5cm</Left>
     <Top>0.5cm</Top>
@@ -39,14 +36,12 @@ lastmod: "2026-07-29"
     </style>     
     <CustomProperties>
       <CustomProperty>
-        <Name>목록에 있는지</Name>
-        <Value>참</Value>
+        <Name>IsInList</Name>
+        <Value>True</Value>
       </CustomProperty>
     </CustomProperties>
 </chart> 
+```
 
-{{< /highlight >}}
+이 코드 단편 예에서 사용자 정의 특성 이름은 IsInList이고 값은 `True`입니다.
 
-이 코드 조각 예제에서 사용자 지정 속성 이름은 IsInList이며, 값은 'True'입니다.
-
-{{% /alert %}}

--- a/ko/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
+++ b/ko/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
@@ -1,18 +1,16 @@
 ---
-title: 맞춤 속성 지원
-linktitle: 맞춤 속성 지원
+title: 맞춤형 속성 지원
+linktitle: 맞춤형 속성 지원
 type: docs
 weight: 20
 url: /ko/reportingservices/custom-properties-supported/
-description: Aspose.PDF for Reporting Services에서 지원되는 맞춤 속성을 확인하십시오. PDF 출력에서 유연성을 극대화하십시오.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services에서 지원되는 맞춤형 속성을 확인하십시오. PDF 출력물의 유연성을 최대화하십시오.
+lastmod: "2026-07-29"
 ---
 
 **이 섹션에는 다음 주제가 포함됩니다:**
 
-- [목차, 표 또는 그림 목록](/pdf/ko/reportingservices/table-of-contents-list-of-tables-or-figures/)
+- [목차, 표 목록 또는 도표](/pdf/ko/reportingservices/table-of-contents-list-of-tables-or-figures/)
 - [선 화살표](/pdf/ko/reportingservices/line-arrows/)
-- [각주 및 미주](/pdf/ko/reportingservices/footnote-endnote/)
-- [양쪽 맞춤 전체 정렬 텍스트 정렬](/pdf/ko/reportingservices/justify-fulljustify-text-alignment/)
-
-
+- [각주 미주](/pdf/ko/reportingservices/footnote-endnote/)
+- [양쪽 맞춤 전체정렬 텍스트 정렬](/pdf/ko/reportingservices/justify-fulljustify-text-alignment/)

--- a/ko/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
+++ b/ko/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
@@ -1,16 +1,16 @@
 ---
-title: 맞춤형 속성 지원
-linktitle: 맞춤형 속성 지원
+title: 지원되는 사용자 정의 속성
+linktitle: 지원되는 사용자 정의 속성
 type: docs
 weight: 20
-url: /ko/reportingservices/custom-properties-supported/
-description: Aspose.PDF for Reporting Services에서 지원되는 맞춤형 속성을 확인하십시오. PDF 출력물의 유연성을 최대화하십시오.
-lastmod: "2026-07-29"
+url: /reportingservices/custom-properties-supported/
+description: Reporting Services에 대해 Aspose.PDF에서 지원되는 사용자 정의 속성을 확인하세요. PDF 출력의 유연성을 극대화하십시오.
+lastmod: "2021-06-05"
 ---
 
-**이 섹션에는 다음 주제가 포함됩니다:**
+**이 섹션에는 다음 주제가 포함됩니다.**
 
-- [목차, 표 목록 또는 도표](/pdf/ko/reportingservices/table-of-contents-list-of-tables-or-figures/)
+- [목차 표 또는 그림 목록](/pdf/ko/reportingservices/table-of-contents-list-of-tables-or-figures/)
 - [선 화살표](/pdf/ko/reportingservices/line-arrows/)
 - [각주 미주](/pdf/ko/reportingservices/footnote-endnote/)
-- [양쪽 맞춤 전체정렬 텍스트 정렬](/pdf/ko/reportingservices/justify-fulljustify-text-alignment/)
+- [전체 양쪽 맞춤텍스트 정렬 맞춤](/pdf/ko/reportingservices/justify-fulljustify-text-alignment/)

--- a/ko/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
+++ b/ko/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
@@ -1,33 +1,33 @@
 ---
-title: 각주 및 미주
-linktitle: 각주 및 미주
+title: 각주 미주
+linktitle: 각주 미주
 type: docs
 weight: 30
 url: /ko/reportingservices/footnote-endnote/
-description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에 각주와 미주를 추가하세요. 자세한 문서 참조를 제공합니다.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에 각주 및 미주를 추가하십시오. 자세한 문서 참조를 제공하십시오.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Report Builder에서는 텍스트 상자에 각주 또는 미주를 설정할 수 없습니다. Aspose.Pdf for Reporting Services를 사용하면 사용자 지정 속성을 추가하여 쉽게 수행할 수 있습니다.
+Report Builder에서는 텍스트 상자에 각주 또는 미주를 설정할 수 없습니다. Aspose.PDF for Reporting Services를 사용하면 사용자 지정 속성을 추가하여 쉽게 수행할 수 있습니다.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 각주
-**사용자 정의 속성** **이름**: 각주
-**사용자 정의 속성 값**: *그* *값* *해야*  *한다*  *하나의* *문자열*
+**맞춤 속성** **이름**: 각주
+**맞춤 속성 값**: *그*\u00A0*값* *은*\u00A0*이어야*\u00A0*하나의*\u00A0*문자열*
 
 미주
-**사용자 정의 속성** **이름**: 미주
-**사용자 정의 속성 값**: *그* *값* *해야*  *한다*  *하나의* *문자열*
+**맞춤 속성** **이름**: 미주
+**맞춤 속성 값**: *그*\u00A0*값* *은*\u00A0*이어야* *하나의*\u00A0*문자열*
 
 {{% alert color="primary" %}}
-다음 예에서는 보고서에 값이 'AsposePdf4RS'인 텍스트 상자가 포함되어 있으며, 우리는 "An optional PDF renderer for SSRS from Aspose Pty. Ltd."라는 텍스트의 각주 형태로 보조 설명을 추가하고자 합니다.
+다음 예제에서는 보고서에 값이 'AsposePdf4RS'인 텍스트 상자가 포함되어 있으며, 여기서 텍스트 "An optional PDF renderer for SSRS from Aspose Pty. Ltd."를 각주의 형태로 보조 설명을 추가하고자 합니다.
 {{% /alert %}}
 
-**예시**
+**예제**
 
 ```cs
 <Textbox Name="Textbox1">
@@ -54,5 +54,3 @@ Report Builder에서는 텍스트 상자에 각주 또는 미주를 설정할 �
 </Textbox>
 ```
 {{% /alert %}}
-
-

--- a/ko/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
+++ b/ko/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
@@ -3,31 +3,32 @@ title: 각주 미주
 linktitle: 각주 미주
 type: docs
 weight: 30
-url: /ko/reportingservices/footnote-endnote/
-description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에 각주 및 미주를 추가하십시오. 자세한 문서 참조를 제공하십시오.
-lastmod: "2026-07-29"
+url: /reportingservices/footnote-endnote/
+description: Reporting Services용 Aspose.PDF를 사용하여 PDF 보고서에 각주와 미주를 추가하세요. 자세한 문서 참조를 제공하십시오.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Builder에서는 텍스트 상자에 각주 또는 미주를 설정할 수 없습니다. Aspose.PDF for Reporting Services를 사용하면 사용자 지정 속성을 추가하여 쉽게 수행할 수 있습니다.
+보고서 작성기는 텍스트 상자의 각주나 미주를 설정할 수 없습니다. Reporting Services용 Aspose.PDF를 사용하면 사용자 지정 속성을 추가하여 쉽게 수행할 수 있습니다.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-각주
-**맞춤 속성** **이름**: 각주
-**맞춤 속성 값**: *그*\u00A0*값* *은*\u00A0*이어야*\u00A0*하나의*\u00A0*문자열*
+```text
+Footnote
+Custom Property `Name`: Footnote
+Custom Property Value: `the` `value` `should` `be` `a` `string`
+```
 
-미주
-**맞춤 속성** **이름**: 미주
-**맞춤 속성 값**: *그*\u00A0*값* *은*\u00A0*이어야* *하나의*\u00A0*문자열*
+```text
+Endnote
+Custom Property `Name`: Endnote
+Custom Property Value: `the` `value` `should` `be` `a` `string`
+```
 
-{{% alert color="primary" %}}
-다음 예제에서는 보고서에 값이 'AsposePdf4RS'인 텍스트 상자가 포함되어 있으며, 여기서 텍스트 "An optional PDF renderer for SSRS from Aspose Pty. Ltd."를 각주의 형태로 보조 설명을 추가하고자 합니다.
-{{% /alert %}}
+다음 예에서 보고서에는 `AsposePdf4RS` 값이 있는 텍스트 상자가 포함되어 있으며 "Aspose Pty. Ltd.의 SSRS용 선택적 PDF 렌더러"라는 텍스트가 있는 각주 형식의 보충 설명을 추가하려고 합니다.
 
-**예제**
+## 예
 
 ```cs
 <Textbox Name="Textbox1">
@@ -53,4 +54,3 @@ Report Builder에서는 텍스트 상자에 각주 또는 미주를 설정할 �
 </Paragraphs>
 </Textbox>
 ```
-{{% /alert %}}

--- a/ko/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
+++ b/ko/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
@@ -5,21 +5,21 @@ type: docs
 weight: 40
 url: /ko/reportingservices/justify-fulljustify-text-alignment/
 description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에서 완벽한 텍스트 정렬을 구현하십시오. 정렬(justify) 및 전체 정렬(full justify) 옵션을 지원합니다.
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Report Builder는 텍스트 상자 “Justify” 및 “FullJustify”에 대한 텍스트 정렬 지정 기능을 지원하지 않습니다. Aspose.Pdf for Reporting Services를 사용하면 사용자 지정 속성을 추가하여 쉽게 수행할 수 있습니다.
+Report Builder는 텍스트 상자 “Justify” 및 “FullJustify”에 대한 텍스트 정렬을 지정하는 기능을 지원하지 않습니다. Aspose.PDF for Reporting Services를 사용하면 사용자 지정 속성을 추가하여 이를 쉽게 수행할 수 있습니다.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 **사용자 지정 속성 이름** : TextAlignment  
-**사용자 정의 속성 유형** : String  
-**사용자 정의 속성 값** : Justify, FullJustify  
+**맞춤 속성 유형** : String  
+**맞춤 속성 값** : Justify, FullJustify  
 
-보고서에서 코드는 다음과 같이 작성되어야 합니다:
+보고서에서 코드는 다음과 같아야 합니다:
 
 **예시**
 
@@ -28,12 +28,10 @@ Report Builder는 텍스트 상자 “Justify” 및 “FullJustify”에 대한
 <value> AsposePdf4RS </value>     
   <CustomProperties>
    <CustomProperty>
-     <Name>TextAlignment</Name>
-     <Value>Justify</Value>
+     <Name>텍스트 정렬</Name>
+     <Value>정당화</Value>
    </CustomProperty>
   </CustomProperties>
 </Textbox>
 {{< /highlight >}}
 {{% /alert %}}
-
-

--- a/ko/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
+++ b/ko/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
@@ -1,37 +1,37 @@
 ---
-title: Justify FullJustify 텍스트 정렬
-linktitle: Justify FullJustify 텍스트 정렬
+title: 전체 양쪽 맞춤텍스트 정렬 맞춤
+linktitle: 전체 양쪽 맞춤텍스트 정렬 맞춤
 type: docs
 weight: 40
-url: /ko/reportingservices/justify-fulljustify-text-alignment/
-description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에서 완벽한 텍스트 정렬을 구현하십시오. 정렬(justify) 및 전체 정렬(full justify) 옵션을 지원합니다.
-lastmod: "2026-07-29"
+url: /reportingservices/justify-fulljustify-text-alignment/
+description: Reporting Services용 Aspose.PDF를 사용하여 PDF 보고서에서 완벽한 텍스트 정렬을 달성하세요. 양쪽 맞춤 및 전체 양쪽 맞춤 옵션을 지원합니다.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Builder는 텍스트 상자 “Justify” 및 “FullJustify”에 대한 텍스트 정렬을 지정하는 기능을 지원하지 않습니다. Aspose.PDF for Reporting Services를 사용하면 사용자 지정 속성을 추가하여 이를 쉽게 수행할 수 있습니다.
+보고서 빌더는 텍스트 상자의 텍스트 정렬을 지정하는 기능을 지원하지 않습니다. `Justify` 그리고 `FullJustify`. Reporting Services용 Aspose.PDF를 사용하면 사용자 지정 속성을 추가하여 쉽게 수행할 수 있습니다.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**사용자 지정 속성 이름** : TextAlignment  
-**맞춤 속성 유형** : String  
-**맞춤 속성 값** : Justify, FullJustify  
+```text
+Custom Property `Name`: TextAlignment  
+Custom Property `Type`: String  
+Custom Property `Values`: Justify, FullJustify  
+```
 
-보고서에서 코드는 다음과 같아야 합니다:
+보고서에서 코드는 다음과 같아야 합니다.
 
-**예시**
+## 예
 
-{{< highlight csharp >}}
+```xml
 <Textbox Name="textbox1">
 <value> AsposePdf4RS </value>     
   <CustomProperties>
    <CustomProperty>
-     <Name>텍스트 정렬</Name>
-     <Value>정당화</Value>
+     <Name>TextAlignment</Name>
+     <Value>Justify</Value>
    </CustomProperty>
   </CustomProperties>
 </Textbox>
-{{< /highlight >}}
-{{% /alert %}}
+```

--- a/ko/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
+++ b/ko/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
@@ -1,32 +1,32 @@
 ---
-title: 라인 화살표
-linktitle: 라인 화살표
+title: 선 화살표
+linktitle: 선 화살표
 type: docs
 weight: 20
 url: /ko/reportingservices/line-arrows/
-description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에 라인 화살표를 추가하는 방법을 배우세요. 보고서 시각 효과를 손쉽게 향상시킵니다.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에 선 화살표를 추가하는 방법을 배우세요. 보고서 시각 효과를 손쉽게 강화합니다.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-RDL 사양에서는 라인 요소에 대한 화살표를 지정하지 않으므로 Report Builder에서는 라인에 화살표 설정을 지원하지 않습니다. Aspose.Pdf for Reporting Services를 사용하면 이를 쉽게 구현할 수 있습니다.
+RDL 사양에는 선 요소에 대한 화살표가 명시되어 있지 않아, Report Builder는 선에 화살표 설정을 지원하지 않습니다. Aspose.PDF for Reporting Services를 사용하면 이를 쉽게 구현할 수 있습니다.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-현재 Aspose.PDF 렌더러는 사용자 정의 속성을 추가하여 라인의 시작 또는 끝에 화살표를 추가하는 것을 지원합니다.
+현재 Aspose.PDF 렌더러는 사용자 지정 속성을 추가하여 선의 시작 또는 끝에 화살표를 추가하는 것을 지원합니다.
 
-선에 시작 화살표 추가  
+라인에 시작 화살표를 추가  
 **사용자 정의 속성** **이름**: HasArrowAtStart  
 **사용자 정의 속성 값**: True  
 
-선에 끝 화살표 추가  
+라인에 끝 화살표를 추가  
 **사용자 정의 속성** **이름**: HasArrowAtEnd  
 **사용자 정의 속성 값**: True  
 
-예를 들어, 현재 보고서 파일에 'line1'과 'line2'라는 두 개의 선이 있고, line1에는 시작 화살표가 있으며, line2에는 시작 및 끝 화살표가 있습니다. 이러한 요구 사항을 충족하려면 다음 코드 조각과 같이 사용자 정의 속성을 추가할 수 있습니다.
+예를 들어, 현재 보고서 파일에 'line1'과 'line2'라는 두 개의 라인이 있고, line1은 시작 화살표가 있으며, line2는 시작 및 끝 화살표가 있습니다. 이러한 요구사항을 충족하려면 다음 코드 조각과 같이 사용자 정의 속성을 추가할 수 있습니다.
 
 **예시**
 
@@ -37,8 +37,8 @@ RDL 사양에서는 라인 요소에 대한 화살표를 지정하지 않으므�
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>HasArrowAtStart</Name>
-        <Value>True</Value>
+        <Name>시작에 화살표가 있음</Name>
+        <Value>참</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
@@ -49,17 +49,15 @@ RDL 사양에서는 라인 요소에 대한 화살표를 지정하지 않으므�
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>HasArrowAtStart</Name>
-        <Value>True</Value>
+        <Name>시작에 화살표가 있음</Name>
+        <Value>참</Value>
       </CustomProperty>
 <CustomProperty>
-        <Name>HasArrowAtEnd</Name>
-        <Value>True</Value>
+        <Name>끝에 화살표가 있음</Name>
+        <Value>참</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
 
 {{< /highlight >}}
 {{% /alert %}}
-
-

--- a/ko/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
+++ b/ko/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
@@ -3,42 +3,44 @@ title: 선 화살표
 linktitle: 선 화살표
 type: docs
 weight: 20
-url: /ko/reportingservices/line-arrows/
-description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에 선 화살표를 추가하는 방법을 배우세요. 보고서 시각 효과를 손쉽게 강화합니다.
-lastmod: "2026-07-29"
+url: /reportingservices/line-arrows/
+description: Reporting Services용 Aspose.PDF를 사용하여 PDF 보고서에 선 화살표를 추가하는 방법을 알아보세요. 손쉽게 보고서 시각적 요소를 향상하세요.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-RDL 사양에는 선 요소에 대한 화살표가 명시되어 있지 않아, Report Builder는 선에 화살표 설정을 지원하지 않습니다. Aspose.PDF for Reporting Services를 사용하면 이를 쉽게 구현할 수 있습니다.
+RDL 사양은 선 요소에 대한 화살표를 지정하지 않으므로 보고서 빌더는 선에 대한 화살표 설정을 지원하지 않습니다. 보고 서비스용 Aspose.PDF를 사용하면 이를 쉽게 수행할 수 있습니다.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+현재 Aspose.PDF 렌더러는 사용자 정의 속성을 추가하여 선의 시작이나 끝 부분에 화살표를 추가하는 것을 지원합니다.
 
-현재 Aspose.PDF 렌더러는 사용자 지정 속성을 추가하여 선의 시작 또는 끝에 화살표를 추가하는 것을 지원합니다.
+```text
+Add Start Arrow for Line  
+Custom Property `Name`: HasArrowAtStart  
+Custom Property `Value`: True  
+```
 
-라인에 시작 화살표를 추가  
-**사용자 정의 속성** **이름**: HasArrowAtStart  
-**사용자 정의 속성 값**: True  
+```text
+Add End Arrow for Line  
+Custom Property `Name`: HasArrowAtEnd  
+Custom Property `Value`: True  
+```
 
-라인에 끝 화살표를 추가  
-**사용자 정의 속성** **이름**: HasArrowAtEnd  
-**사용자 정의 속성 값**: True  
+예를 들어, 다음과 같은 두 줄이 있습니다. `line1` 그리고 `line2` 현재 보고서 파일에서 line1에는 시작 화살표가 있고 line2에는 시작 및 끝 화살표가 있습니다. 이러한 요구 사항을 충족하려면 다음 코드 조각과 같이 사용자 정의 속성을 추가할 수 있습니다.
 
-예를 들어, 현재 보고서 파일에 'line1'과 'line2'라는 두 개의 라인이 있고, line1은 시작 화살표가 있으며, line2는 시작 및 끝 화살표가 있습니다. 이러한 요구사항을 충족하려면 다음 코드 조각과 같이 사용자 정의 속성을 추가할 수 있습니다.
+## 예
 
-**예시**
-
-{{< highlight csharp >}}
+```xml
  <Line Name="line1">
     <Style>
       ......
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>시작에 화살표가 있음</Name>
-        <Value>참</Value>
+        <Name>HasArrowAtStart</Name>
+        <Value>True</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
@@ -49,15 +51,14 @@ RDL 사양에는 선 요소에 대한 화살표가 명시되어 있지 않아, R
     </style>
     <CustomProperties>
       <CustomProperty>
-        <Name>시작에 화살표가 있음</Name>
-        <Value>참</Value>
+        <Name>HasArrowAtStart</Name>
+        <Value>True</Value>
       </CustomProperty>
 <CustomProperty>
-        <Name>끝에 화살표가 있음</Name>
-        <Value>참</Value>
+        <Name>HasArrowAtEnd</Name>
+        <Value>True</Value>
       </CustomProperty>
     </CustomProperties>
 </Line>
+```
 
-{{< /highlight >}}
-{{% /alert %}}

--- a/ko/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
+++ b/ko/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
@@ -1,25 +1,24 @@
 ---
-title: Table of Contents List of Tables or Figures
-linktitle: Table of Contents List of Tables or Figures
+title: 목차 표 또는 그림 목록
+linktitle: 목차 표 또는 그림 목록
 type: docs
 weight: 10
 url: /reportingservices/table-of-contents-list-of-tables-or-figures/
-description: Learn how to add a Table of Contents, List of Tables, or Figures in PDF reports using Aspose.PDF for Reporting Services.
+description: Reporting Services용 Aspose.PDF를 사용하여 PDF 보고서에 목차, 표 목록 또는 그림을 추가하는 방법을 알아보세요.
 lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Designer does not support adding table of contents for report documents. With Aspose.PDF for Reporting Services you can easily instruct the PDF render to produce PDF documents with Table of Contents, or List of Tables or Figures. You can do it in the following steps:
+보고서 디자이너는 보고서 문서에 대한 목차 추가를 지원하지 않습니다. Reporting Services용 Aspose.PDF를 사용하면 목차, 표 또는 그림 목록이 포함된 PDF 문서를 생성하도록 PDF 렌더링에 쉽게 지시할 수 있습니다. 다음 단계에 따라 수행할 수 있습니다.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/bin, where ```<Instance>``` is the directory of the Report Server. If the file does not exist, create it in the ```<Instance>```/bin directory and place the following markup inside.
+Aspose.Pdf.ListSectionStyle.xml 파일이 ```<Instance>```/bin, where ```<Instance>``` is the directory of the Report Server. If the file does not exist, create it in the ```<Instance>```/bin 디렉터리에 있는지 확인하고 그 안에 다음 마크업을 배치합니다.
 
-## Table of Contents
+## 목차
 
-**Example**
+### 예
 
 ```cs
 <ListSection ListType="TableOfContents">
@@ -41,9 +40,9 @@ Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/b
 </ListSection>
 ```
 
-##  List of TableS
+##  테이블 목록
 
-**Example**
+### 예
 
 ```cs
 <ListSection ListType="ListOfTables">
@@ -53,9 +52,9 @@ Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/b
 </ListSection>
 ```
 
-## List of Figures
+## 그림 목록
 
-**Example**
+### 예
 
 ```cs
  <ListSection ListType="ListOfFigures">
@@ -66,40 +65,29 @@ Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/b
 
 ```
 
-Please refer to 'Working with TOC' section of the Aspose.Pdf online documentation.
+Aspose.Pdf 온라인 문서의 'Working with TOC' 섹션을 참조하세요.
 
-**2-** Add report parameter 'IsListSectionSupported' and set the value to be True as shown in the 'List Section' paragraph.
-**3-** Add custom property for your report item you want to be listed in Table of Contents, List of Tables or Figures.
+**2-** 보고서 매개변수 `IsListSectionSupported`을 추가하고 `List Section` 단락에 표시된 대로 값을 True로 설정합니다.
+**3-** 목차, 표 또는 그림 목록에 나열하려는 보고서 항목에 대한 사용자 정의 속성을 추가합니다.
 
-{{% /alert %}}
+```text
+Custom Property Name: IsInList
+Property Value: Boolean
+Custom Property Value: True or False
+```
 
-{{% alert color="primary" %}}
+현재 보고서 항목을 목차나 표 또는 그림 목록의 색인별로 나열하여 표시합니다.
 
-**Custom Property Name** :IsInList
-**Property Value** :Boolean
-**Custom Property Value** : True or False
+```text
+Custom Property Name: Title
+Custom Property Type: String
+```
 
-{{% alert color="primary" %}}
+목차, 표 또는 그림 목록에 표시되는 항목 제목입니다.
 
-Marks the current report item as listed by index in the table of contents, or the list of tables or figures.
+```text
+Custom Property Name: ListLevel
+Custom Property Type: Integer
+```
 
-{{% /alert %}}
-
-**Custom Property Name** : Title
-**Custom Property Type** : String
-
-{{% alert color="primary" %}}
-
-The item title displayed in the table of contents, list of tables or figures.
-{{% /alert %}}
-
-**Custom Property Name** : ListLevel
-**Custom Property Type** : Integer
-
-{{% alert color="primary" %}}
-
-The level of listed items displayed in the table of contents.
-
-{{% /alert %}}
-
-{{% /alert %}}
+목차에 표시되는 나열된 항목의 수준입니다.

--- a/ko/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
+++ b/ko/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
@@ -1,25 +1,25 @@
 ---
-title: 목차, 표 목록 또는 그림
-linktitle: 목차, 표 목록 또는 그림
+title: Table of Contents List of Tables or Figures
+linktitle: Table of Contents List of Tables or Figures
 type: docs
 weight: 10
-url: /ko/reportingservices/table-of-contents-list-of-tables-or-figures/
-description: Aspose.PDF for Reporting Services를 사용하여 PDF 보고서에 목차, 표 목록 또는 그림을 추가하는 방법을 알아보세요.
-lastmod: "2026-06-19"
+url: /reportingservices/table-of-contents-list-of-tables-or-figures/
+description: Learn how to add a Table of Contents, List of Tables, or Figures in PDF reports using Aspose.PDF for Reporting Services.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Designer는 보고서 문서에 목차를 추가하는 것을 지원하지 않습니다. Aspose.Pdf for Reporting Services를 사용하면 PDF 렌더에 목차 또는 표 목록, 그림이 포함된 PDF 문서를 생성하도록 쉽게 지시할 수 있습니다. 다음 단계에 따라 수행할 수 있습니다:
+Report Designer does not support adding table of contents for report documents. With Aspose.PDF for Reporting Services you can easily instruct the PDF render to produce PDF documents with Table of Contents, or List of Tables or Figures. You can do it in the following steps:
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-Aspose.Pdf.ListSectionStyle.xml 파일이 존재하는지 확인하세요 ```<Instance>```/bin, 어디에 ```<Instance>``` 은(는) Report Server의 디렉터리입니다. 파일이 존재하지 않으면 해당 디렉터리에 생성하십시오. ```<Instance>```/bin 디렉터리 안에 다음 마크업을 넣으세요.
+Make sure that Aspose.Pdf.ListSectionStyle.xml file exists in ```<Instance>```/bin, where ```<Instance>``` is the directory of the Report Server. If the file does not exist, create it in the ```<Instance>```/bin directory and place the following markup inside.
 
-## 목차
+## Table of Contents
 
-**예시**
+**Example**
 
 ```cs
 <ListSection ListType="TableOfContents">
@@ -41,9 +41,9 @@ Aspose.Pdf.ListSectionStyle.xml 파일이 존재하는지 확인하세요 ```<In
 </ListSection>
 ```
 
-##  표 목록
+##  List of TableS
 
-**예시**
+**Example**
 
 ```cs
 <ListSection ListType="ListOfTables">
@@ -53,9 +53,9 @@ Aspose.Pdf.ListSectionStyle.xml 파일이 존재하는지 확인하세요 ```<In
 </ListSection>
 ```
 
-## 그림 목록
+## List of Figures
 
-**예시**
+**Example**
 
 ```cs
  <ListSection ListType="ListOfFigures">
@@ -68,40 +68,38 @@ Aspose.Pdf.ListSectionStyle.xml 파일이 존재하는지 확인하세요 ```<In
 
 Please refer to 'Working with TOC' section of the Aspose.Pdf online documentation.
 
-**2-** 보고서 매개변수 'IsListSectionSupported'를 추가하고 'List Section' 단락에 표시된 대로 값을 True로 설정하십시오.
-**3-** 목차, 표 목록 또는 그림에 나열하려는 보고서 항목에 대한 사용자 지정 속성을 추가하십시오.
+**2-** Add report parameter 'IsListSectionSupported' and set the value to be True as shown in the 'List Section' paragraph.
+**3-** Add custom property for your report item you want to be listed in Table of Contents, List of Tables or Figures.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**사용자 지정 속성 이름** :IsInList
-**속성 값** :Boolean
-**사용자 지정 속성 값** : True 또는 False
+**Custom Property Name** :IsInList
+**Property Value** :Boolean
+**Custom Property Value** : True or False
 
 {{% alert color="primary" %}}
 
-현재 보고서 항목을 목차, 표 목록 또는 그림 목록에서 인덱스로 표시합니다.
+Marks the current report item as listed by index in the table of contents, or the list of tables or figures.
 
 {{% /alert %}}
 
-**사용자 정의 속성 이름** : 제목
-**사용자 정의 속성 유형** : 문자열
+**Custom Property Name** : Title
+**Custom Property Type** : String
 
 {{% alert color="primary" %}}
 
-목차, 표 또는 그림 목록에 표시되는 항목 제목입니다.
+The item title displayed in the table of contents, list of tables or figures.
 {{% /alert %}}
 
-**사용자 정의 속성 이름** : 목록 수준
-**맞춤 속성 유형** : 정수
+**Custom Property Name** : ListLevel
+**Custom Property Type** : Integer
 
 {{% alert color="primary" %}}
 
-목차에 표시되는 항목들의 수준입니다.
+The level of listed items displayed in the table of contents.
 
 {{% /alert %}}
 
 {{% /alert %}}
-
-

--- a/ko/reportingservices/features/_index.md
+++ b/ko/reportingservices/features/_index.md
@@ -4,15 +4,14 @@ linktitle: 기능
 type: docs
 weight: 30
 url: /ko/reportingservices/features/
-description: Aspose.PDF for Reporting Services의 주요 기능을 알아보세요. 고급 PDF 렌더링 기능 및 맞춤 설정으로 SSRS 보고서를 강화합니다.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services의 핵심 기능을 확인하십시오. 고급 PDF 렌더링 기능 및 사용자 지정으로 SSRS 보고서를 향상시킵니다.
+lastmod: "2026-07-29"
 ---
 
-**이 섹션에는 다음 주제가 포함됩니다:**
+**이 섹션에는 다음 항목이 포함됩니다:**
+
 - [포괄적인 RDL 지원](/pdf/ko/reportingservices/comprehensive-rdl-support/)
-- [매개변수 보고서 지원](/pdf/ko/reportingservices/parameterized-report-support/)
+- [매개변수화된 보고서 지원](/pdf/ko/reportingservices/parameterized-report-support/)
 - [사용자 지정 보고서 항목 지원](/pdf/ko/reportingservices/custom-report-item-support/)
-- [간편하고 가벼운 배포](/pdf/ko/reportingservices/easy-and-lightweight-deployment/)
+- [간편하고 경량화된 배포](/pdf/ko/reportingservices/easy-and-lightweight-deployment/)
 - [세계 최고 수준의 무료 기술 지원](/pdf/ko/reportingservices/world-class-free-technical-support/)
-
-

--- a/ko/reportingservices/features/_index.md
+++ b/ko/reportingservices/features/_index.md
@@ -1,17 +1,17 @@
 ---
-title: 기능
-linktitle: 기능
+title: 특징
+linktitle: 특징
 type: docs
 weight: 30
-url: /ko/reportingservices/features/
-description: Aspose.PDF for Reporting Services의 핵심 기능을 확인하십시오. 고급 PDF 렌더링 기능 및 사용자 지정으로 SSRS 보고서를 향상시킵니다.
-lastmod: "2026-07-29"
+url: /reportingservices/features/
+description: 보고 서비스용 Aspose.PDF의 주요 기능을 알아보세요. 고급 PDF 렌더링 기능과 사용자 정의를 통해 SSRS 보고서를 향상하세요.
+lastmod: "2021-06-05"
 ---
 
-**이 섹션에는 다음 항목이 포함됩니다:**
+**이 섹션에는 다음 주제가 포함됩니다.**
 
 - [포괄적인 RDL 지원](/pdf/ko/reportingservices/comprehensive-rdl-support/)
 - [매개변수화된 보고서 지원](/pdf/ko/reportingservices/parameterized-report-support/)
-- [사용자 지정 보고서 항목 지원](/pdf/ko/reportingservices/custom-report-item-support/)
-- [간편하고 경량화된 배포](/pdf/ko/reportingservices/easy-and-lightweight-deployment/)
-- [세계 최고 수준의 무료 기술 지원](/pdf/ko/reportingservices/world-class-free-technical-support/)
+- [사용자 정의 보고서 항목 지원](/pdf/ko/reportingservices/custom-report-item-support/)
+- [쉽고 가벼운 배포](/pdf/ko/reportingservices/easy-and-lightweight-deployment/)
+- [세계적 수준의 무료 기술 지원](/pdf/ko/reportingservices/world-class-free-technical-support/)

--- a/ko/reportingservices/features/comprehensive-rdl-support/_index.md
+++ b/ko/reportingservices/features/comprehensive-rdl-support/_index.md
@@ -3,34 +3,34 @@ title: 포괄적인 RDL 지원
 linktitle: 포괄적인 RDL 지원
 type: docs
 weight: 10
-url: /ko/reportingservices/comprehensive-rdl-support/
-description: Aspose.PDF for Reporting Services에서 포괄적인 RDL 지원을 발견하십시오. 복잡한 SQL Server 보고서를 전문적인 PDF로 렌더링합니다.
-lastmod: "2026-07-29"
+url: /reportingservices/comprehensive-rdl-support/
+description: 보고 서비스를 위한 Aspose.PDF에서 포괄적인 RDL 지원을 알아보세요. 복잡한 SQL Server 보고서를 전문적인 PDF로 렌더링합니다.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF for Reporting Services는 RDL 사양을 지원합니다. 이는 다음을 의미합니다:
+Reporting Services용 Aspose.PDF는 RDL 사양을 지원합니다. 그것은 다음을 의미합니다:
 
-* 기존 보고서를 재설계하거나 맞춤화할 필요가 없습니다.
-* 특정 보고서 디자이너를 사용할 필요가 없습니다. 모든 RDL 보고서 디자이너를 사용하면 보고서는 설계한 그대로 정확히 내보내집니다.
+* 기존 보고서를 다시 디자인하거나 사용자 정의할 필요가 없습니다.
+* 특정 보고서 디자이너를 사용할 필요가 없습니다. RDL 보고서 디자이너를 사용할 수 있으며 보고서는 사용자가 디자인한 대로 정확하게 내보내집니다.
 
 {{% /alert %}}
 
-## **지원되는 RDL 요소**
-Aspose.PDF for Reporting Services는 다음 RDL 요소를 지원합니다:
+## 지원되는 RDL 요소
+Reporting Services용 Aspose.PDF는 다음 RDL 요소를 지원합니다.
 
 - 섹션
 - 머리글, 바닥글
 - 텍스트 상자
 - 이미지
 - 차트
-- 목록
-- 표
+- 기울기
+- 테이블
 - 행렬
 - 스타일
 - 직사각형
-- 선
+- 윤곽
 - 하위 보고서
-- 게이지 패널 (RS2008)
-- Tablix (RS2008)
+- 게이지 패널(RS2008)
+- 테이블릭스(RS2008)

--- a/ko/reportingservices/features/comprehensive-rdl-support/_index.md
+++ b/ko/reportingservices/features/comprehensive-rdl-support/_index.md
@@ -4,8 +4,8 @@ linktitle: 포괄적인 RDL 지원
 type: docs
 weight: 10
 url: /ko/reportingservices/comprehensive-rdl-support/
-description: Aspose.PDF for Reporting Services에서 포괄적인 RDL 지원을 확인하십시오. 복잡한 SQL Server 보고서를 전문가 수준의 PDF로 변환합니다.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services에서 포괄적인 RDL 지원을 발견하십시오. 복잡한 SQL Server 보고서를 전문적인 PDF로 렌더링합니다.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
@@ -13,7 +13,7 @@ lastmod: "2026-06-19"
 Aspose.PDF for Reporting Services는 RDL 사양을 지원합니다. 이는 다음을 의미합니다:
 
 * 기존 보고서를 재설계하거나 맞춤화할 필요가 없습니다.
-* 특정 보고서 디자이너를 사용할 필요가 없습니다. 원하는 RDL 보고서 디자이너를 사용하면 설계한 그대로 보고서가 내보내집니다.
+* 특정 보고서 디자이너를 사용할 필요가 없습니다. 모든 RDL 보고서 디자이너를 사용하면 보고서는 설계한 그대로 정확히 내보내집니다.
 
 {{% /alert %}}
 
@@ -29,10 +29,8 @@ Aspose.PDF for Reporting Services는 다음 RDL 요소를 지원합니다:
 - 표
 - 행렬
 - 스타일
-- 사각형
+- 직사각형
 - 선
-- 서브 보고서
+- 하위 보고서
 - 게이지 패널 (RS2008)
 - Tablix (RS2008)
-
-

--- a/ko/reportingservices/features/custom-report-item-support/_index.md
+++ b/ko/reportingservices/features/custom-report-item-support/_index.md
@@ -1,23 +1,21 @@
 ---
-title: 사용자 지정 보고서 항목 지원
-linktitle: 사용자 지정 보고서 항목 지원
+title: 사용자 정의 보고서 항목 지원
+linktitle: 사용자 정의 보고서 항목 지원
 type: docs
 weight: 30
 url: /ko/reportingservices/custom-report-item-support/
-description: Aspose.PDF for Reporting Services에서 사용자 지정 보고서 항목 지원을 활용하십시오. 맞춤형 고품질 PDF 출력을 손쉽게 달성할 수 있습니다.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services의 사용자 정의 보고서 항목 지원을 활용하십시오. 맞춤형이며 고품질의 PDF 출력을 손쉽게 달성할 수 있습니다.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-RS2016, RS2017, RS2019, RS2022 및 Power BI에 대한 RDL 사양에서 거의 모든 보고서 항목은 사용자 지정 속성을 추가하여 확장할 수 있습니다. 현재 Aspose.PDF for Reporting Services 2016, 2017, 2019, 2022 및 Power BI는 다음과 같은 세 가지 속성을 지원합니다:
+RS2016, RS2017, RS2019, RS2022 및 Power BI용 RDL 사양에서는 거의 모든 보고서 항목에 사용자 정의 속성을 추가하여 확장할 수 있습니다. 현재 Aspose.PDF for Reporting Services 2016, 2017, 2019, 2022 및 Power BI는 다음과 같은 세 가지 속성을 지원합니다:
 
 - 목차, 표 또는 그림 목록.
-- 라인 화살표.
-- 각주/끝주석.
+- 선 화살표.
+- 각주/미주.
 
-그들을 사용하는 방법을 알아보세요 [보고서 항목 속성 확장](/pdf/ko/reportingservices/expand-report-items-properties/) 기사.
+그들을 사용하는 방법을 알아보세요 [보고서 항목 속성 확장](/pdf/ko/reportingservices/expand-report-items-properties/) 문서.
 
 {{% /alert %}}
-
-

--- a/ko/reportingservices/features/custom-report-item-support/_index.md
+++ b/ko/reportingservices/features/custom-report-item-support/_index.md
@@ -3,19 +3,19 @@ title: 사용자 정의 보고서 항목 지원
 linktitle: 사용자 정의 보고서 항목 지원
 type: docs
 weight: 30
-url: /ko/reportingservices/custom-report-item-support/
-description: Aspose.PDF for Reporting Services의 사용자 정의 보고서 항목 지원을 활용하십시오. 맞춤형이며 고품질의 PDF 출력을 손쉽게 달성할 수 있습니다.
-lastmod: "2026-07-29"
+url: /reportingservices/custom-report-item-support/
+description: Reporting Services를 위해 Aspose.PDF의 사용자 정의 보고서 항목 지원을 활용하세요. 맞춤형 고품질 PDF 출력을 쉽게 얻을 수 있습니다.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-RS2016, RS2017, RS2019, RS2022 및 Power BI용 RDL 사양에서는 거의 모든 보고서 항목에 사용자 정의 속성을 추가하여 확장할 수 있습니다. 현재 Aspose.PDF for Reporting Services 2016, 2017, 2019, 2022 및 Power BI는 다음과 같은 세 가지 속성을 지원합니다:
+RS2016, RS2017, RS2019, RS2022 및 Power BI용 RDL 사양에서는 사용자 지정 속성을 추가하여 거의 모든 보고서 항목을 확장할 수 있습니다. 현재 Reporting Services 2016, 2017, 2019, 2022용 Aspose.PDF 및 Power BI는 다음과 같은 세 가지 속성을 지원합니다.
 
 - 목차, 표 또는 그림 목록.
 - 선 화살표.
 - 각주/미주.
 
-그들을 사용하는 방법을 알아보세요 [보고서 항목 속성 확장](/pdf/ko/reportingservices/expand-report-items-properties/) 문서.
+에서 사용 방법을 알아보세요. [보고서 항목 속성 확장](/pdf/ko/reportingservices/expand-report-items-properties/) 기사.
 
 {{% /alert %}}

--- a/ko/reportingservices/features/easy-and-lightweight-deployment/_index.md
+++ b/ko/reportingservices/features/easy-and-lightweight-deployment/_index.md
@@ -1,14 +1,14 @@
 ---
-title: 쉽고 가벼운 배포
-linktitle: 쉽고 가벼운 배포
+title: 간편하고 가벼운 배포
+linktitle: 간편하고 가벼운 배포
 type: docs
 weight: 40
 url: /ko/reportingservices/easy-and-lightweight-deployment/
-description: 최소한의 노력으로 Aspose.PDF for Reporting Services를 배포하는 방법을 배우세요. 가벼운 설정으로 빠른 구현과 효율성을 보장합니다.
-lastmod: "2026-06-19"
+description: 최소한의 노력으로 Aspose.PDF for Reporting Services를 배포하는 방법을 알아보세요. 가벼운 설정으로 빠른 구현과 효율성을 보장합니다.
+lastmod: "2026-07-29"
 ---
 
-**Aspose.Pdf for Reporting Services**는 Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 및 Power BI Report Server용 맞춤형 렌더링 확장 기능입니다. Aspose.Pdf for Reporting Services는 다음 중 하나를 실행하는 컴퓨터에 설치할 수 있는 단일 MSI 설치 프로그램으로 제공됩니다.
+**Aspose.PDF for Reporting Services**는 Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 및 Power BI Report Server용 맞춤형 렌더링 확장 기능입니다. Aspose.PDF for Reporting Services는 다음 중 하나를 실행하는 컴퓨터에 설치할 수 있는 단일 MSI 설치 프로그램으로 제공됩니다:
 
 - Microsoft SQL Server 2016 Reporting Services  
 - Microsoft SQL Server 2017 Reporting Services  
@@ -16,8 +16,6 @@ lastmod: "2026-06-19"
 - Microsoft SQL Server 2022 Reporting Services  
 - Microsoft Power BI Report Server
  
-Aspose.Pdf for Reporting Services는 배포 및 관리가 쉽습니다. 이는 하나의 .NET 어셈블리인 Aspose.Pdf.ReportingServices.dll만으로 구성되며, 완전히 C# 로 작성되고 CLS 규격을 준수하며 안전한 관리 코드만을 포함하기 때문입니다. 서버에 .NET Framework 4.8.1이 설치되어 있어야 합니다.
+Aspose.PDF for Reporting Services는 배포 및 관리가 쉽습니다. 이는 단 하나의 .NET 어셈블리인 Aspose.Pdf.ReportingServices.dll로 구성되며, 완전히 C#로 작성되고 CLS를 준수하고 안전한 관리 코드만 포함하기 때문입니다. 서버에 .NET Framework 4.8.1이 설치되어 있어야 합니다.
 
-Aspose.Pdf.ReportingServices.dll은 ReportServer\bin 디렉터리에 복사되어야 하며, Reporting Services가 새로운 렌더링 확장을 인식하도록 구성 파일을 업데이트해야 합니다. 이러한 단계는 Aspose.Pdf for Reporting Services 설치 프로그램에 의해 수행되지만, 이 문서에 설명된 대로 수동으로 수행할 수도 있습니다.
-
-
+Aspose.Pdf.ReportingServices.dll을 ReportServer\bin 디렉터리로 복사하고, Reporting Services가 새로운 렌더링 확장을 인식하도록 구성 파일을 업데이트해야 합니다. 이러한 단계는 Aspose.PDF for Reporting Services 설치 프로그램에 의해 수행되지만, 이 문서에 자세히 설명된 대로 수동으로 수행할 수도 있습니다.

--- a/ko/reportingservices/features/easy-and-lightweight-deployment/_index.md
+++ b/ko/reportingservices/features/easy-and-lightweight-deployment/_index.md
@@ -1,21 +1,21 @@
 ---
-title: 간편하고 가벼운 배포
-linktitle: 간편하고 가벼운 배포
+title: 쉽고 가벼운 배포
+linktitle: 쉽고 가벼운 배포
 type: docs
 weight: 40
-url: /ko/reportingservices/easy-and-lightweight-deployment/
-description: 최소한의 노력으로 Aspose.PDF for Reporting Services를 배포하는 방법을 알아보세요. 가벼운 설정으로 빠른 구현과 효율성을 보장합니다.
-lastmod: "2026-07-29"
+url: /reportingservices/easy-and-lightweight-deployment/
+description: 최소한의 노력으로 Reporting Services용 Aspose.PDF를 배포하는 방법을 알아보세요. 경량 설정으로 빠른 구현과 효율성이 보장됩니다.
+lastmod: "2021-06-05"
 ---
 
-**Aspose.PDF for Reporting Services**는 Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 및 Power BI Report Server용 맞춤형 렌더링 확장 기능입니다. Aspose.PDF for Reporting Services는 다음 중 하나를 실행하는 컴퓨터에 설치할 수 있는 단일 MSI 설치 프로그램으로 제공됩니다:
+**Reporting Services용 Aspose.PDF**는 Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 및 Power BI Report Server용 사용자 지정 렌더링 확장 프로그램입니다. Reporting Services용 Aspose.PDF는 다음 중 하나를 실행하는 컴퓨터에 설치할 수 있는 단일 MSI 설치 프로그램으로 제공됩니다.
 
-- Microsoft SQL Server 2016 Reporting Services  
-- Microsoft SQL Server 2017 Reporting Services  
-- Microsoft SQL Server 2019 Reporting Services  
-- Microsoft SQL Server 2022 Reporting Services  
-- Microsoft Power BI Report Server
+- Microsoft SQL Server 2016 보고 서비스  
+- Microsoft SQL Server 2017 보고 서비스  
+- Microsoft SQL Server 2019 보고 서비스  
+- Microsoft SQL Server 2022 보고 서비스  
+- Microsoft Power BI 보고서 서버
  
-Aspose.PDF for Reporting Services는 배포 및 관리가 쉽습니다. 이는 단 하나의 .NET 어셈블리인 Aspose.Pdf.ReportingServices.dll로 구성되며, 완전히 C#로 작성되고 CLS를 준수하고 안전한 관리 코드만 포함하기 때문입니다. 서버에 .NET Framework 4.8.1이 설치되어 있어야 합니다.
+Reporting Services용 Aspose.PDF는 단 하나의 .NET 어셈블리 Aspose.Pdf.ReportingServices.dll로 구성되어 있고 완전히 C#으로 작성되었으며 CLS 규격을 준수하고 안전한 관리 코드만 포함하고 있으므로 배포 및 관리가 쉽습니다. 서버에 .NET Framework 4.8.1이 설치되어 있어야 합니다.
 
-Aspose.Pdf.ReportingServices.dll을 ReportServer\bin 디렉터리로 복사하고, Reporting Services가 새로운 렌더링 확장을 인식하도록 구성 파일을 업데이트해야 합니다. 이러한 단계는 Aspose.PDF for Reporting Services 설치 프로그램에 의해 수행되지만, 이 문서에 자세히 설명된 대로 수동으로 수행할 수도 있습니다.
+Aspose.Pdf.ReportingServices.dll을 ReportServer\bin 디렉터리에 복사해야 하며 Reporting Services가 새 렌더링 확장 프로그램을 인식할 수 있도록 구성 파일을 업데이트해야 합니다. 이러한 단계는 Reporting Services용 Aspose.PDF 설치 프로그램에 의해 수행되지만 이 문서에 추가로 설명된 대로 수동으로 수행할 수도 있습니다.

--- a/ko/reportingservices/features/parameterized-report-support/_index.md
+++ b/ko/reportingservices/features/parameterized-report-support/_index.md
@@ -1,27 +1,27 @@
 ---
-title: 매개변수 보고서 지원
-linktitle: 매개변수 보고서 지원
+title: 매개변수화된 보고서 지원
+linktitle: 매개변수화된 보고서 지원
 type: docs
 weight: 20
-url: /ko/reportingservices/parameterized-report-support/
-lastmod: "2026-07-29"
+url: /reportingservices/parameterized-report-support/
+lastmod: "2021-06-05"
 ---
 
-매개변수 보고서는 보고서 처리를 위해 사용되는 입력 값을 수락하는 보고서입니다. 매개변수 보고서를 사용하면 보고서 실행 시 설정된 값에 따라 보고서의 출력을 다양하게 할 수 있습니다. Aspose.PDF for Reporting Services는 두 종류의 매개변수를 지원합니다: 보고서 서버 매개변수와 보고서 매개변수. 보고서 서버 매개변수는 보고서 서버의 모든 보고서에 사용됩니다. 특정 보고서에 적합한 매개변수를 만들고 싶다면 보고서 매개변수를 사용해야 합니다.
+매개변수화된 보고서는 보고서 처리에 사용되는 입력 값을 받아들이는 보고서입니다. 매개 변수가 있는 보고서를 사용하면 보고서가 실행될 때 설정되는 값을 기반으로 보고서 출력을 다양화할 수 있습니다. Reporting Services용 Aspose.PDF는 보고서 서버 매개 변수와 보고서 매개 변수라는 두 가지 매개 변수를 지원합니다. 보고서 서버 매개 변수는 보고서 서버의 모든 보고서에 사용됩니다. 일부 매개변수를 특정 보고서에 적합하게 만들려면 보고서 매개변수를 사용해야 합니다.
 
-현재, Aspose.PDF 렌더러는 다음과 같은 다양한 매개변수를 지원합니다:
+현재 Aspose.Pdf 렌더러는 다음과 같은 광범위한 매개변수를 지원합니다.
 
-## **지원되는 매개변수**
-현재 버전에서는 Aspose.PDF 렌더가 매개변수의 여러 측면을 지원하며, 그 내용은 다음과 같습니다:
+## 지원되는 매개변수
+현재 버전에서 Aspose.PDF 렌더링은 다음과 같은 매개변수의 다양한 측면을 지원합니다.
 
 - 페이지 방향
-- HTML 서식
+- HTML 형식
 - 보안 속성
 - 페이지 크기
 - 페이지 여백 크기
-- 글꼴 임베딩
-- PDF/A 적합성
+- 글꼴 삽입
+- PDF/A 규격
 - XMP 메타데이터
 - 디버그 정보
 
-매개변수에 대해 자세히 알아보려면 [Aspose.PDF for Reporting Services 구성](/pdf/ko/reportingservices/configure-aspose-pdf-for-reporting-services/) 문서.
+매개변수에 대한 자세한 내용은 [보고 서비스를 위한 Aspose.PDF 구성](/pdf/ko/reportingservices/configure-aspose-pdf-for-reporting-services/) 기사.

--- a/ko/reportingservices/features/parameterized-report-support/_index.md
+++ b/ko/reportingservices/features/parameterized-report-support/_index.md
@@ -4,26 +4,24 @@ linktitle: 매개변수 보고서 지원
 type: docs
 weight: 20
 url: /ko/reportingservices/parameterized-report-support/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-매개변수 보고서는 보고서 처리에 사용되는 입력 값을 받아들이는 보고서입니다. 매개변수 보고서를 사용하면 보고서 실행 시 설정된 값에 따라 보고서 출력이 달라질 수 있습니다. Aspose.Pdf for Reporting Services는 두 가지 종류의 매개변수를 지원합니다: 보고서 서버 매개변수와 보고서 매개변수. 보고서 서버 매개변수는 보고서 서버의 모든 보고서에 사용됩니다. 특정 보고서에 적합한 매개변수를 만들고 싶다면 보고서 매개변수를 사용해야 합니다.
+매개변수 보고서는 보고서 처리를 위해 사용되는 입력 값을 수락하는 보고서입니다. 매개변수 보고서를 사용하면 보고서 실행 시 설정된 값에 따라 보고서의 출력을 다양하게 할 수 있습니다. Aspose.PDF for Reporting Services는 두 종류의 매개변수를 지원합니다: 보고서 서버 매개변수와 보고서 매개변수. 보고서 서버 매개변수는 보고서 서버의 모든 보고서에 사용됩니다. 특정 보고서에 적합한 매개변수를 만들고 싶다면 보고서 매개변수를 사용해야 합니다.
 
-현재 Aspose.Pdf 렌더러는 다음과 같은 다양한 매개변수를 지원합니다:
+현재, Aspose.PDF 렌더러는 다음과 같은 다양한 매개변수를 지원합니다:
 
 ## **지원되는 매개변수**
-현재 버전에서는 Aspose.PDF 렌더가 매개변수의 다양한 측면을 지원하며, 그 내용은 다음과 같습니다:
+현재 버전에서는 Aspose.PDF 렌더가 매개변수의 여러 측면을 지원하며, 그 내용은 다음과 같습니다:
 
 - 페이지 방향
 - HTML 서식
 - 보안 속성
 - 페이지 크기
 - 페이지 여백 크기
-- 글꼴 포함
-- PDF/A 준수
+- 글꼴 임베딩
+- PDF/A 적합성
 - XMP 메타데이터
 - 디버그 정보
 
-다음에서 매개변수에 대해 자세히 알아보세요 [Aspose.PDF for Reporting Services 구성](/pdf/ko/reportingservices/configure-aspose-pdf-for-reporting-services/) 문서.
-
-
+매개변수에 대해 자세히 알아보려면 [Aspose.PDF for Reporting Services 구성](/pdf/ko/reportingservices/configure-aspose-pdf-for-reporting-services/) 문서.

--- a/ko/reportingservices/features/world-class-free-technical-support/_index.md
+++ b/ko/reportingservices/features/world-class-free-technical-support/_index.md
@@ -4,19 +4,18 @@ linktitle: 세계 수준의 무료 기술 지원
 type: docs
 weight: 50
 url: /ko/reportingservices/world-class-free-technical-support/
-description: Aspose.PDF for Reporting Services에 대한 세계 수준의 무료 기술 지원을 즐기세요. 필요할 때 언제든지 전문가의 도움을 받을 수 있습니다.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services에 대한 세계 수준의 무료 기술 지원을 누리세요. 필요할 때 언제든 전문가의 도움을 받을 수 있습니다.
+lastmod: "2026-07-29"
 ---
 
-Aspose는 무료이면서 무제한인 기술 지원으로 유명하며, 이는 기술 문서, 매뉴얼, 포럼 및 언제나 준비된 지원과 제품 개발자들이 뒷받침합니다. 제품의 새 버전이나 핫픽스가 출시될 경우, 활성 구독이 있는 경우 모든 새로운 릴리스를 비용 없이 이용할 수 있습니다.
+Aspose는 무료이면서 무제한인 기술 지원으로 유명하며, 이는 기술 문서, 매뉴얼, 포럼 및 언제든지 준비된 지원과 제품 개발자들에 의해 뒷받침됩니다. 제품의 새로운 버전이나 핫픽스가 출시될 경우, 활성 구독이 있으면 모든 새 릴리스를 무료로 이용할 수 있습니다.
 
-**Aspose.Support Forums**는 기술 문제를 해결할 뿐만 아니라 활기차고 성장하는 Aspose 사용자 커뮤니티와 함께 개발 토론에 참여할 수 있는 장소입니다. 현재 Aspose 웹사이트에 등록된 사용자는 129,000명 이상입니다.
+**Aspose.Support Forums**는 기술 문제를 해결할 뿐만 아니라 활기차고 성장하는 Aspose 사용자 커뮤니티와 개발 논의에 참여할 수 있는 장소입니다. 현재 Aspose 웹 사이트에 등록된 사용자는 129,000명 이상입니다.
 
-Aspose.Blogs는 최신 릴리스에 대한 정보와 Aspose 개발자들의 의견을 확인할 수 있는 곳입니다.
+Aspose.Blogs는 최신 릴리스 정보와 Aspose 개발자들의 의견을 확인할 수 있는 곳입니다.
 
-Aspose.Support Forums에는 다양한 활동이 있습니다:
+Aspose.Support Forums에서는 다양한 활동이 이루어지고 있습니다:
 
 ![todo:image_alt_text](world-class-free-technical-support.png)
 
  
-

--- a/ko/reportingservices/features/world-class-free-technical-support/_index.md
+++ b/ko/reportingservices/features/world-class-free-technical-support/_index.md
@@ -1,21 +1,21 @@
 ---
-title: 세계 수준의 무료 기술 지원
-linktitle: 세계 수준의 무료 기술 지원
+title: 세계적 수준의 무료 기술 지원
+linktitle: 세계적 수준의 무료 기술 지원
 type: docs
 weight: 50
-url: /ko/reportingservices/world-class-free-technical-support/
-description: Aspose.PDF for Reporting Services에 대한 세계 수준의 무료 기술 지원을 누리세요. 필요할 때 언제든 전문가의 도움을 받을 수 있습니다.
-lastmod: "2026-07-29"
+url: /reportingservices/world-class-free-technical-support/
+description: 보고 서비스용 Aspose.PDF에 대한 세계적 수준의 무료 기술 지원을 즐겨보세요. 필요할 때마다 전문가의 도움을 받으세요.
+lastmod: "2021-06-05"
 ---
 
-Aspose는 무료이면서 무제한인 기술 지원으로 유명하며, 이는 기술 문서, 매뉴얼, 포럼 및 언제든지 준비된 지원과 제품 개발자들에 의해 뒷받침됩니다. 제품의 새로운 버전이나 핫픽스가 출시될 경우, 활성 구독이 있으면 모든 새 릴리스를 무료로 이용할 수 있습니다.
+Aspose는 기술 기사, 매뉴얼, 포럼, 상시 지원 및 제품 개발자의 지원을 받는 무료 무제한 기술 지원으로 유명합니다. 새 버전이 있거나 제품의 핫픽스가 출시되는 경우 활성 구독이 있는 경우 모든 새 릴리스를 무료로 사용할 수 있습니다.
 
-**Aspose.Support Forums**는 기술 문제를 해결할 뿐만 아니라 활기차고 성장하는 Aspose 사용자 커뮤니티와 개발 논의에 참여할 수 있는 장소입니다. 현재 Aspose 웹 사이트에 등록된 사용자는 129,000명 이상입니다.
+**Aspose.Support 포럼**은 기술적인 문제를 해결할 뿐만 아니라 활기차고 성장하는 Aspose 사용자 커뮤니티와의 개발 토론에 참여할 수 있는 장소입니다. 현재 Aspose 웹사이트에는 129,000명 이상의 사용자가 등록되어 있습니다.
 
-Aspose.Blogs는 최신 릴리스 정보와 Aspose 개발자들의 의견을 확인할 수 있는 곳입니다.
+Aspose.Blogs는 최신 릴리스에 대한 정보와 Aspose 개발자의 의견을 찾을 수 있는 곳입니다.
 
-Aspose.Support Forums에서는 다양한 활동이 이루어지고 있습니다:
+Aspose.Support 포럼에는 다양한 활동이 있습니다:
 
-![todo:image_alt_text](world-class-free-technical-support.png)
+![Free Technical Support](world-class-free-technical-support.png)
 
  

--- a/ko/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
+++ b/ko/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
@@ -1,19 +1,17 @@
 ---
-title: Aspose.PDF 설치
-linktitle: Aspose.PDF 설치
+title: Aspose.PDF를 설치하세요.
+linktitle: Aspose.PDF를 설치하세요.
 type: docs
 weight: 50
-url: /ko/reportingservices/install-aspose-pdf-for-reporting-services/
-description: Aspose.PDF for Reporting Services 설치 방법을 알아보세요. SSRS에서 PDF 내보내기 기능을 활성화하는 단계별 가이드를 따라하세요.
-lastmod: "2026-07-29"
+url: /reportingservices/install-aspose-pdf-for-reporting-services/
+description: Reporting Services용 Aspose.PDF를 설치하는 방법을 알아보세요. SSRS에서 PDF 내보내기 기능을 활성화하려면 이 단계별 가이드를 따르세요.
+lastmod: "2021-06-05"
 ---
 
-{{% alert color="primary" %}}
+**이 섹션에는 다음 주제가 포함됩니다.**
 
-**이 섹션에는 다음 주제가 포함됩니다:**
+- [MSI 설치 프로그램으로 설치](/pdf/reportingservices/install-with-msi-installer/)
+- [수동 설치](/pdf/reportingservices/install-manually/)
+- [구성 도구로 설치](/pdf/reportingservices/install-with-configuring-tool/)
 
-- [MSI 설치 프로그램으로 설치](/pdf/ko/reportingservices/install-with-msi-installer/)
-- [수동 설치](/pdf/ko/reportingservices/install-manually/)
-- [구성 도구로 설치](/pdf/ko/reportingservices/install-with-configuring-tool/)
 
-{{% /alert %}}

--- a/ko/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
+++ b/ko/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
@@ -4,18 +4,16 @@ linktitle: Aspose.PDF 설치
 type: docs
 weight: 50
 url: /ko/reportingservices/install-aspose-pdf-for-reporting-services/
-description: Reporting Services용 Aspose.PDF를 설치하는 방법을 알아보세요. SSRS에서 PDF 내보내기 기능을 활성화하는 단계별 가이드를 따라하십시오.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services 설치 방법을 알아보세요. SSRS에서 PDF 내보내기 기능을 활성화하는 단계별 가이드를 따라하세요.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
 **이 섹션에는 다음 주제가 포함됩니다:**
 
-- [MSI 설치 관리자를 사용하여 설치](/pdf/ko/reportingservices/install-with-msi-installer/)
+- [MSI 설치 프로그램으로 설치](/pdf/ko/reportingservices/install-with-msi-installer/)
 - [수동 설치](/pdf/ko/reportingservices/install-manually/)
-- [설정 도구로 설치](/pdf/ko/reportingservices/install-with-configuring-tool/)
+- [구성 도구로 설치](/pdf/ko/reportingservices/install-with-configuring-tool/)
 
 {{% /alert %}}
-
-

--- a/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
+++ b/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
@@ -4,12 +4,10 @@ linktitle: 수동으로 설치
 type: docs
 weight: 20
 url: /ko/reportingservices/install-manually/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 **이 섹션에는 다음 주제가 포함됩니다:**
 
 - [보고서 서버에 설치](/pdf/ko/reportingservices/install-to-report-server/)
-
-
 

--- a/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
+++ b/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
@@ -3,11 +3,11 @@ title: 수동으로 설치
 linktitle: 수동으로 설치
 type: docs
 weight: 20
-url: /ko/reportingservices/install-manually/
-lastmod: "2026-07-29"
+url: /reportingservices/install-manually/
+lastmod: "2021-06-05"
 ---
 
-**이 섹션에는 다음 주제가 포함됩니다:**
+**이 섹션에는 다음 주제가 포함됩니다.**
 
-- [보고서 서버에 설치](/pdf/ko/reportingservices/install-to-report-server/)
+- [보고서 서버에 설치](/pdf/reportingservices/install-to-report-server/)
 

--- a/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
+++ b/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
@@ -1,40 +1,40 @@
 ---
-title: Report Server에 설치
-linktitle: Report Server에 설치
+title: Install to Report Server
+linktitle: Install to Report Server
 type: docs
 weight: 10
-url: /ko/reportingservices/install-to-report-server/
-lastmod: "2026-06-19"
+url: /reportingservices/install-to-report-server/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF for Reporting Services를 수동으로 설치하고 MSI 설치 프로그램을 사용하지 않는 경우에만 다음 단계를 따라야 합니다. MSI 설치 프로그램은 필요한 모든 설치 및 등록 작업을 자동으로 수행합니다.
+You only need to follow these steps if you install Aspose.PDF for Reporting Services manually, not using the MSI installer. MSI installer performs all necessary installation and registration actions automatically.
 
 {{% /alert %}}
 
-다음 단계에서는 Microsoft SQL Server Reporting Services가 설치된 디렉터리에서 파일을 복사하고 수정해야 합니다. SSRS 2016 어셈블리는 zip 패키지의 \Bin\SSRS2016 디렉터리에 있습니다; SSRS 2017 어셈블리는 \Bin\SSRS2017 디렉터리에 있습니다; SSRS 2019 어셈블리는 \Bin\SSRS2019 디렉터리에 있습니다; SSRS 2022 어셈블리는 \Bin\SSRS2022 디렉터리에 있습니다; Power BI Report Server 어셈블리는 \Bin\PowerBI 디렉터리에 있습니다. 
+In the following steps, you will need to copy and modify files in the directory where Microsoft SQL Server Reporting Services is installed. The SSRS 2016 assembly is located in the \Bin\SSRS2016 directory of the zip package; the SSRS 2017 assembly is located in the \Bin\SSRS2017 directory; the SSRS 2019 assembly is located in the \Bin\SSRS2019 directory; the SSRS 2022 assembly is located in the \Bin\SSRS2022 directory; the Power BI Report Server assembly is located in the \Bin\PowerBI directory. 
 
 {{% alert color="primary" %}}
 
-**Step 1.** Report Server 설치 디렉터리를 찾습니다. Microsoft SQL Server의 루트 디렉터리는 일반적으로 C:\Program Files\Microsoft SQL Server입니다. Reporting Services 2016, Reporting Services 2017 이후 버전 및 Power BI Report Server에 따라 추가 절차가 약간 다릅니다:
+**Step 1.** Locate the Report Server installation directory. The root directory for Microsoft SQL Server is usually C:\Program Files\Microsoft SQL Server. Further process is slightly different for Reporting Services 2016, Reporting Services 2017 and later, and Power BI Report Server:
 
-- Report Server 2016는 기본적으로 C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer 디렉터리에 설치됩니다. 기본 인스턴스 대신 사용자 지정 명명된 인스턴스를 사용하는 경우 기본 경로는 C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer가 됩니다.
-- Report Server 2017 및 이후 버전은 기본적으로 C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer 디렉터리에 설치됩니다.
-- Power BI Report Server는 기본적으로 C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer 디렉터리에 설치됩니다.
+- Report Server 2016 by default is installed in the C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer directory. If you are using custom named instances instead of the default one, the default path will be C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
+- Report Server 2017 and later by default is installed in the C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer directory.
+- Power BI Report Server by default is installed in the C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer directory.
 
-다음 텍스트에서는 보고 서비스(앞에서 언급한 경로 중 하나)의 설치 디렉터리를 다음과 같이 참조합니다 ```<Instance>```.
+In the following text the installation directory of the Reporting Services (one of the aforementioned paths) will be referenced to as ```<Instance>```.
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**2단계.** 해당 SSRS 버전에 맞는 Aspose.Pdf.ReportingServices.dll을 복사하여 ```<Instance>```\bin 폴더.
+**Step 2.** Copy Aspose.Pdf.ReportingServices.dll for the corresponding SSRS version to the ```<Instance>```\bin folder.
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Step 3.** Aspose.Pdf for Reporting Services를 렌더링 확장으로 등록합니다. 열어 ```<Instance>```\rsreportserver.config 파일에 다음 줄을 추가하세요 ```<Render>``` 요소:
+**Step 3.** Register Aspose.PDF for Reporting Services as a rendering extension. Open the ```<Instance>```\rsreportserver.config file and add the following lines into the ```<Render>``` element:
 {{% /alert %}}
 
-**예제**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -49,10 +49,10 @@ Aspose.PDF for Reporting Services를 수동으로 설치하고 MSI 설치 프로
 {{< /highlight >}}
 
 {{% alert color="primary" %}}
-**Step 4.** Aspose.Pdf for Reporting Services에 실행 권한을 제공하십시오. Open the ```<Instance>```\rssrvpolicy.config 파일에 다음 텍스트를 두 번째 외부 항목의 마지막 항목으로 추가합니다. ```<CodeGroup>``` 요소 (이어야 하는 ```<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):```
+**Step 4.** Provide Aspose.PDF for Reporting Services with permissions to execute. Open the ```<Instance>```\rssrvpolicy.config file and add the following text as the last item in the second to outer ```<CodeGroup>``` element (which should be ```<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):```
 {{% /alert %}}
 
-**예시**
+**Example**
 
 {{< highlight csharp >}}
 
@@ -81,19 +81,16 @@ Name="Aspose.Pdf_for_Reporting_Services" Description="This code group grants ful
 {{< /highlight >}}
 
 {{% alert color="primary" %}}
-**Step 5.** Aspose.Pdf for Reporting Services가 성공적으로 설치되었는지 확인합니다. Reporting Services 웹 포털을 열고 보고서에 사용할 수 있는 내보내기 형식 목록을 확인합니다. 웹 브라우저를 시작하고 주소 표시줄에 Reporting Services 웹 포털 URL을 입력하여 웹 포털을 실행할 수 있습니다 (by default it is http://```<Reporting_Services_server_name>```/reports/). 웹 포털에서 사용 가능한 보고서 중 하나를 선택하고 Export 드롭다운 목록을 엽니다. Aspose.Pdf for Reporting Services 확장 기능이 제공하는 형식을 포함한 내보내기 형식 목록이 표시됩니다. PDF via Aspose.PDF 항목을 선택합니다.
+**Step 5.** Verify that Aspose.PDF for Reporting Services was installed successfully. Open the Reporting Services web portal and check the list of available export formats for a report. You can launch the web portal by starting a web browser and typing the Reporting Services web portal URL in the address bar (by default it is http://```<Reporting_Services_server_name>```/reports/). Select one of the reports available in your web portal and pull the Export dropdown list. You should see the list of export formats including the ones provided by the Aspose.PDF for Reporting Services extension. Select PDF via Aspose.PDF item.
 
  
 {{% /alert %}}
 
 ![todo:image_alt_text](install-to-report-server_1.png)
 
-선택한 항목을 클릭합니다. 선택한 형식으로 보고서를 생성하고 클라이언트에 전송합니다. 웹 브라우저 설정에 따라 내보낸 보고서를 저장할 위치를 선택하는 저장 파일 대화 상자를 표시하거나 자동으로 파일을 다운로드 폴더(Downloads)로 다운로드합니다.
+Click the selected item. It will generate the report in the selected format, send it to the client, and, depending on your web browser settings, either show you the Save File dialog to choose where to save the exported report, or automatically download the file to the your Downloads folder.
 
 {{% alert color="primary" %}}
-축하합니다. Aspose.Pdf for Reporting Services를 성공적으로 설치하고 보고서를 PDF 문서로 내보냈습니다!
+Congratulations, you’ve successfully installed Aspose.PDF for Reporting Services and exported a report as a PDF document!
 {{% /alert %}}
-
-
-
 

--- a/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
+++ b/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
@@ -1,6 +1,6 @@
 ---
-title: Install to Report Server
-linktitle: Install to Report Server
+title: 보고서 서버에 설치
+linktitle: 보고서 서버에 설치
 type: docs
 weight: 10
 url: /reportingservices/install-to-report-server/
@@ -9,52 +9,38 @@ lastmod: "2021-06-05"
 
 {{% alert color="primary" %}}
 
-You only need to follow these steps if you install Aspose.PDF for Reporting Services manually, not using the MSI installer. MSI installer performs all necessary installation and registration actions automatically.
+MSI 설치 프로그램을 사용하지 않고 Reporting Services용 Aspose.PDF를 수동으로 설치하는 경우에만 다음 단계를 수행하면 됩니다. MSI 설치 프로그램은 필요한 모든 설치 및 등록 작업을 자동으로 수행합니다.
 
 {{% /alert %}}
 
-In the following steps, you will need to copy and modify files in the directory where Microsoft SQL Server Reporting Services is installed. The SSRS 2016 assembly is located in the \Bin\SSRS2016 directory of the zip package; the SSRS 2017 assembly is located in the \Bin\SSRS2017 directory; the SSRS 2019 assembly is located in the \Bin\SSRS2019 directory; the SSRS 2022 assembly is located in the \Bin\SSRS2022 directory; the Power BI Report Server assembly is located in the \Bin\PowerBI directory. 
+다음 단계에서는 Microsoft SQL Server Reporting Services가 설치된 디렉터리에서 파일을 복사하고 수정해야 합니다. SSRS 2016 어셈블리는 zip 패키지의 \Bin\SSRS2016 디렉터리에 있습니다. SSRS 2017 어셈블리는 \Bin\SSRS2017 디렉터리에 있습니다. SSRS 2019 어셈블리는 \Bin\SSRS2019 디렉터리에 있습니다. SSRS 2022 어셈블리는 \Bin\SSRS2022 디렉터리에 있습니다. Power BI Report Server 어셈블리는 \Bin\PowerBI 디렉터리에 있습니다.
 
-{{% alert color="primary" %}}
+**1단계.** 보고서 서버 설치 디렉터리를 찾습니다. Microsoft SQL Server의 루트 디렉터리는 일반적으로 C:\Program Files\Microsoft SQL Server입니다. Reporting Services 2016, Reporting Services 2017 이상 및 Power BI Report Server의 추가 프로세스는 약간 다릅니다.
 
-**Step 1.** Locate the Report Server installation directory. The root directory for Microsoft SQL Server is usually C:\Program Files\Microsoft SQL Server. Further process is slightly different for Reporting Services 2016, Reporting Services 2017 and later, and Power BI Report Server:
+- 보고서 서버 2016은 기본적으로 C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer 디렉터리에 설치됩니다. 기본 인스턴스 대신 명명된 사용자 지정 인스턴스를 사용하는 경우 기본 경로는 C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer입니다.
+- 보고서 서버 2017 이상은 기본적으로 C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer 디렉터리에 설치됩니다.
+- Power BI Report Server는 기본적으로 C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer 디렉터리에 설치됩니다.
 
-- Report Server 2016 by default is installed in the C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer directory. If you are using custom named instances instead of the default one, the default path will be C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
-- Report Server 2017 and later by default is installed in the C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer directory.
-- Power BI Report Server by default is installed in the C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer directory.
+다음 텍스트에서 보고 서비스의 설치 디렉터리(앞서 언급한 경로 중 하나)는 `<Instance>`으로 참조됩니다.
 
-In the following text the installation directory of the Reporting Services (one of the aforementioned paths) will be referenced to as ```<Instance>```.
-{{% /alert %}}
+**2단계.** 해당 SSRS 버전에 대한 Aspose.Pdf.ReportingServices.dll을 `<Instance>\bin` 폴더에 복사합니다.
 
-{{% alert color="primary" %}}
-**Step 2.** Copy Aspose.Pdf.ReportingServices.dll for the corresponding SSRS version to the ```<Instance>```\bin folder.
-{{% /alert %}}
+**3단계.** Reporting Services용 Aspose.PDF를 렌더링 확장 프로그램으로 등록합니다. `<Instance>\rsreportserver.config` 파일을 열고 `<Render>` 요소에 다음 줄을 추가합니다.
 
-{{% alert color="primary" %}}
-**Step 3.** Register Aspose.PDF for Reporting Services as a rendering extension. Open the ```<Instance>```\rsreportserver.config file and add the following lines into the ```<Render>``` element:
-{{% /alert %}}
+## 예
 
-**Example**
-
-{{< highlight csharp >}}
-
- <Render>
+```xml
+<Render>
 ...
-<!--Start here.-->
-
 <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices"/>
-
 </Render>
+```
 
-{{< /highlight >}}
+**4단계.** 실행 권한이 있는 Reporting Services용 Aspose.PDF를 제공합니다. `<Instance>\rssrvpolicy.config` 파일을 열고 다음 텍스트를 `<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):`이어야 하는 외부 `<CodeGroup>` 요소의 두 번째 마지막 항목으로 추가합니다.
 
-{{% alert color="primary" %}}
-**Step 4.** Provide Aspose.PDF for Reporting Services with permissions to execute. Open the ```<Instance>```\rssrvpolicy.config file and add the following text as the last item in the second to outer ```<CodeGroup>``` element (which should be ```<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):```
-{{% /alert %}}
+## 예
 
-**Example**
-
-{{< highlight csharp >}}
+```xml
 
  <CodeGroup>
 ...
@@ -77,20 +63,14 @@ Name="Aspose.Pdf_for_Reporting_Services" Description="This code group grants ful
 </CodeGroup>
 
 </CodeGroup>
+```
 
-{{< /highlight >}}
+**5단계.** Reporting Services용 Aspose.PDF가 성공적으로 설치되었는지 확인합니다. Reporting Services 웹 포털을 열고 보고서에 사용 가능한 내보내기 형식 목록을 확인하세요. 웹 브라우저를 시작하고 주소 표시줄에 보고 서비스 웹 포털 URL(기본적으로 http://@@KEEP_0@@/reports/).)을 입력하여 웹 포털을 시작할 수 있습니다. 웹 포털에서 사용할 수 있는 보고서 중 하나를 선택하고 내보내기 드롭다운 목록을 당겨서 웹 포털을 시작할 수 있습니다. 보고 서비스 확장을 위한 Aspose.PDF에서 제공하는 형식을 포함하여 내보내기 형식 목록이 표시되어야 합니다. Aspose.PDF 항목을 통해 PDF를 선택하세요.
 
-{{% alert color="primary" %}}
-**Step 5.** Verify that Aspose.PDF for Reporting Services was installed successfully. Open the Reporting Services web portal and check the list of available export formats for a report. You can launch the web portal by starting a web browser and typing the Reporting Services web portal URL in the address bar (by default it is http://```<Reporting_Services_server_name>```/reports/). Select one of the reports available in your web portal and pull the Export dropdown list. You should see the list of export formats including the ones provided by the Aspose.PDF for Reporting Services extension. Select PDF via Aspose.PDF item.
+![Install to report server](install-to-report-server_1.png)
 
- 
-{{% /alert %}}
+선택한 항목을 클릭하세요. 선택한 형식으로 보고서를 생성하여 클라이언트에 보내고, 웹 브라우저 설정에 따라 내보낸 보고서를 저장할 위치를 선택할 수 있는 파일 저장 대화 상자를 표시하거나 파일을 다운로드 폴더에 자동으로 다운로드합니다.
 
-![todo:image_alt_text](install-to-report-server_1.png)
+축하합니다. Reporting Services용 Aspose.PDF를 성공적으로 설치하고 보고서를 PDF 문서로 내보냈습니다!
 
-Click the selected item. It will generate the report in the selected format, send it to the client, and, depending on your web browser settings, either show you the Save File dialog to choose where to save the exported report, or automatically download the file to the your Downloads folder.
-
-{{% alert color="primary" %}}
-Congratulations, you’ve successfully installed Aspose.PDF for Reporting Services and exported a report as a PDF document!
-{{% /alert %}}
 

--- a/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
+++ b/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
@@ -1,25 +1,24 @@
 ---
-title: Configuring Tool을 사용하여 설치
-linktitle: Configuring Tool을 사용하여 설치
+title: 구성 도구를 사용하여 설치
+linktitle: 구성 도구를 사용하여 설치
 type: docs
 weight: 30
 url: /ko/reportingservices/install-with-configuring-tool/
-description: 구성 도구를 사용한 Aspose.PDF for Reporting Services 설치 단계별 가이드(원활한 통합을 위해)
-lastmod: "2026-06-19"
+description: 구성 도구를 사용하여 Aspose.PDF for Reporting Services를 원활하게 통합하기 위한 단계별 설치 가이드.
+lastmod: "2026-07-29"
 ---
 
-Aspose.Pdf for Reporting Services Configuring Tool은 지원되는 모든 Report Server(RS) 버전에 대해 Aspose.Pdf for Reporting Services 확장을 구성하는 데 도움을 줄 수 있습니다. 현재 RS2016, RS2017, RS2019, RS2022 및 Power BI Report Server를 지원합니다. Configuring Tool은 .NET Framework 4.8이 필요합니다.
+Aspose.PDF for Reporting Services Configuring Tool은 지원되는 모든 보고서 서버(RS) 버전에 대해 Aspose.PDF for Reporting Services 확장을 구성하는 데 도움을 줍니다. 현재 RS2016, RS2017, RS2019, RS2022 및 Power BI Report Server를 지원합니다. Configuring Tool은 .NET Framework 4.8이 필요합니다.
 
-확장 기능을 설치하고 Report Server에 등록하려면 'Register' 작업 유형을 선택하세요. 확장 기능을 등록 취소하고 제거하려면 'Unregister' 작업 유형을 선택하세요.
+확장 기능을 설치하고 Report Server에 등록하려면 'Register' 작업 유형을 선택하십시오. 확장을 등록 취소하고 제거하려면 'Unregister' 작업 유형을 선택하십시오.
 
 ![todo:image_alt_text](install-with-configuring-tool_1.png)
 
 **다음 단계에서는 이를 자세히 사용하는 방법을 설명합니다:**
 
-1. Aspose.Pdf for Reporting Services 확장 기능의 DLL 파일 경로를 입력하거나 찾아보세요;
+1. Aspose.PDF for Reporting Services 확장 기능의 DLL 파일 경로를 입력하거나 찾아보세요;
 1. 해당 작업 유형을 선택하세요: Register 또는 Unregister;
-1. 구성하려는 Report Server 버전에 해당하는 탭을 선택하십시오. 선택한 DLL 파일이 해당 RS 버전에 맞는지 확인하십시오. 제품의 요청된 버전이 머신에 설치되지 않은 경우, 구성 도구가 팁으로 알려줍니다. 이름이 지정된 RS2016 인스턴스(기본 'MSSQLSERVER'가 아닌)를 위해 확장 기능을 구성하고 있다면, 사용자 정의 인스턴스 이름을 입력한 뒤 'Refresh' 버튼을 누르세요.
-1. 아래 텍스트 상자에 표시된 구성 파일 경로와 이름이 올바른지 확인하십시오. 올바르지 않은 경우, 'Refresh' 버튼을 눌러 RS 인스턴스를 다시 찾을 수 있으며, 또는 직접 수동으로 찾아볼 수 있습니다.
-1. 'Config' 버튼을 누르십시오. 도구가 이제 요청된 구성을 시도하고, 구성이 성공했는지 여부를 알려줄 것입니다.
+1. 구성하려는 Report Server 버전에 해당하는 탭을 선택하십시오. 해당 RS 버전에 맞는 DLL 파일을 선택했는지 확인하십시오. 요청한 제품 버전이 머신에 설치되어 있지 않으면 구성 도구가 팁을 안내합니다. 이름이 지정된 RS2016 인스턴스(기본 \u0027MSSQLSERVER\u0027 인스턴스가 아님)를 위해 확장을 구성하는 경우, 사용자 지정 인스턴스 이름을 입력한 다음 \u0027Refresh\u0027 버튼을 클릭하십시오.
+1. 하단 텍스트 상자에 표시되는 구성 파일 경로와 이름이 올바른지 확인하십시오. 올바르지 않을 경우 \u0027Refresh\u0027 버튼을 눌러 RS 인스턴스를 다시 찾을 수 있으며, 수동으로 찾아볼 수도 있습니다.
+1. \u0027Config\u0027 버튼을 클릭하십시오. 도구가 요청된 구성을 시도하며, 구성 성공 여부를 알려드립니다.
  
-

--- a/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
+++ b/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
@@ -3,22 +3,21 @@ title: 구성 도구를 사용하여 설치
 linktitle: 구성 도구를 사용하여 설치
 type: docs
 weight: 30
-url: /ko/reportingservices/install-with-configuring-tool/
-description: 구성 도구를 사용하여 Aspose.PDF for Reporting Services를 원활하게 통합하기 위한 단계별 설치 가이드.
-lastmod: "2026-07-29"
+url: /reportingservices/install-with-configuring-tool/
+description: 원활한 통합을 위한 구성 도구를 사용하여 Reporting Services용 Aspose.PDF를 설치하는 단계별 가이드입니다.
+lastmod: "2021-06-05"
 ---
 
-Aspose.PDF for Reporting Services Configuring Tool은 지원되는 모든 보고서 서버(RS) 버전에 대해 Aspose.PDF for Reporting Services 확장을 구성하는 데 도움을 줍니다. 현재 RS2016, RS2017, RS2019, RS2022 및 Power BI Report Server를 지원합니다. Configuring Tool은 .NET Framework 4.8이 필요합니다.
+보고 서비스용 Aspose.PDF 구성 도구를 사용하면 지원되는 RS(보고서 서버) 버전에 대해 보고 서비스 확장용 Aspose.PDF를 구성하는 데 도움이 됩니다. 현재 RS2016, RS2017, RS2019, RS2022 및 Power BI Report Server를 지원합니다. 구성 도구에는 .NET Framework 4.8이 필요합니다.
 
-확장 기능을 설치하고 Report Server에 등록하려면 'Register' 작업 유형을 선택하십시오. 확장을 등록 취소하고 제거하려면 'Unregister' 작업 유형을 선택하십시오.
+확장을 설치하고 보고서 서버에 등록하려면 `Register` 작업 유형을 선택합니다. 확장 프로그램을 등록 취소하고 제거하려면 `Unregister` 작업 유형을 선택하세요.
 
-![todo:image_alt_text](install-with-configuring-tool_1.png)
+![Install with configuring tool](install-with-configuring-tool_1.png)
 
-**다음 단계에서는 이를 자세히 사용하는 방법을 설명합니다:**
+**다음 단계에서는 사용 방법을 자세히 설명합니다.**
 
-1. Aspose.PDF for Reporting Services 확장 기능의 DLL 파일 경로를 입력하거나 찾아보세요;
-1. 해당 작업 유형을 선택하세요: Register 또는 Unregister;
-1. 구성하려는 Report Server 버전에 해당하는 탭을 선택하십시오. 해당 RS 버전에 맞는 DLL 파일을 선택했는지 확인하십시오. 요청한 제품 버전이 머신에 설치되어 있지 않으면 구성 도구가 팁을 안내합니다. 이름이 지정된 RS2016 인스턴스(기본 \u0027MSSQLSERVER\u0027 인스턴스가 아님)를 위해 확장을 구성하는 경우, 사용자 지정 인스턴스 이름을 입력한 다음 \u0027Refresh\u0027 버튼을 클릭하십시오.
-1. 하단 텍스트 상자에 표시되는 구성 파일 경로와 이름이 올바른지 확인하십시오. 올바르지 않을 경우 \u0027Refresh\u0027 버튼을 눌러 RS 인스턴스를 다시 찾을 수 있으며, 수동으로 찾아볼 수도 있습니다.
-1. \u0027Config\u0027 버튼을 클릭하십시오. 도구가 요청된 구성을 시도하며, 구성 성공 여부를 알려드립니다.
- 
+1. Reporting Services 확장을 위한 Aspose.PDF의 DLL 파일 경로를 입력하거나 찾아보세요.
+1. 해당 작업 유형을 선택합니다: 등록 또는 등록 취소;
+1. 구성하려는 보고서 서버 버전에 해당하는 탭을 선택하십시오. RS 버전용 DLL 파일을 선택했는지 확인하십시오. 요청한 제품 버전이 시스템에 설치되어 있지 않으면 구성 도구에서 팁을 알려줍니다. 명명된 RS2016 인스턴스(기본 'MSSQLSERVER' 인스턴스 아님)에 대한 확장을 구성하는 경우 사용자 정의 인스턴스 이름을 입력한 후 '새로 고침' 버튼을 누르세요.
+1. 하단 텍스트 상자에 표시된 구성 파일 경로와 이름이 올바른지 확인하십시오. 그렇지 않은 경우 '새로 고침' 버튼을 눌러 RS 인스턴스를 다시 찾거나 수동으로 찾아볼 수 있습니다.
+1. '구성' 버튼을 누르세요. 이제 도구는 요청된 구성을 시도하고 구성의 성공 여부를 알려줍니다.

--- a/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
+++ b/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
@@ -1,24 +1,23 @@
 ---
-title: MSI 설치 프로그램으로 설치
-linktitle: MSI 설치 프로그램으로 설치
+title: MSI Installer로 설치
+linktitle: MSI Installer로 설치
 type: docs
 weight: 10
 url: /ko/reportingservices/install-with-msi-installer/
-description: MSI 설치 프로그램을 사용하여 Aspose.PDF for Reporting Services를 설치하는 방법을 알아보세요. 빠른 설정을 위한 간단한 가이드.
-lastmod: "2026-06-19"
+description: MSI 설치 관리자를 사용하여 Aspose.PDF for Reporting Services를 설치하는 방법을 배웁니다. 빠른 설정을 위한 간단한 가이드.
+lastmod: "2026-07-29"
 ---
 
-MSI 설치 프로그램을 사용하여 Aspose.Pdf for Reporting Services를 설치할 수 있습니다. Aspose.Pdf.ReportingServices.msi 를 실행하고 설치 프로그램이 제공하는 단계에 따라 진행하십시오. 설치 프로그램은 어셈블리와 기타 파일을 지정된 디렉터리로 복사하고 Reporting Services의 기본 인스턴스에 제품을 설치합니다. 'Configure Aspose.Pdf for Reporting Services' 섹션에 설명된 특수 구성 매개변수를 추가하려는 경우가 아니라면 파일을 수동으로 복사하거나 수정할 필요가 없습니다.
+MSI 설치 관리자를 사용하여 Aspose.PDF for Reporting Services를 설치할 수 있습니다. Aspose.Pdf.ReportingServices.msi를 실행하고 설치 관리자가 제공하는 단계에 따라 진행하십시오. 설치 관리자는 어셈블리와 기타 파일을 지정된 디렉터리로 복사하고 Reporting Services의 기본 인스턴스에 제품을 설치합니다. 'Configure Aspose.PDF for Reporting Services' 섹션에 설명된 특수 구성 매개변수를 추가하려는 경우를 제외하고 파일을 수동으로 복사하거나 수정할 필요가 없습니다.
 
-자동 설치는 대부분의 경우에 작동하는 최선의 옵션입니다. 그러나 다음과 같은 상황에서는 제품을 수동으로 설치해야 할 수도 있습니다:
+자동 설치는 대부분의 경우에 작동하는 가장 좋은 옵션입니다. 그러나 다음과 같은 상황에서는 제품을 수동으로 설치해야 할 수도 있습니다:
  
 - I/O 보안 문제로 인해 자동 설치가 실패합니다.
-- Reporting Services 2016의 명명된(기본이 아닌) 인스턴스나 여러 인스턴스에 제품을 설치해야 합니다.
-- 최신 버전으로 업그레이드하면서 MSI installer를 사용해 이전 버전을 제거하고 새 버전을 설치하는 대신 어셈블리만 교체하고 싶을 경우.
+- Reporting Services 2016의 명명된(기본이 아닌) 인스턴스 또는 여러 인스턴스에 제품을 설치해야 합니다.
+- 최신 버전으로 업그레이드하고, MSI 설치 프로그램을 사용해 이전 버전을 제거하고 새 버전을 설치하는 대신 어셈블리만 교체하고 싶습니다.
  
 {{% alert color="primary" %}}
 
-참고: 뒤의 경우에는 오프라인 문서와 같은 다른 구성 요소가 해당 버전으로 업그레이드되지 않을 수 있다는 점에 유의하세요.
+참고: 후자의 경우 (예: 오프라인 문서)와 같은 다른 구성 요소가 해당 버전으로 업그레이드되지 않을 수 있음을 유의하십시오.
 
 {{% /alert %}}
-

--- a/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
+++ b/ko/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
@@ -1,23 +1,23 @@
 ---
-title: MSI Installer로 설치
-linktitle: MSI Installer로 설치
+title: MSI 설치 프로그램으로 설치
+linktitle: MSI 설치 프로그램으로 설치
 type: docs
 weight: 10
-url: /ko/reportingservices/install-with-msi-installer/
-description: MSI 설치 관리자를 사용하여 Aspose.PDF for Reporting Services를 설치하는 방법을 배웁니다. 빠른 설정을 위한 간단한 가이드.
-lastmod: "2026-07-29"
+url: /reportingservices/install-with-msi-installer/
+description: MSI 설치 프로그램을 사용하여 Reporting Services용 Aspose.PDF를 설치하는 방법을 알아보세요. 빠른 설정을 위한 간단한 가이드입니다.
+lastmod: "2021-06-05"
 ---
 
-MSI 설치 관리자를 사용하여 Aspose.PDF for Reporting Services를 설치할 수 있습니다. Aspose.Pdf.ReportingServices.msi를 실행하고 설치 관리자가 제공하는 단계에 따라 진행하십시오. 설치 관리자는 어셈블리와 기타 파일을 지정된 디렉터리로 복사하고 Reporting Services의 기본 인스턴스에 제품을 설치합니다. 'Configure Aspose.PDF for Reporting Services' 섹션에 설명된 특수 구성 매개변수를 추가하려는 경우를 제외하고 파일을 수동으로 복사하거나 수정할 필요가 없습니다.
+MSI 설치 프로그램을 사용하여 Reporting Services용 Aspose.PDF를 설치할 수 있습니다. Aspose.Pdf.ReportingServices.msi를 실행하고 설치 프로그램에서 제공하는 단계를 따릅니다. 설치 프로그램은 어셈블리 및 기타 파일을 지정된 디렉터리에 복사하고 Reporting Services의 기본 인스턴스에 제품을 설치합니다. 'Reporting Services용 Aspose.PDF 구성' 섹션에 설명된 대로 특수 구성 매개변수를 추가하려는 경우가 아니면 파일을 수동으로 복사하거나 수정할 필요가 없습니다.
 
-자동 설치는 대부분의 경우에 작동하는 가장 좋은 옵션입니다. 그러나 다음과 같은 상황에서는 제품을 수동으로 설치해야 할 수도 있습니다:
- 
+자동 설치는 대부분의 경우에 작동하는 최상의 옵션입니다. 그러나 다음과 같은 일부 상황에서는 제품을 수동으로 설치해야 할 수도 있습니다.
+
 - I/O 보안 문제로 인해 자동 설치가 실패합니다.
-- Reporting Services 2016의 명명된(기본이 아닌) 인스턴스 또는 여러 인스턴스에 제품을 설치해야 합니다.
-- 최신 버전으로 업그레이드하고, MSI 설치 프로그램을 사용해 이전 버전을 제거하고 새 버전을 설치하는 대신 어셈블리만 교체하고 싶습니다.
+- Reporting Services 2016의 명명된(기본값 아님) 인스턴스 또는 여러 인스턴스에 제품을 설치해야 합니다.
+- 최신 버전으로 업그레이드하고 이전 버전을 제거하고 MSI 설치 프로그램을 사용하여 새 버전을 설치하는 대신 어셈블리를 교체하려고 합니다.
  
 {{% alert color="primary" %}}
 
-참고: 후자의 경우 (예: 오프라인 문서)와 같은 다른 구성 요소가 해당 버전으로 업그레이드되지 않을 수 있음을 유의하십시오.
+참고: 후자의 경우 해당 버전으로 업그레이드되지 않은 다른 구성 요소(예: 오프라인 설명서)가 발생할 수 있습니다.
 
 {{% /alert %}}

--- a/ko/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
+++ b/ko/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
@@ -1,52 +1,50 @@
 ---
-title: License
-linktitle: License
+title: 특허
+linktitle: 특허
 
 type: docs
 weight: 70
 url: /reportingservices/license-aspose-pdf-for-reporting-services/
-description: Understand licensing options for Aspose.PDF for Reporting Services. Find out how to activate your license and unlock full functionality.
+description: Reporting Services용 Aspose.PDF의 라이선스 옵션을 이해합니다. 라이센스를 활성화하고 전체 기능을 잠금 해제하는 방법을 알아보세요.
 lastmod: "2021-06-05"
 ---
 
-**Aspose.PDF for Reporting Services** evaluation version provide the same set of features as present in Licensed version, except for the evaluation watermark in resultant PDF when using evaluation version. Please visit our website and download the product version and start exploring our product with complete set of features in an evaluation mode.
+**Reporting Services용 Aspose.PDF** 평가판은 평가판 사용 시 결과 PDF에 표시되는 평가 워터마크를 제외하고 라이선스 버전에 있는 것과 동일한 기능 세트를 제공합니다. 당사 웹사이트를 방문하여 제품 버전을 다운로드하고 평가 모드에서 전체 기능 세트를 갖춘 당사 제품을 탐색해 보십시오.
 
-When you are happy with your evaluation, [buy a license](https://purchase.aspose.com/buy). Before purchasing, make sure you understand and agree to the license subscription terms.
+평가가 만족스러우면 [라이선스를 구입](https://purchase.aspose.com/buy)하세요. 구매하기 전에 라이선스 구독 약관을 이해하고 동의해야 합니다.
 
-The license will be available for download from the order page after the order is paid. The license is a clear text, digitally signed XML file. The license contains information such as the client's name, the purchased product and the type of the license. Do not modify the content of the license file as it will invalidate the license.
+라이선스는 주문 결제 후 주문 페이지에서 다운로드할 수 있습니다. 라이센스는 디지털 서명된 일반 텍스트 XML 파일입니다. 라이선스에는 고객 이름, 구매한 제품, 라이선스 유형 등의 정보가 포함됩니다. 라이센스가 무효화되므로 라이센스 파일의 내용을 수정하지 마십시오.
 
-## Licensing a Server
+## 서버 라이센스
 
-Download the license file and copy it to the C:\Program Files\Microsoft SQL Server\```<Instance>``\Reporting Services\ReportServer\bin, or C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin, or C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin folder on the server (the same folder where the Aspose.Pdf.ReportingServices.dll is placed).
+라이선스 파일을 다운로드하여 서버의 C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\bin 또는 C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin 또는 C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin 폴더(Aspose.Pdf.ReportingServices.dll이 있는 폴더와 동일한 폴더)에 복사합니다. 배치됩니다).
 
-```<Instance>``` is the subdirectory name that corresponds to the Microsoft SQL Server 2016 instance you want to license.
+`<Instance>`은 라이선스를 부여하려는 Microsoft SQL Server 2016 인스턴스에 해당하는 하위 디렉터리 이름입니다.
 
-The default instance directory for Microsoft SQL Server 2016 is MSRS13.MSSQLSERVER.
-For the Microsoft SQL Server 2017 and later the default instance path is C:\Program Files\Microsoft SQL Server\SSRS.
-For the Power BI Report Server the default instance path is C:\Program Files\Microsoft Power BI Report Server\PBIRS.
+Microsoft SQL Server 2016의 기본 인스턴스 디렉터리는 MSRS13.MSSQLSERVER입니다.
+Microsoft SQL Server 2017 이상의 경우 기본 인스턴스 경로는 C:\Program Files\Microsoft SQL Server\SSRS입니다.
+Power BI Report Server의 경우 기본 인스턴스 경로는 C:\Program Files\Microsoft Power BI Report Server\PBIRS입니다.
 
-**PDF generated using “Territory sales drilldown” report**
+**"지역 판매 드릴다운" 보고서를 사용하여 생성된 PDF**
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_1.png)
+![License-Territory sales drilldown](license-aspose-pdf-for-reporting-services_1.png)
 
+**"판매 주문 세부정보" 보고서를 사용하여 생성된 PDF**
 
-**PDF generated using “Sales Order details” report**
+![License-Sales Order details](license-aspose-pdf-for-reporting-services_2.png)
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_2.png)
+라이센스를 초기화하는 동안 문제가 발생하면 아래와 같이 결과 PDF 문서에 평가 워터마크가 표시됩니다.
 
-If there is a problem while initializing the license, an evaluation watermark is displayed in the resultant PDF document as specified below.
+**워터마크가 있는 "지역 판매 드릴다운"을 사용하여 생성된 PDF 문서**
 
-**PDF document generated using “Territory Sales Drilldown” with watermark**
+![License-Territory Sales Drilldown](license-aspose-pdf-for-reporting-services_3.png)
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_3.png)
+지원되는 라이선스 파일 이름은 Aspose.PDF.ReportingServices.lic, Aspose.Total.ReportingServices.lic 및 Aspose.Total.Product.Family.lic입니다. 파일 이름이 다른 경우 이름을 바꾸십시오.
 
-Please note that that supported license file names are Aspose.PDF.ReportingServices.lic, Aspose.Total.ReportingServices.lic and Aspose.Total.Product.Family.lic. If the file has any other name, please rename it.
-
-
-## Temporary License
+## 임시면허
 
 {{% alert color="primary" %}}
 
-You may also request a 30 days temporary license to test the product. Please visit the following link for more information on how to get Temporary license. [Get a Temporary License](https://purchase.aspose.com/temporary-license).
+제품을 테스트하기 위해 30일 임시 라이센스를 요청할 수도 있습니다. 임시 라이센스를 얻는 방법에 대한 자세한 내용을 보려면 다음 링크를 방문하십시오. [임시 라이센스를 받으세요](https://purchase.aspose.com/temporary-license).
 
 {{% /alert %}}

--- a/ko/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
+++ b/ko/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
@@ -1,23 +1,23 @@
 ---
-title: 라이선스
-linktitle: 라이선스
+title: License
+linktitle: License
 
 type: docs
 weight: 70
-url: /ko/reportingservices/license-aspose-pdf-for-reporting-services/
-description: Aspose.PDF for Reporting Services에 대한 라이선스 옵션을 이해하십시오. 라이선스를 활성화하고 전체 기능을 잠금 해제하는 방법을 확인하세요.
-lastmod: "2026-06-19"
+url: /reportingservices/license-aspose-pdf-for-reporting-services/
+description: Understand licensing options for Aspose.PDF for Reporting Services. Find out how to activate your license and unlock full functionality.
+lastmod: "2021-06-05"
 ---
 
-**Aspose.Pdf for Reporting Services** 평가 버전은 라이선스 버전과 동일한 기능을 제공하지만, 평가 버전을 사용할 때 결과 PDF에 평가 워터마크가 표시됩니다. 웹사이트를 방문하여 제품 버전을 다운로드하고 전체 기능을 갖춘 평가 모드에서 제품을 탐색해 보세요.
+**Aspose.PDF for Reporting Services** evaluation version provide the same set of features as present in Licensed version, except for the evaluation watermark in resultant PDF when using evaluation version. Please visit our website and download the product version and start exploring our product with complete set of features in an evaluation mode.
 
-평가 결과에 만족하시면, [라이선스를 구매하십시오](https://purchase.aspose.com/buy). 구매하기 전에 라이선스 구독 조건을 이해하고 동의했는지 확인하십시오.
+When you are happy with your evaluation, [buy a license](https://purchase.aspose.com/buy). Before purchasing, make sure you understand and agree to the license subscription terms.
 
-주문이 결제된 후 주문 페이지에서 라이선스를 다운로드할 수 있습니다. 라이선스는 일반 텍스트이며 디지털 서명된 XML 파일입니다. 라이선스에는 클라이언트 이름, 구매한 제품 및 라이선스 유형과 같은 정보가 포함됩니다. 라이선스 파일의 내용을 수정하면 라이선스가 무효화됩니다.
+The license will be available for download from the order page after the order is paid. The license is a clear text, digitally signed XML file. The license contains information such as the client's name, the purchased product and the type of the license. Do not modify the content of the license file as it will invalidate the license.
 
-## 서버 라이선스 부여
+## Licensing a Server
 
-라이선스 파일을 다운로드하고 C:\Program Files\Microsoft SQL Server\에 복사하십시오.```<Instance>``\Reporting Services\ReportServer\bin, or C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin, or C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin folder on the server (the same folder where the Aspose.Pdf.ReportingServices.dll is placed).
+Download the license file and copy it to the C:\Program Files\Microsoft SQL Server\```<Instance>``\Reporting Services\ReportServer\bin, or C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin, or C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin folder on the server (the same folder where the Aspose.Pdf.ReportingServices.dll is placed).
 
 ```<Instance>``` is the subdirectory name that corresponds to the Microsoft SQL Server 2016 instance you want to license.
 
@@ -50,4 +50,3 @@ Please note that that supported license file names are Aspose.PDF.ReportingServi
 You may also request a 30 days temporary license to test the product. Please visit the following link for more information on how to get Temporary license. [Get a Temporary License](https://purchase.aspose.com/temporary-license).
 
 {{% /alert %}}
-

--- a/ko/reportingservices/product-overview/_index.md
+++ b/ko/reportingservices/product-overview/_index.md
@@ -4,8 +4,8 @@ linktitle: 제품 개요
 type: docs
 weight: 10
 url: /ko/reportingservices/product-overview/
-description: Aspose.PDF for Reporting Services에 대한 개요 – 고급 레이아웃 기능을 갖춘 SSRS 보고서를 PDF로 렌더링하기 위한 포괄적인 솔루션입니다.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services에 대한 개요 – 고급 레이아웃 기능을 갖춘 SSRS 보고서를 PDF로 렌더링하기 위한 종합 솔루션입니다.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
@@ -16,16 +16,15 @@ lastmod: "2026-06-19"
 
 ## Aspose.PDF for Reporting Services에 오신 것을 환영합니다!
 
-Microsoft SQL Server Reporting Services는 많은 조직이 직면한 필요, 즉 비즈니스 인텔리전스 및 보고 솔루션을 구축해야 하는 필요를 충족합니다. 지금까지 개발자는 보고서를 애플리케이션에 삽입해야 했고, 조직은 비용이 많이 들고 때때로 문제를 일으키는 서드파티 보고 솔루션을 구매해야 했습니다. 이제 Microsoft SQL Server Reporting Services는 기업 전체에 보고서를 배포하기 위한 완전한 솔루션을 제공하여 비즈니스가 더 나은, 더 빠른 결정을 내릴 수 있게 합니다.
+Microsoft SQL Server Reporting Services는 많은 조직이 직면하고 있는 필요, 즉 비즈니스 인텔리전스 및 보고 솔루션을 구축해야 하는 필요를 충족합니다. 지금까지 개발자는 보고서를 애플리케이션에 삽입해야 했으며, 조직은 비용이 많이 들고 때때로 문제를 일으키는 타사 보고 솔루션을 구매해야 했습니다. 이제 Microsoft SQL Server Reporting Services는 기업 전반에 보고서를 배포하기 위한 완전한 솔루션을 제공하여 비즈니스가 보다 더 나은, 더 빠르게 의사결정을 내릴 수 있도록 합니다.
 
-**Aspose.Pdf for Reporting Services**는 Aspose의 또 다른 고유한 솔루션으로, Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 및 Power BI Report Server에서 PDF 보고서를 생성할 수 있게 합니다. 테이블, 매트릭스, 차트 및 이미지를 포함한 모든 RDL 보고서 기능이 최고 수준의 정밀도로 PDF로 변환됩니다.
+**Aspose.PDF for Reporting Services**는 Aspose의 또 다른 고유한 솔루션으로, Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 및 Power BI Report Server에서 PDF 보고서를 생성할 수 있게 합니다. 테이블, 매트릭스, 차트 및 이미지 등을 포함한 모든 RDL 보고서 기능이 가장 높은 정밀도로 PDF로 변환됩니다.
 
-Microsoft SQL Server Reporting Services는 보고서를 PDF 문서로 내보내는 기본 기능을 가지고 있지만, 최종 사용자에게 필요한 기술 지원을 제공하지 못합니다. Aspose.Pdf는 최고 수준의 효율적인 기술 지원을 제공하기 위해 노력합니다.
+Microsoft SQL Server Reporting Services는 보고서를 PDF 문서로 내보내는 기본 기능을 제공하지만, 최종 사용자에게 필요한 기술 지원을 제공하지 못합니다. Aspose.Pdf는 최고 수준의 효율적인 기술 지원을 제공하기 위해 노력합니다.
 
-Aspose.Pdf for Reporting Services는 Adobe.Pdf SDK를 사용하지 않고 서버에서 문서를 생성합니다. Aspose.Pdf for Reporting Services는 내부적으로 Aspose.Pdf for .NET – 서버 측 문서 처리 및 변환을 위한 세계 최고 수준의 구성 요소를 사용합니다.
+Aspose.PDF for Reporting Services는 Adobe.Pdf SDK를 사용하지 않고 서버에서 문서를 생성합니다. Aspose.PDF for Reporting Services는 내부적으로 Aspose.PDF for .NET을 사용합니다 – 서버 측 문서 처리 및 변환을 위한 세계적인 구성 요소입니다.
 
-## Aspose.PDF for Reporting Services는 모든 보고서를 PDF 형식으로 내보낼 수 있게 합니다.
+## Aspose.PDF for Reporting Services를 사용하면 모든 보고서를 PDF 형식으로 내보낼 수 있습니다.
 
 ![todo:image_alt_text](product-overview_2.png)
-
 

--- a/ko/reportingservices/product-overview/_index.md
+++ b/ko/reportingservices/product-overview/_index.md
@@ -1,11 +1,11 @@
 ---
-title: 제품 개요
-linktitle: 제품 개요
+title: 제품개요
+linktitle: 제품개요
 type: docs
 weight: 10
-url: /ko/reportingservices/product-overview/
-description: Aspose.PDF for Reporting Services에 대한 개요 – 고급 레이아웃 기능을 갖춘 SSRS 보고서를 PDF로 렌더링하기 위한 종합 솔루션입니다.
-lastmod: "2026-07-29"
+url: /reportingservices/product-overview/
+description: Reporting Services용 Aspose.PDF 개요 – 고급 레이아웃 기능을 사용하여 SSRS 보고서를 PDF로 렌더링하기 위한 포괄적인 솔루션입니다.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
@@ -14,17 +14,17 @@ lastmod: "2026-07-29"
 
 {{% /alert %}}
 
-## Aspose.PDF for Reporting Services에 오신 것을 환영합니다!
+## 보고 서비스를 위한 Aspose.PDF에 오신 것을 환영합니다!
 
-Microsoft SQL Server Reporting Services는 많은 조직이 직면하고 있는 필요, 즉 비즈니스 인텔리전스 및 보고 솔루션을 구축해야 하는 필요를 충족합니다. 지금까지 개발자는 보고서를 애플리케이션에 삽입해야 했으며, 조직은 비용이 많이 들고 때때로 문제를 일으키는 타사 보고 솔루션을 구매해야 했습니다. 이제 Microsoft SQL Server Reporting Services는 기업 전반에 보고서를 배포하기 위한 완전한 솔루션을 제공하여 비즈니스가 보다 더 나은, 더 빠르게 의사결정을 내릴 수 있도록 합니다.
+Microsoft SQL Server 보고 서비스는 많은 조직이 직면하고 있는 비즈니스 인텔리전스 및 보고 솔루션 구축 요구 사항을 충족합니다. 지금까지 개발자는 애플리케이션에 보고서를 포함해야 했고, 조직은 비싸고 때로는 문제가 있는 타사 보고 솔루션을 구입해야 했습니다. 이제 Microsoft SQL Server 보고 서비스는 기업 전체에 보고서를 배포하기 위한 완벽한 솔루션을 제공합니다. 기업이 더 나은 의사결정을 더 빠르게 내릴 수 있도록 지원합니다.
 
-**Aspose.PDF for Reporting Services**는 Aspose의 또 다른 고유한 솔루션으로, Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 및 Power BI Report Server에서 PDF 보고서를 생성할 수 있게 합니다. 테이블, 매트릭스, 차트 및 이미지 등을 포함한 모든 RDL 보고서 기능이 가장 높은 정밀도로 PDF로 변환됩니다.
+**Reporting Services용 Aspose.PDF**는 Aspose의 또 다른 고유한 솔루션으로, Microsoft SQL Server 2016/2017/2019/2022 Reporting Services 및 Power BI Report Server에서 PDF 보고서를 생성할 수 있습니다. 테이블, 행렬, 차트 및 이미지를 포함한 모든 RDL 보고서 기능은 가장 높은 정밀도로 PDF로 변환됩니다.
 
-Microsoft SQL Server Reporting Services는 보고서를 PDF 문서로 내보내는 기본 기능을 제공하지만, 최종 사용자에게 필요한 기술 지원을 제공하지 못합니다. Aspose.Pdf는 최고 수준의 효율적인 기술 지원을 제공하기 위해 노력합니다.
+Microsoft SQL Server 보고 서비스에는 보고서를 PDF 문서로 내보내는 기능이 내장되어 있지만 최종 사용자에게 필요한 기술 지원을 제공하는 기능은 부족합니다. Aspose.Pdf는 최고이고 효율적인 기술 지원을 제공하기 위해 노력하고 있습니다.
 
-Aspose.PDF for Reporting Services는 Adobe.Pdf SDK를 사용하지 않고 서버에서 문서를 생성합니다. Aspose.PDF for Reporting Services는 내부적으로 Aspose.PDF for .NET을 사용합니다 – 서버 측 문서 처리 및 변환을 위한 세계적인 구성 요소입니다.
+Reporting Services용 Aspose.PDF는 Adobe.Pdf SDK를 활용하지 않고 서버에서 문서를 생성합니다. Reporting Services용 Aspose.PDF는 서버 측 문서 처리 및 변환을 위한 세계적 수준의 구성 요소인 .NET용 Aspose.PDF를 내부적으로 사용합니다.
 
-## Aspose.PDF for Reporting Services를 사용하면 모든 보고서를 PDF 형식으로 내보낼 수 있습니다.
+## Reporting Services용 Aspose.PDF를 사용하면 모든 보고서를 PDF 형식으로 내보낼 수 있습니다.
 
-![todo:image_alt_text](product-overview_2.png)
+![Product Overview](product-overview_2.png)
 

--- a/ko/reportingservices/sample-reports-gallery/_index.md
+++ b/ko/reportingservices/sample-reports-gallery/_index.md
@@ -3,35 +3,35 @@ title: 샘플 보고서 갤러리
 linktitle: 샘플 보고서 갤러리
 type: docs
 weight: 40
-url: /ko/reportingservices/sample-reports-gallery/
-description: Aspose.PDF for Reporting Services를 사용하여 생성된 샘플 보고서를 탐색하십시오. SSRS 보고서를 정교한 PDF 출력으로 변환할 수 있는 방식을 확인하십시오.
-lastmod: "2026-07-29"
+url: /reportingservices/sample-reports-gallery/
+description: Reporting Services용 Aspose.PDF를 사용하여 생성된 샘플 보고서를 살펴보세요. SSRS 보고서가 어떻게 세련된 PDF 출력으로 변환될 수 있는지 알아보세요.
+lastmod: "2024-05-05"
 ---
 
 {{% alert color="primary" %}}
 
-이 갤러리는 Aspose.PDF for Reporting Services에 의해 내보내진 PDF 보고서를 보여줍니다.
+이 갤러리는 Reporting Services용 Aspose.PDF로 내보낸 PDF 보고서를 보여줍니다.
 
 {{% /alert %}}
 
-여기에 표시된 대부분의 보고서는 Adventure Works 데이터베이스에서 가져왔습니다. Adventure Works는 Microsoft SQL Server용 샘플 데이터베이스이며 Microsoft에서 다운로드할 수 있습니다. [여기](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
+여기에 표시된 대부분의 보고서는 Adventure Works 데이터베이스에서 가져온 것입니다. Adventure Works는 Microsoft SQL Server용 샘플 데이터베이스로, Microsoft에서 다운로드할 수 있습니다. [여기](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
 
 ## 회사 매출
 
-![PDF 형식의 회사 매출  보고서](sample-reports-gallery_1.png)
+![PDF로 된 회사 판매 보고서](sample-reports-gallery_1.png)
 
 ## 직원 매출 요약
 
-![PDF 형식의 직원 매출 요약 보고서](sample-reports-gallery_2.png)
+![PDF로 된 직원 판매 요약 보고서](sample-reports-gallery_2.png)
 
 ## 제품 카탈로그
 
 ![PDF 형식의 제품 카탈로그 보고서](sample-reports-gallery_3.png)
 
-## 제품 라인 판매
+## 제품군 판매
 
 ![PDF 형식의 제품 라인 판매 보고서](sample-reports-gallery_4.png)
 
-## 판매 주문 상세
+## 판매 주문 세부정보
 
-![PDF 형식의 판매 주문 상세 보고서](sample-reports-gallery_5.png)
+![PDF로 된 판매 주문 상세 보고서](sample-reports-gallery_5.png)

--- a/ko/reportingservices/sample-reports-gallery/_index.md
+++ b/ko/reportingservices/sample-reports-gallery/_index.md
@@ -4,25 +4,25 @@ linktitle: 샘플 보고서 갤러리
 type: docs
 weight: 40
 url: /ko/reportingservices/sample-reports-gallery/
-description: Aspose.PDF for Reporting Services를 사용하여 생성된 샘플 보고서를 탐색하세요. SSRS 보고서가 어떻게 세련된 PDF 출력으로 변환될 수 있는지 확인하십시오.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services를 사용하여 생성된 샘플 보고서를 탐색하십시오. SSRS 보고서를 정교한 PDF 출력으로 변환할 수 있는 방식을 확인하십시오.
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-이 갤러리는 Aspose.Pdf for Reporting Services에서 내보낸 PDF 보고서를 보여줍니다.
+이 갤러리는 Aspose.PDF for Reporting Services에 의해 내보내진 PDF 보고서를 보여줍니다.
 
 {{% /alert %}}
 
-여기에 표시된 대부분의 보고서는 Adventure Works 데이터베이스에서 가져온 것입니다. Adventure Works는 Microsoft SQL Server용 샘플 데이터베이스이며, Microsoft에서 다운로드할 수 있습니다. [여기](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
+여기에 표시된 대부분의 보고서는 Adventure Works 데이터베이스에서 가져왔습니다. Adventure Works는 Microsoft SQL Server용 샘플 데이터베이스이며 Microsoft에서 다운로드할 수 있습니다. [여기](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
 
 ## 회사 매출
 
-![PDF 형식의 회사 매출 보고서](sample-reports-gallery_1.png)
+![PDF 형식의 회사 매출  보고서](sample-reports-gallery_1.png)
 
-## 직원 판매 요약
+## 직원 매출 요약
 
-![PDF 형식의 직원 판매 요약 보고서](sample-reports-gallery_2.png)
+![PDF 형식의 직원 매출 요약 보고서](sample-reports-gallery_2.png)
 
 ## 제품 카탈로그
 
@@ -35,4 +35,3 @@ lastmod: "2026-06-19"
 ## 판매 주문 상세
 
 ![PDF 형식의 판매 주문 상세 보고서](sample-reports-gallery_5.png)
-

--- a/ko/reportingservices/supported-file-formats/_index.md
+++ b/ko/reportingservices/supported-file-formats/_index.md
@@ -3,27 +3,27 @@ title: 지원되는 파일 형식
 linktitle: 지원되는 파일 형식
 type: docs
 weight: 20
-url: /ko/reportingservices/supported-file-formats/
-description: Aspose.PDF for Reporting Services의 지원되는 파일 형식을 확인하십시오. SSRS 보고서를 PDF, DOC, XLS 등으로 쉽게 렌더링할 수 있습니다.
-lastmod: "2026-07-29"
+url: /reportingservices/supported-file-formats/
+description: Reporting Services에 대해 지원되는 Aspose.PDF 파일 형식을 확인하세요. SSRS 보고서를 PDF, DOC, XLS 등으로 쉽게 렌더링하세요.
+lastmod: "2021-06-05"
 ---
 
 ## 지원되는 로드 형식
 
-다음 표는 Aspose.PDF for Reporting Services가 로드할 수 있는 파일 형식을 나타냅니다.
+다음 표는 Reporting Services용 Aspose.PDF가 로드할 수 있는 파일 형식을 나타냅니다.
 
-|**형식**|**설명**|
+|**체재**|**설명**|
 | :- | :- |
 |RDL|보고서 정의 언어|
 |[HTML](https://docs.fileformat.com/web/html/)|하이퍼텍스트 마크업 언어|
 
-## 지원 저장 형식
+## 지원되는 저장 형식
 
-다음 표는 Aspose.PDF for Reporting Services를 사용하여 문서를 저장할 수 있는 파일 형식을 나타냅니다. 
+다음 표는 Reporting Services용 Aspose.PDF를 사용하여 문서를 저장할 수 있는 파일 형식을 나타냅니다. 
 
-|**형식**|**설명**|
+|**체재**|**설명**|
 | :- | :- |
-|[PDF](https://docs.fileformat.com/pdf/)|문서를 PDF 형식으로 저장합니다|
-|PDF/A |문서를 PDF/A 형식으로 저장합니다|
-|[XPS](https://docs.fileformat.com/page-description-language/xps/)|문서를 XML Paper Specification 형식으로 저장합니다|
-|EPUB|문서를 전자책 파일 형식으로 저장합니다|
+|[PDF](https://docs.fileformat.com/pdf/)|문서를 PDF 형식으로 저장합니다.|
+|PDF/A |문서를 PDF/A 형식으로 저장합니다.|
+|[XPS](https://docs.fileformat.com/page-description-language/xps/)|문서를 XML Paper Spec 형식으로 저장합니다.|
+|EPUB|문서를 E-Book 파일 형식으로 저장합니다.|

--- a/ko/reportingservices/supported-file-formats/_index.md
+++ b/ko/reportingservices/supported-file-formats/_index.md
@@ -4,8 +4,8 @@ linktitle: 지원되는 파일 형식
 type: docs
 weight: 20
 url: /ko/reportingservices/supported-file-formats/
-description: Aspose.PDF for Reporting Services의 지원되는 파일 형식을 확인해 보세요. SSRS 보고서를 PDF, DOC, XLS 등으로 쉽게 렌더링할 수 있습니다.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services의 지원되는 파일 형식을 확인하십시오. SSRS 보고서를 PDF, DOC, XLS 등으로 쉽게 렌더링할 수 있습니다.
+lastmod: "2026-07-29"
 ---
 
 ## 지원되는 로드 형식
@@ -17,7 +17,7 @@ lastmod: "2026-06-19"
 |RDL|보고서 정의 언어|
 |[HTML](https://docs.fileformat.com/web/html/)|하이퍼텍스트 마크업 언어|
 
-## 지원되는 저장 형식
+## 지원 저장 형식
 
 다음 표는 Aspose.PDF for Reporting Services를 사용하여 문서를 저장할 수 있는 파일 형식을 나타냅니다. 
 
@@ -27,4 +27,3 @@ lastmod: "2026-06-19"
 |PDF/A |문서를 PDF/A 형식으로 저장합니다|
 |[XPS](https://docs.fileformat.com/page-description-language/xps/)|문서를 XML Paper Specification 형식으로 저장합니다|
 |EPUB|문서를 전자책 파일 형식으로 저장합니다|
-

--- a/ko/reportingservices/technical-articles/_index.md
+++ b/ko/reportingservices/technical-articles/_index.md
@@ -1,14 +1,13 @@
 ---
-title: 기술 문서
-linktitle: 기술 문서
+title: 기술 기사
+linktitle: 기술 기사
 type: docs
 weight: 120
 url: /ko/reportingservices/technical-articles/
-description: Aspose.PDF for Reporting Services에 대한 기술 문서를 탐색하세요. 효과적인 PDF 렌더링을 위한 깊이 있는 통찰과 실용적인 팁을 얻으세요.
-lastmod: "2026-06-19"
+description: Aspose.PDF for Reporting Services에 대한 기술 기사를 탐색하십시오. 효과적인 PDF 렌더링을 위한 심도 있는 통찰과 실용적인 팁을 얻으세요.
+lastmod: "2026-07-29"
 ---
 
 **이 섹션에는 다음 주제가 포함됩니다:**
-- [SQL Reporting Services에서 Aspose.Pdf for Reporting Services로 마이그레이션](/pdf/ko/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
-- [MS SharePoint와 SQL Reporting Services 통합](/pdf/ko/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/)
-
+- [SQL Reporting Services에서 Aspose.PDF for Reporting Services로 마이그레이션](/pdf/ko/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
+- [SQL Reporting Services와 MS SharePoint 통합](/pdf/ko/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/)

--- a/ko/reportingservices/technical-articles/_index.md
+++ b/ko/reportingservices/technical-articles/_index.md
@@ -3,11 +3,12 @@ title: 기술 기사
 linktitle: 기술 기사
 type: docs
 weight: 120
-url: /ko/reportingservices/technical-articles/
-description: Aspose.PDF for Reporting Services에 대한 기술 기사를 탐색하십시오. 효과적인 PDF 렌더링을 위한 심도 있는 통찰과 실용적인 팁을 얻으세요.
-lastmod: "2026-07-29"
+url: /reportingservices/technical-articles/
+description: 보고 서비스용 Aspose.PDF에 대한 기술 문서를 살펴보세요. 효과적인 PDF 렌더링을 위한 심층적인 통찰력과 실용적인 팁을 얻으세요.
+lastmod: "2021-06-05"
 ---
 
-**이 섹션에는 다음 주제가 포함됩니다:**
-- [SQL Reporting Services에서 Aspose.PDF for Reporting Services로 마이그레이션](/pdf/ko/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
-- [SQL Reporting Services와 MS SharePoint 통합](/pdf/ko/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/)
+**이 섹션에는 다음 주제가 포함됩니다.**
+
+- [보고 서비스를 위해 SQL 보고 서비스에서 Aspose.PDF로 마이그레이션](/pdf/ko/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
+- [MS SharePoint와 SQL 보고 서비스 통합](/pdf/ko/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/)

--- a/ko/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
+++ b/ko/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
@@ -1,14 +1,13 @@
 ---
-title: SQL Reporting Services에서 Aspose.Pdf for Reporting Services로 마이그레이션
-linktitle: SQL Reporting Services에서 Aspose.Pdf for Reporting Services로 마이그레이션
+title: SQL Reporting Services에서 Aspose.PDF for Reporting Services로 마이그레이션
+linktitle: SQL Reporting Services에서 Aspose.PDF for Reporting Services로 마이그레이션
 type: docs
 weight: 10
 url: /ko/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/
-description: SQL Reporting Services에서 Aspose.PDF for Reporting Services로 마이그레이션하는 방법을 알아보세요. PDF 생성 프로세스를 업그레이드하십시오.
-lastmod: "2026-06-19"
+description: SQL Reporting Services에서 Aspose.PDF for Reporting Services로 마이그레이션하는 방법을 배우세요. PDF 생성 프로세스를 업그레이드하십시오.
+lastmod: "2026-07-29"
 ---
 
-**이 섹션에는 다음 항목이 포함됩니다:**
+**이 섹션에는 다음 주제가 포함됩니다:**
 
-- [왜 Aspose.PDF for Reporting Services를 선택해야 하는가](/pdf/ko/reportingservices/why-choose-aspose-pdf-for-reporting-services/)
-
+- [왜 Aspose.PDF for Reporting Services를 선택합니까](/pdf/ko/reportingservices/why-choose-aspose-pdf-for-reporting-services/)

--- a/ko/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
+++ b/ko/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
@@ -1,13 +1,13 @@
 ---
-title: SQL Reporting Services에서 Aspose.PDF for Reporting Services로 마이그레이션
-linktitle: SQL Reporting Services에서 Aspose.PDF for Reporting Services로 마이그레이션
+title: 보고 서비스를 위해 SQL 보고 서비스에서 Aspose.PDF로 마이그레이션
+linktitle: 보고 서비스를 위해 SQL 보고 서비스에서 Aspose.PDF로 마이그레이션
 type: docs
 weight: 10
-url: /ko/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/
-description: SQL Reporting Services에서 Aspose.PDF for Reporting Services로 마이그레이션하는 방법을 배우세요. PDF 생성 프로세스를 업그레이드하십시오.
-lastmod: "2026-07-29"
+url: /reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/
+description: SQL Reporting Services에서 Reporting Services용 Aspose.PDF로 마이그레이션하는 방법을 알아보세요. PDF 생성 프로세스를 업그레이드하세요.
+lastmod: "2024-05-05"
 ---
 
-**이 섹션에는 다음 주제가 포함됩니다:**
+**이 섹션에는 다음 주제가 포함됩니다.**
 
-- [왜 Aspose.PDF for Reporting Services를 선택합니까](/pdf/ko/reportingservices/why-choose-aspose-pdf-for-reporting-services/)
+- [보고 서비스를 위해 Aspose.PDF를 선택하는 이유](/pdf/ko/reportingservices/why-choose-aspose-pdf-for-reporting-services/)

--- a/ko/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
+++ b/ko/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
@@ -1,36 +1,36 @@
 ---
-title: 왜 Aspose.PDF for Reporting Services를 선택합니까?
-linktitle: 왜 Aspose.PDF for Reporting Services를 선택합니까?
+title: 보고 서비스를 위해 Aspose.PDF를 선택하는 이유
+linktitle: 보고 서비스를 위해 Aspose.PDF를 선택하는 이유
 type: docs
 weight: 10
-url: /ko/reportingservices/why-choose-aspose-pdf-for-reporting-services/
-lastmod: "2026-07-29"
+url: /reportingservices/why-choose-aspose-pdf-for-reporting-services/
+lastmod: "2021-06-05"
 ---
 
-**Aspose.PDF for Reporting Services**는 Microsoft SQL Server 2016, 2017, 2019 및 2022 Reporting Services와 Microsoft Power BI Report Server를 사용하여 PDF 보고서를 생성할 수 있는 강력한 .NET 솔루션입니다. Aspose.PDF for Reporting Services는 독립적으로 동작하지 않고 SQL Reporting Services용 렌더링 확장 기능입니다. 테이블, 차트, 이미지, 머리글/바닥글, 선 등 기본 보고서 요소를 지원할 뿐만 아니라, SQL Reporting Services에 추가적인 이점을 제공하는 사용자 정의 속성을 추가할 수 있는 기능도 제공합니다. 이러한 속성을 사용하면 Report Designer에서 지원되지 않는 목차(List of Contents)를 생성할 수 있습니다. 결과 PDF 문서에 Report Builder에서 기본적으로 지원되지 않는 각주/미주(Footnotes/Endnotes)를 포함시킬 수도 있습니다. 또 다른 흥미로운 기능은 선에 화살표(Line Arrows)를 추가할 수 있는 것으로, 이는 SQL Reporting Services에서 지원되지 않지만 Aspose.PDF for Reporting Services를 통해 선 요소의 시작이나 끝에 화살표를 삽입할 수 있습니다. 또한 Aspose.PDF for Reporting Services는 Report Designer에서 지원되지 않는 텍스트 정렬(Justify 또는 FullJustify) 지정 기능을 제공합니다. 이러한 텍스트 모드는 결과 문서의 형식을 보다 깔끔하고 읽기 쉽게 만들어 줍니다.
+**Reporting Services용 Aspose.PDF**는 Microsoft SQL Server 2016, 2017, 2019, 2022 Reporting Services 및 Microsoft Power BI Report Server를 사용하여 PDF 보고서를 생성할 수 있는 강력한 .NET 솔루션입니다. Reporting Services용 Aspose.PDF는 독립적으로 작동하지 않지만 SQL Reporting Services용 렌더링 확장 프로그램입니다. 테이블, 차트, 이미지, 머리글/바닥글, 줄 등과 같은 기본 보고서 요소를 지원할 뿐만 아니라 SQL Reporting Services를 더욱 활용하는 사용자 정의 속성을 추가하는 기능도 제공합니다. 이러한 속성을 사용하는 동안 보고서 디자이너에서 지원하지 않는 목차 목록을 생성할 수 있습니다. 보고서 작성기에서는 기본적으로 지원되지 않는 결과 PDF 문서에 각주/미주가 있을 수 있습니다. 또 다른 흥미로운 기능은 SQL Reporting Services에서도 지원되지 않는 선 화살표가 있다는 것입니다. 그러나 Reporting Services용 Aspose.PDF는 선 요소의 시작 또는 끝에 화살표를 추가하는 기능을 제공할 수 있습니다. 또한 Reporting Services용 Aspose.PDF는 보고서 디자이너에서 지원하지 않는 텍스트 정렬(Justify 또는 FullJustify) 정보를 지정하는 기능을 제공합니다. 이러한 텍스트 모드를 사용하면 결과 문서의 형식이 더 좋고 읽기 쉬워집니다.
 
-앞서 언급한 기능 외에도 보고서에 대해 다른 구성 매개변수를 설정하여 SQL Reporting Services에서 기본적으로 지원되지 않는 기능을 얻을 수 있습니다. 다음은 Aspose.PDF for Reporting Services에서 제공하는 이러한 기능에 대한 간략한 개요입니다.
+이전에 언급한 기능 외에도 보고서에 대한 특정 다른 구성 매개 변수를 설정하여 SQL Reporting Services에서 기본적으로 지원하지 않는 기능을 얻을 수도 있습니다. 다음은 보고 서비스를 위해 Aspose.PDF에서 제공하는 기능에 대한 간략한 설명입니다.
 
 ## 보안 설정
 
-때때로 비밀번호로 보호된 PDF 문서를 내보내고 텍스트 복사 및 인쇄 권한을 제한하고 싶을 수 있습니다. 안타깝게도 Reporting Services는 이 기능을 지원하지 않습니다. 하지만 Aspose.PDF for Reporting Services를 사용하면 이를 구현할 수 있습니다. 보고서 또는 보고서 서버에 해당 보안 매개변수를 추가하면 제한된 권한을 가진 보안 PDF 문서를 얻을 수 있습니다. 자세한 내용은 \u0027Security Setting\u0027 섹션을 참조하십시오.
+때로는 제한된 텍스트 복사 및 인쇄 권한으로 비밀번호로 보호된 PDF 문서를 내보내고 싶을 수도 있습니다. 안타깝게도 Reporting Services는 이러한 가능성을 지원하지 않습니다. 그러나 Reporting Services용 Aspose.PDF를 사용하여 구현할 수 있습니다. 제한된 권한으로 보안 PDF 문서를 얻으려면 보고서 또는 보고서 서버에 해당 보안 매개변수를 추가하기만 하면 됩니다. 자세한 내용은 '보안 설정' 항목을 참고하세요.
 
-## 맞춤 글꼴 임베딩
+## 사용자 정의 글꼴 포함
 
-Reporting Services 디자이너는 텍스트에 대한 임베디드 글꼴을 지원하지 않지만, Aspose.PDF for Reporting Services를 사용하면 PDF 문서에 글꼴 정보를 쉽게 임베드할 수 있습니다. 자세한 내용은 \u0027IsFontEmbedded\u0027 섹션을 참조하십시오.
+Reporting Services 디자이너는 텍스트에 포함된 글꼴을 지원하지 않습니다. Reporting Services용 Aspose.PDF를 사용하면 PDF 문서에 글꼴 정보를 쉽게 포함할 수 있습니다. 자세한 내용은 'IsFontEmbedded' 섹션을 참조하세요.
 
 ## XMP 메타데이터
 
-Reporting Services 디자이너는 XMP 메타데이터 삽입을 지원하지 않습니다. Aspose.PDF for Reporting Services는 해당 XMP 메타데이터를 설정하기 위해 네 가지 매개변수(CreationDate, ModifyDate, MetaDataDate 및 CreatorTool)를 제공합니다. 자세한 내용은 'XMP Metadata' 섹션을 참조하십시오.
+Reporting Services 디자이너는 XMP 메타데이터 포함을 지원하지 않습니다. Reporting Services용 Aspose.PDF는 해당 XMP 메타데이터를 설정하기 위한 4가지 매개 변수(CreationDate, ModifyDate, MetaDataDate 및 CreatorTool)를 제공합니다. 자세한 내용은 'XMP ​​메타데이터' 섹션을 참조하세요.
 
 ## PDF/A
 
-SQL Server Reporting Services를 사용할 경우 PDF 문서를 단순 형식으로만 생성할 수 있으며 PDF/A 문서 생성은 지원되지 않습니다. 그러나 Aspose.PDF for Reporting Services는 단일 구성 매개변수를 추가함으로써 PDF/A 규격에 부합하는 문서를 만들 수 있는 기능을 제공합니다. 자세한 내용은 'PDF Conformance' 섹션을 참조하십시오.
+SQL Server Reporting Services를 사용하는 경우 간단한 형식으로만 PDF 문서를 생성할 수 있으며 PDF/A 문서 생성은 지원되지 않습니다. 그러나 Reporting Services용 Aspose.PDF는 단일 구성 매개변수를 추가하여 PDF/A 호환 문서를 생성하는 기능을 제공합니다. 자세한 내용은 'PDF 적합성' 섹션을 참조하세요.
 
 ## 페이지 회전 각도
 
-Aspose.PDF for Reporting Services를 사용할 때 페이지가 표시되거나 인쇄될 때 시계 방향으로 회전해야 하는 각도를 도 단위로 설정할 수 있습니다. 자세한 내용은 'Page Rotating Angle' 섹션을 참조하십시오.
+Reporting Services용 Aspose.PDF를 사용할 때 표시하거나 인쇄할 때 페이지를 시계 방향으로 회전해야 하는 각도를 설정할 수 있습니다. 자세한 내용은 '페이지 회전 각도' 항목을 참조하세요.
 
 ## 페이지 여백 크기
 
-Reporting Services 디자이너는 페이지 여백 크기 설정을 지원하지 않습니다. Aspose.PDF for Reporting Services는 반면에 해당 페이지 여백 크기를 설정하기 위한 네 가지 매개변수를 제공합니다. 이 매개변수는 PageMarginLeft, PageMarginRight, PageMarginTop 및 PageMarginBottom입니다. 자세한 내용은 'Page Margin Size' 섹션을 참조하십시오.
+Reporting Services 디자이너는 페이지 여백 크기 설정을 지원하지 않습니다. 반면 Reporting Services용 Aspose.PDF는 해당 페이지 여백 크기를 설정하는 네 가지 매개 변수를 제공합니다. PageMarginLeft, PageMarginRight, PageMarginTop 및 PageMarginBottom입니다. 자세한 내용은 '페이지 여백 크기' 항목을 참조하세요.

--- a/ko/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
+++ b/ko/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
@@ -1,36 +1,36 @@
 ---
-title: Reporting Services에 Aspose.Pdf를 선택하는 이유
-linktitle: Reporting Services에 Aspose.Pdf를 선택하는 이유
+title: 왜 Aspose.PDF for Reporting Services를 선택합니까?
+linktitle: 왜 Aspose.PDF for Reporting Services를 선택합니까?
 type: docs
 weight: 10
 url: /ko/reportingservices/why-choose-aspose-pdf-for-reporting-services/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
-**Aspose.Pdf for Reporting Services**는 Microsoft SQL Server 2016, 2017, 2019 및 2022 Reporting Services와 Microsoft Power BI Report Server를 사용하여 PDF 보고서를 생성할 수 있는 강력한 .NET 솔루션입니다. Aspose.Pdf for Reporting Services는 독립적으로 작동하지 않고 SQL Reporting Services용 렌더링 확장 기능입니다. 테이블, 차트, 이미지, Headers/Footers, 선 등 기본 보고서 요소를 지원할 뿐만 아니라 사용자 정의 속성을 추가할 수 있는 기능을 제공하여 SQL Reporting Services에 추가적인 이점을 제공합니다. 이러한 속성을 사용할 때 Report Designer에서 지원하지 않는 List of Contents를 생성할 수 있습니다. 결과 PDF 문서에 Footnotes/Endnotes를 포함시킬 수 있는데, 이는 Report Builder에서 기본적으로 지원되지 않습니다. 또 다른 흥미로운 기능은 SQL Reporting Services에서 지원되지 않는 Line Arrows를 제공하는 것으로, Aspose.Pdf for Reporting Services를 통해 선 요소의 시작이나 끝에 화살표를 추가할 수 있습니다. 또한 Aspose.Pdf for Reporting Services는 Report Designer에서 지원되지 않는 텍스트 정렬(Justify 또는 FullJustify) 정보를 지정하는 기능을 제공합니다. 이러한 텍스트 모드는 결과 문서를 더 잘 포맷하고 읽기 쉽게 만듭니다.
+**Aspose.PDF for Reporting Services**는 Microsoft SQL Server 2016, 2017, 2019 및 2022 Reporting Services와 Microsoft Power BI Report Server를 사용하여 PDF 보고서를 생성할 수 있는 강력한 .NET 솔루션입니다. Aspose.PDF for Reporting Services는 독립적으로 동작하지 않고 SQL Reporting Services용 렌더링 확장 기능입니다. 테이블, 차트, 이미지, 머리글/바닥글, 선 등 기본 보고서 요소를 지원할 뿐만 아니라, SQL Reporting Services에 추가적인 이점을 제공하는 사용자 정의 속성을 추가할 수 있는 기능도 제공합니다. 이러한 속성을 사용하면 Report Designer에서 지원되지 않는 목차(List of Contents)를 생성할 수 있습니다. 결과 PDF 문서에 Report Builder에서 기본적으로 지원되지 않는 각주/미주(Footnotes/Endnotes)를 포함시킬 수도 있습니다. 또 다른 흥미로운 기능은 선에 화살표(Line Arrows)를 추가할 수 있는 것으로, 이는 SQL Reporting Services에서 지원되지 않지만 Aspose.PDF for Reporting Services를 통해 선 요소의 시작이나 끝에 화살표를 삽입할 수 있습니다. 또한 Aspose.PDF for Reporting Services는 Report Designer에서 지원되지 않는 텍스트 정렬(Justify 또는 FullJustify) 지정 기능을 제공합니다. 이러한 텍스트 모드는 결과 문서의 형식을 보다 깔끔하고 읽기 쉽게 만들어 줍니다.
 
-앞서 언급한 기능들 외에도 보고서에 대한 특정 기타 구성 매개변수를 설정하여 SQL Reporting Services에서 기본적으로 지원되지 않는 기능을 얻을 수 있습니다. 다음은 Aspose.Pdf for Reporting Services에서 제공하는 이러한 기능들의 간략한 개요입니다.
+앞서 언급한 기능 외에도 보고서에 대해 다른 구성 매개변수를 설정하여 SQL Reporting Services에서 기본적으로 지원되지 않는 기능을 얻을 수 있습니다. 다음은 Aspose.PDF for Reporting Services에서 제공하는 이러한 기능에 대한 간략한 개요입니다.
 
 ## 보안 설정
 
-때로는 텍스트 복사 및 인쇄 권한이 제한된 비밀번호로 보호된 PDF 문서를 내보내고자 할 수 있습니다. 안타깝게도 Reporting Services는 이 기능을 지원하지 않습니다. 그러나 Aspose.Pdf for Reporting Services를 사용하면 이를 구현할 수 있습니다. 보고서 또는 보고서 서버에 해당 보안 매개변수를 추가하여 제한된 권한을 가진 보안 PDF 문서를 얻으십시오. 자세한 내용은 'Security Setting' 섹션을 참조하십시오.
+때때로 비밀번호로 보호된 PDF 문서를 내보내고 텍스트 복사 및 인쇄 권한을 제한하고 싶을 수 있습니다. 안타깝게도 Reporting Services는 이 기능을 지원하지 않습니다. 하지만 Aspose.PDF for Reporting Services를 사용하면 이를 구현할 수 있습니다. 보고서 또는 보고서 서버에 해당 보안 매개변수를 추가하면 제한된 권한을 가진 보안 PDF 문서를 얻을 수 있습니다. 자세한 내용은 \u0027Security Setting\u0027 섹션을 참조하십시오.
 
 ## 맞춤 글꼴 임베딩
 
-Reporting Services 디자이너는 텍스트에 대한 임베디드 글꼴을 지원하지 않습니다; Aspose.Pdf for Reporting Services를 사용하면 PDF 문서에 글꼴 정보를 쉽게 임베드할 수 있습니다. 자세한 내용은 'IsFontEmbedded' 섹션을 참조하십시오.
+Reporting Services 디자이너는 텍스트에 대한 임베디드 글꼴을 지원하지 않지만, Aspose.PDF for Reporting Services를 사용하면 PDF 문서에 글꼴 정보를 쉽게 임베드할 수 있습니다. 자세한 내용은 \u0027IsFontEmbedded\u0027 섹션을 참조하십시오.
 
 ## XMP 메타데이터
 
-Reporting Services 디자이너는 XMP 메타데이터 삽입을 지원하지 않습니다. Aspose.Pdf for Reporting Services는 해당 XMP 메타데이터를 설정하기 위해 네 가지 매개변수(CreationDate, ModifyDate, MetaDataDate 및 CreatorTool)를 제공합니다. 자세한 내용은 'XMP Metadata' 섹션을 참조하십시오.
+Reporting Services 디자이너는 XMP 메타데이터 삽입을 지원하지 않습니다. Aspose.PDF for Reporting Services는 해당 XMP 메타데이터를 설정하기 위해 네 가지 매개변수(CreationDate, ModifyDate, MetaDataDate 및 CreatorTool)를 제공합니다. 자세한 내용은 'XMP Metadata' 섹션을 참조하십시오.
 
 ## PDF/A
 
-SQL Server Reporting Services를 사용할 때는 PDF 문서를 단순 형식으로만 생성할 수 있으며 PDF/A 문서 생성은 지원되지 않습니다. 그러나 Aspose.Pdf for Reporting Services는 하나의 구성 매개변수를 추가하여 PDF/A 규격을 준수하는 문서를 만들 수 있는 기능을 제공합니다. 자세한 내용은 'PDF Conformance' 섹션을 참조하십시오.
+SQL Server Reporting Services를 사용할 경우 PDF 문서를 단순 형식으로만 생성할 수 있으며 PDF/A 문서 생성은 지원되지 않습니다. 그러나 Aspose.PDF for Reporting Services는 단일 구성 매개변수를 추가함으로써 PDF/A 규격에 부합하는 문서를 만들 수 있는 기능을 제공합니다. 자세한 내용은 'PDF Conformance' 섹션을 참조하십시오.
 
 ## 페이지 회전 각도
 
-Aspose.Pdf for Reporting Services를 사용할 때, 표시되거나 인쇄될 때 페이지를 시계 방향으로 회전시킬 각도를 설정할 수 있습니다. 자세한 내용은 'Page Rotating Angle' 섹션을 참조하십시오.
+Aspose.PDF for Reporting Services를 사용할 때 페이지가 표시되거나 인쇄될 때 시계 방향으로 회전해야 하는 각도를 도 단위로 설정할 수 있습니다. 자세한 내용은 'Page Rotating Angle' 섹션을 참조하십시오.
 
 ## 페이지 여백 크기
 
-Reporting Services 디자이너는 페이지 여백 크기 설정을 지원하지 않습니다. 반면에 Aspose.Pdf for Reporting Services는 해당 페이지 여백 크기를 설정하기 위한 네 가지 매개변수를 제공합니다. 이 매개변수는 PageMarginLeft, PageMarginRight, PageMarginTop 및 PageMarginBottom입니다. 자세한 내용은 'Page Margin Size' 섹션을 참조하십시오.
+Reporting Services 디자이너는 페이지 여백 크기 설정을 지원하지 않습니다. Aspose.PDF for Reporting Services는 반면에 해당 페이지 여백 크기를 설정하기 위한 네 가지 매개변수를 제공합니다. 이 매개변수는 PageMarginLeft, PageMarginRight, PageMarginTop 및 PageMarginBottom입니다. 자세한 내용은 'Page Margin Size' 섹션을 참조하십시오.

--- a/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
+++ b/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
@@ -1,15 +1,15 @@
 ---
-title: MS SharePoint와 SQL Reporting Services 통합
-linktitle: MS SharePoint와 SQL Reporting Services 통합
+title: MS SharePoint와 SQL 보고 서비스 통합
+linktitle: MS SharePoint와 SQL 보고 서비스 통합
 type: docs
 weight: 20
-url: /ko/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/
-lastmod: "2026-07-29"
+url: /reportingservices/sql-reporting-services-integration-with-ms-sharepoint/
+lastmod: "2021-06-05"
 ---
 
-**이 섹션에는 다음 주제가 포함됩니다:**
+**이 섹션에는 다음 주제가 포함됩니다.**
 
 - [소개](/pdf/ko/reportingservices/introduction/)
-- [Reporting Services 설정](/pdf/ko/reportingservices/setting-up-reporting-services/)
+- [보고 서비스 설정](/pdf/ko/reportingservices/setting-up-reporting-services/)
 - [Reporting Services 서버에서 SharePoint 설정](/pdf/ko/reportingservices/setting-up-sharepoint-on-reporting-services-server/)
-- [Reporting Services 및 SharePoint 구성](/pdf/ko/reportingservices/reporting-services-and-sharepoint-configuration/)
+- [보고 서비스 및 SharePoint 구성](/pdf/ko/reportingservices/reporting-services-and-sharepoint-configuration/)

--- a/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
+++ b/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
@@ -1,10 +1,10 @@
 ---
-title: SQL Reporting Services와 MS SharePoint 통합
-linktitle: SQL Reporting Services와 MS SharePoint 통합
+title: MS SharePoint와 SQL Reporting Services 통합
+linktitle: MS SharePoint와 SQL Reporting Services 통합
 type: docs
 weight: 20
 url: /ko/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 **이 섹션에는 다음 주제가 포함됩니다:**
@@ -13,4 +13,3 @@ lastmod: "2026-06-19"
 - [Reporting Services 설정](/pdf/ko/reportingservices/setting-up-reporting-services/)
 - [Reporting Services 서버에서 SharePoint 설정](/pdf/ko/reportingservices/setting-up-sharepoint-on-reporting-services-server/)
 - [Reporting Services 및 SharePoint 구성](/pdf/ko/reportingservices/reporting-services-and-sharepoint-configuration/)
-

--- a/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
+++ b/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
@@ -4,18 +4,18 @@ linktitle: 소개
 type: docs
 weight: 10
 url: /ko/reportingservices/introduction/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF for Reporting Services는 오랜 기간 동안 SQL Reporting Services를 통한 PDF 생성에 매우 뛰어나며, SQL Reporting Services에서 기본적으로 지원되지 않는 다양한 구성 및 매개변수 옵션을 제공합니다. 최근에는 Aspose.PDF for Reporting Services와 SharePoint의 통합에 대한 몇 가지 요청을 받았습니다. 이 문서에서는 MS SharePoint 2010에 중점을 둘 것입니다. 진행하기 전에 SharePoint 팜이 이미 설정되어 있다고 가정합니다. 이 예제에서는 전체 SharePoint Cloud를 사용할 것입니다. 그러나 단계는 SharePoint Foundation Server에서도 유사합니다.
+Aspose.PDF for Reporting Services는 수년간 SQL Reporting Services를 통한 PDF 생성에 매우 눈에 띄는 제품이며, SQL Reporting Services에서 기본적으로 지원되지 않는 다양한 구성 및 매개변수 옵션을 제공합니다. 최근 우리는 Aspose.PDF for Reporting Services와 SharePoint 통합에 대한 요청을 받았습니다. 이 기사에서는 MS SharePoint 2010에 초점을 맞출 것입니다. 진행하기 전에 SharePoint Farm이 이미 설정되어 있다고 가정합니다. 이 예제에서는 전체 SharePoint Cloud를 사용할 것입니다. 그러나 단계는 SharePoint Foundation Server에서도 유사합니다.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-계속 진행하기 전에, 이 문서를 준비하면서 참고한 주제들을 살펴보겠습니다.
+앞으로 진행하기 전에, 이 기사 준비 중에 참고한 주제들을 살펴보겠습니다.
 
 - [Reporting Services와 SharePoint 기술 통합 개요](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
 - [SharePoint 통합 모드에서 Reporting Services 배포 토폴로지](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
@@ -25,30 +25,29 @@ Aspose.PDF for Reporting Services는 오랜 기간 동안 SQL Reporting Services
 
 ## 환경 설정
 
-우리 설정은 4대의 서버로 구성됩니다. 여기에는 도메인 컨트롤러, SQL Server, SharePoint Server 및 Reporting Services용 서버가 포함됩니다. SharePoint와 Reporting Services를 동일한 서버에 배치할 수 있으며, 이렇게 하면 약간 단순화되고 차이점을 몇 가지 강조할 것입니다.
+우리 설정은 4개의 서버로 구성됩니다. 여기에는 Domain Controller, SQL Server, SharePoint Server 및 Reporting Services용 서버가 포함됩니다. SharePoint와 Reporting Services를 동일한 서버에 배치할 수 있으며, 이렇게 하면 약간 단순화되고 차이점을 몇 가지 지적하겠습니다.
 
 ## 설치 전제 조건
 
 {{% alert color="primary" %}}
 
-SharePoint용 Reporting Services Add-In은 통합을 올바르게 작동시키는 핵심 구성 요소 중 하나입니다. Add-In은 SharePoint 팜에 있는 모든 Web Front Ends (WFE)와 중앙 관리 서버에 설치되어야 합니다. SQL 2008 R2 & SharePoint 2010의 새로운 변경 사항 중 하나는 2008 R2 Add-In이 이제 SharePoint 설치의 전제 조건이 된다는 것입니다. 이는 SharePoint를 설치할 때 RS Add‑In이 자동으로 배포된다는 의미입니다. 아래 그림에 표시되고 강조되었습니다. 이는 실제로 SP 2007 및 RS 2008에서 Add‑In을 설치할 때 발생하던 많은 문제를 방지합니다.
+Reporting Services Add-In for SharePoint는 통합을 올바르게 작동시키는 핵심 구성 요소 중 하나입니다. 이 Add-In은 SharePoint 팜에 있는 모든 Web Front End (WFE)와 Central Admin 서버에 설치되어야 합니다. SQL 2008 R2와 SharePoint 2010의 새로운 변경 사항 중 하나는 2008 R2 Add-In이 이제 SharePoint 설치의 전제 조건이 된다는 점입니다. 이는 SharePoint를 설치할 때 RS Add-In이 자동으로 배포된다는 의미입니다. 아래 그림에서 표시되고 강조된 바와 같습니다. 이는 실제로 우리가 SP 2007 및 RS 2008에서 Add-In을 설치할 때 겪었던 많은 문제를 방지합니다.
 
 ![todo:image_alt_text](introduction_1.png)
 
-**Image1 :- Share Point용 Reporting Services 애드인**
+**Image1 :- Share Point용 Reporting Services 추가 기능**
 {{% /alert %}}
 
 ## SharePoint 인증
 
-**RS 통합 파트로 들어가기 전에 SharePoint 팜에 대해 강조하고 싶은 점은 사이트를 어떻게 설정하느냐입니다. 보다 구체적으로 사이트 인증을 어떻게 구성하느냐인데, 클래식인지 Claims인지 여부입니다. 이 선택은 초기 단계에서 중요합니다. 한 번 설정하면 변경할 수 없다고 생각합니다. 만약 변경 가능하다고 해도 간단한 과정이 아닐 것입니다.**
+**RS 통합 파트로 들어가기 전에 SharePoint 팜에 대해 강조하고 싶은 점은 사이트를 설정하는 방법입니다. 특히 사이트 인증을 어떻게 구성하는지입니다. 클래식인지 클레임인지 여부가 중요합니다. 이 선택은 초기에 중요한데, 한 번 설정하면 변경할 수 없다고 생각합니다. 변경할 수 있다 하더라도 간단한 과정이 아닙니다.**
 
-NOTE: ***Reporting Services 2008 R2는 Claims를 인식하지 못합니다***
+NOTE: ***Reporting Services 2008 R2는 클레임을 지원하지 않습니다***
 
-SharePoint 사이트를 Claims를 사용하도록 선택하더라도 Reporting Services 자체는 Claims를 인식하지 못합니다. 그렇지만 이는 Reporting Services의 인증 방식에 영향을 미칩니다. 그렇다면 Reporting Services 관점에서는 어떤 차이가 있나요? 핵심은 사용자 자격 증명을 데이터 소스로 전달할지 여부입니다. Classic:- Kerberos를 사용할 수 있으며 사용자 자격 증명을 백엔드 데이터 소스로 전달할 수 있습니다(이를 위해 Kerberos가 필요합니다). Claims:- Claims 토큰이 사용되며 Windows 토큰이 아닙니다. RS는 이 시나리오에서 항상 Trusted Authentication을 사용하며 SPUser 토큰에만 접근할 수 있습니다. 데이터 소스 내에 자격 증명을 저장해야 합니다.
+SharePoint 사이트를 Claims 사용하도록 선택하더라도 Reporting Services 자체는 Claims를 인식하지 않습니다. 하지만 이는 Reporting Services의 인증 방식에 영향을 줍니다. 그렇다면 Reporting Services 관점에서 차이점은 무엇일까요? 이것은 사용자 자격 증명을 데이터 소스로 전달할지 여부에 달려 있습니다. Classic:- Kerberos를 사용하여 사용자의 자격 증명을 백엔드 데이터소스로 전달할 수 있습니다(이를 위해 Kerberos가 필요합니다). Claims:- Claims 토큰이 사용되며 Windows 토큰이 아닙니다. RS는 항상 Trusted Authentication을 사용하며 SPUser 토큰에만 접근할 수 있습니다. 데이터 소스 내에 자격 증명을 저장해야 합니다.
 
-Classic :- Kerberos를 사용하여 사용자 자격 증명을 백엔드 데이터 소스로 전달할 수 있습니다(이를 위해 Kerberos가 필요합니다).
+Classic :- Kerberos를 사용하고 사용자의 자격 증명을 백엔드 데이터소스로 전달할 수 있습니다(이를 위해 Kerberos가 필요합니다.
 
-Claims :- Claims 토큰이 사용되며 Windows 토큰이 아닙니다. RS는 이 시나리오에서 항상 Trusted Authentication을 사용하며 SPUser 토큰에만 접근할 수 있습니다. 데이터 소스 내에 자격 증명을 저장해야 합니다.
+Claims :- Claims 토큰이 사용되며 Windows 토큰이 아닙니다. 이 시나리오에서 RS는 항상 Trusted Authentication을 사용하며 SPUser 토큰에만 접근할 수 있습니다. 데이터 소스 내에 자격 증명을 저장해야 합니다.
 
-우선 우리는 RS 설정에만 집중하고 싶습니다. 현재 SharePoint가 내 SharePoint Box에 설치되어 포트 80의 클래식 인증 사이트로 설정되었습니다. RS 서버에 Reporting Services를 방금 설치했으며, 그것이 전부입니다.
-
+우선 현재는 RS 설정에만 집중하고 싶습니다. 현재 SharePoint는 내 SharePoint Box에 설치되어 포트 80에서 클래식 인증 사이트로 설정되어 있습니다. RS 서버에는 Reporting Services를 방금 설치했으며, 그것뿐입니다.

--- a/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
+++ b/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
@@ -3,51 +3,51 @@ title: 소개
 linktitle: 소개
 type: docs
 weight: 10
-url: /ko/reportingservices/introduction/
-lastmod: "2026-07-29"
+url: /reportingservices/introduction/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF for Reporting Services는 수년간 SQL Reporting Services를 통한 PDF 생성에 매우 눈에 띄는 제품이며, SQL Reporting Services에서 기본적으로 지원되지 않는 다양한 구성 및 매개변수 옵션을 제공합니다. 최근 우리는 Aspose.PDF for Reporting Services와 SharePoint 통합에 대한 요청을 받았습니다. 이 기사에서는 MS SharePoint 2010에 초점을 맞출 것입니다. 진행하기 전에 SharePoint Farm이 이미 설정되어 있다고 가정합니다. 이 예제에서는 전체 SharePoint Cloud를 사용할 것입니다. 그러나 단계는 SharePoint Foundation Server에서도 유사합니다.
+Reporting Services용 Aspose.PDF는 수년 동안 SQL Reporting Services를 통한 PDF 생성에 있어 매우 뛰어난 기능을 수행했으며 SQL Reporting Services에서 기본적으로 지원되지 않는 다양한 구성 및 매개 변수화 옵션을 제공합니다. 최근 우리는 SharePoint와의 Reporting Services 통합을 위한 Aspose.PDF에 관한 요청을 받았습니다. 이 기사에서는 MS SharePoint 2010에 중점을 둘 것입니다. 더 진행하기 전에 이미 SharePoint Farm 설정이 있다고 가정합니다. 이 예에서는 전체 SharePoint Cloud를 사용하겠습니다. 그러나 단계는 SharePoint Foundation Server와 유사합니다.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-앞으로 진행하기 전에, 이 기사 준비 중에 참고한 주제들을 살펴보겠습니다.
+더 진행하기 전에 이 기사를 준비하는 동안 참고한 참고 주제를 살펴보겠습니다.
 
-- [Reporting Services와 SharePoint 기술 통합 개요](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
-- [SharePoint 통합 모드에서 Reporting Services 배포 토폴로지](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
-- [SharePoint 2010 통합을 위한 Reporting Services 구성](http://msdn.microsoft.com/en-us/library/bb326356.aspx)
+- [보고 서비스 및 SharePoint 기술 통합 개요](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
+- [SharePoint 통합 모드의 Reporting Services 배포 토폴로지](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
+- [SharePoint 2010 통합을 위한 보고 서비스 구성](http://msdn.microsoft.com/en-us/library/bb326356.aspx)
 
 {{% /alert %}}
 
-## 환경 설정
+## 환경설정
 
-우리 설정은 4개의 서버로 구성됩니다. 여기에는 Domain Controller, SQL Server, SharePoint Server 및 Reporting Services용 서버가 포함됩니다. SharePoint와 Reporting Services를 동일한 서버에 배치할 수 있으며, 이렇게 하면 약간 단순화되고 차이점을 몇 가지 지적하겠습니다.
+Out 설정은 4개의 서버로 구성됩니다. 여기에는 도메인 컨트롤러, SQL Server, SharePoint Server 및 Reporting Services용 서버가 포함됩니다. SharePoint와 Reporting Services를 동일한 상자에 포함하도록 선택할 수도 있습니다. 이렇게 하면 이 작업이 약간 단순화되고 몇 가지 차이점을 지적하겠습니다.
 
-## 설치 전제 조건
+## 설치 전제조건
 
 {{% alert color="primary" %}}
 
-Reporting Services Add-In for SharePoint는 통합을 올바르게 작동시키는 핵심 구성 요소 중 하나입니다. 이 Add-In은 SharePoint 팜에 있는 모든 Web Front End (WFE)와 Central Admin 서버에 설치되어야 합니다. SQL 2008 R2와 SharePoint 2010의 새로운 변경 사항 중 하나는 2008 R2 Add-In이 이제 SharePoint 설치의 전제 조건이 된다는 점입니다. 이는 SharePoint를 설치할 때 RS Add-In이 자동으로 배포된다는 의미입니다. 아래 그림에서 표시되고 강조된 바와 같습니다. 이는 실제로 우리가 SP 2007 및 RS 2008에서 Add-In을 설치할 때 겪었던 많은 문제를 방지합니다.
+SharePoint용 Reporting Services 추가 기능은 통합이 제대로 작동하도록 하는 핵심 구성 요소 중 하나입니다. 추가 기능은 중앙 관리 서버와 함께 SharePoint 팜에 있는 WFE(웹 프런트 엔드)에 설치해야 합니다. SQL 2008 R2 및 SharePoint 2010의 새로운 변경 사항 중 하나는 2008 R2 추가 기능이 이제 SharePoint 설치를 위한 필수 구성 요소라는 것입니다. 이는 SharePoint를 설치할 때 RS 추가 기능이 설치된다는 의미입니다. 아래 그림에 표시되어 강조되어 있습니다. 이렇게 하면 실제로 추가 기능을 설치할 때 SP 2007 및 RS 2008에서 볼 수 있는 많은 문제를 피할 수 있습니다.
 
-![todo:image_alt_text](introduction_1.png)
+![Introduction](introduction_1.png)
 
-**Image1 :- Share Point용 Reporting Services 추가 기능**
+**이미지1 :- Share Point용 보고 서비스 추가 기능**
 {{% /alert %}}
 
 ## SharePoint 인증
 
-**RS 통합 파트로 들어가기 전에 SharePoint 팜에 대해 강조하고 싶은 점은 사이트를 설정하는 방법입니다. 특히 사이트 인증을 어떻게 구성하는지입니다. 클래식인지 클레임인지 여부가 중요합니다. 이 선택은 초기에 중요한데, 한 번 설정하면 변경할 수 없다고 생각합니다. 변경할 수 있다 하더라도 간단한 과정이 아닙니다.**
+**RS 통합 부분을 살펴보기 전에 SharePoint 팜에 대해 지적하고 싶은 한 가지는 사이트 설정 방법입니다. 보다 구체적으로 사이트에 대한 인증을 구성하는 방법입니다. 클래식인지 클레임인지 여부. 이 선택은 처음에 중요합니다. 나는 이 옵션이 일단 완료되면 변경할 수 있다고 믿지 않습니다. 변경할 수 있다면 간단한 과정이 아닐 것입니다.
 
-NOTE: ***Reporting Services 2008 R2는 클레임을 지원하지 않습니다***
+참고: ***Reporting Services 2008 R2는 클레임을 인식하지 않습니다***
 
-SharePoint 사이트를 Claims 사용하도록 선택하더라도 Reporting Services 자체는 Claims를 인식하지 않습니다. 하지만 이는 Reporting Services의 인증 방식에 영향을 줍니다. 그렇다면 Reporting Services 관점에서 차이점은 무엇일까요? 이것은 사용자 자격 증명을 데이터 소스로 전달할지 여부에 달려 있습니다. Classic:- Kerberos를 사용하여 사용자의 자격 증명을 백엔드 데이터소스로 전달할 수 있습니다(이를 위해 Kerberos가 필요합니다). Claims:- Claims 토큰이 사용되며 Windows 토큰이 아닙니다. RS는 항상 Trusted Authentication을 사용하며 SPUser 토큰에만 접근할 수 있습니다. 데이터 소스 내에 자격 증명을 저장해야 합니다.
+클레임을 사용하기 위해 SharePoint 사이트를 선택하더라도 Reporting Services 자체는 클레임을 인식하지 못합니다. 즉, Reporting Services에서 인증이 작동하는 방식에 영향을 미칩니다. 그렇다면 Reporting Services 관점과의 차이점은 무엇입니까? 사용자 자격 증명을 데이터 소스에 전달할지 여부가 결정됩니다. 클래식:- Kerberos를 사용하고 사용자의 자격 증명을 백엔드 데이터 소스에 전달할 수 있습니다(이를 위해서는 Kerberos를 사용해야 함). 클레임:- Windows 토큰이 아닌 클레임 토큰이 사용됩니다. RS는 이 시나리오에서 항상 신뢰할 수 있는 인증을 사용하며 SPUser 토큰에만 액세스할 수 있습니다. 데이터 소스 내에 자격 증명을 저장해야 합니다.
 
-Classic :- Kerberos를 사용하고 사용자의 자격 증명을 백엔드 데이터소스로 전달할 수 있습니다(이를 위해 Kerberos가 필요합니다.
+클래식 :- Kerberos를 사용하고 사용자의 자격 증명을 백엔드 데이터 소스에 전달할 수 있습니다(이를 위해서는 Kerberos를 사용해야 합니다.
 
-Claims :- Claims 토큰이 사용되며 Windows 토큰이 아닙니다. 이 시나리오에서 RS는 항상 Trusted Authentication을 사용하며 SPUser 토큰에만 접근할 수 있습니다. 데이터 소스 내에 자격 증명을 저장해야 합니다.
+클레임 :-Windows 토큰이 아닌 클레임 토큰이 사용됩니다. RS는 이 시나리오에서 항상 신뢰할 수 있는 인증을 사용하며 SPUser 토큰에만 액세스할 수 있습니다. 데이터 소스 내에 자격 증명을 저장해야 합니다.
 
-우선 현재는 RS 설정에만 집중하고 싶습니다. 현재 SharePoint는 내 SharePoint Box에 설치되어 포트 80에서 클래식 인증 사이트로 설정되어 있습니다. RS 서버에는 Reporting Services를 방금 설치했으며, 그것뿐입니다.
+지금은 RS 설정에만 집중하고 싶습니다. 이 시점에서 SharePoint는 내 SharePoint Box에 설치되고 포트 80의 클래식 인증 사이트로 설정됩니다. RS 서버에는 방금 보고 서비스를 설치했으며 그게 전부입니다.

--- a/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
+++ b/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
@@ -1,44 +1,44 @@
 ---
-title: Reporting Services 및 SharePoint 구성
-linktitle: Reporting Services 및 SharePoint 구성
+title: 보고 서비스 및 SharePoint 구성
+linktitle: 보고 서비스 및 SharePoint 구성
 type: docs
 weight: 40
-url: /ko/reportingservices/reporting-services-and-sharepoint-configuration/
-lastmod: "2026-07-29"
+url: /reportingservices/reporting-services-and-sharepoint-configuration/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-이제 SharePoint가 RS 서버에 설치되고 구성되었으며, RS가 Reporting Services Configuration Manager를 통해 설정되었으니, Central Admin 내에서의 구성으로 이동할 수 있습니다. RS 2008 R2는 이 프로세스를 크게 단순화했습니다. 이전에는 작업을 수행하려면 3단계 프로세스가 필요했습니다. 이제는 한 단계만 있으면 됩니다.
+이제 SharePoint가 RS 서버에 설치 및 구성되고 RS가 Reporting Services 구성 관리자를 통해 설정 및 설정되었으므로 중앙 관리 내의 구성으로 이동할 수 있습니다. RS 2008 R2는 이 프로세스를 매우 단순화했습니다. 우리는 이것을 작동시키기 위해 수행해야 하는 3단계 프로세스를 사용했습니다. 이제 한 단계만 남았습니다.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-우리는 Central Administrator 웹 사이트로 이동한 다음 General Application Settings으로 들어갑니다. 아래쪽에 Reporting Services가 표시됩니다.
+중앙 관리자 웹 사이트로 이동한 다음 일반 응용 프로그램 설정으로 이동하려고 합니다. 아래쪽에는 보고 서비스가 표시됩니다.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_1.png)
-**Image1**:- SharePoint 구성 대화상자
+![Configuration-step1](reporting-services-and-sharepoint-configuration_1.png)
+**이미지1**:- SharePoint 구성 대화 상자
 
-"Reporting Services Integration" 링크를 선택합니다. 다음 화면이 표시됩니다.
+"보고 서비스 통합" 링크를 선택합니다. 다음 화면이 표시됩니다.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_2.png)
-**Image2**:- Reporting Services 통합 자격 증명을 지정하십시오
+![Configuration-step2](reporting-services-and-sharepoint-configuration_2.png)
+**이미지2**:- Reporting Services 통합 자격 증명 지정
 
 {{% /alert %}}
 
-## Web 서비스 URL:
+## 웹 서비스 URL:
 
-**Reporting Services 구성 관리자에서 찾은 보고서 서버의 URL을 제공하겠습니다.**
+**보고 서비스 구성 관리자에서 찾은 보고서 서버의 URL을 제공하겠습니다.**
 
 ## 인증 모드:
 
-**우리는 인증 모드도 선택합니다. 다음 MSDN 링크에서는 이것이 무엇인지 자세히 설명합니다.
-SharePoint 통합 모드에서 Reporting Services에 대한 보안 개요**
+**인증 모드도 선택합니다. 다음 MSDN 링크는 이것이 무엇인지 자세히 설명합니다.
+SharePoint 통합 모드의 Reporting Services에 대한 보안 개요**
 
 {{% alert color="primary" %}}
 
-**간단히 말하면, 사이트가 클레임 인증을 사용하고 있다면 여기에서 무엇을 선택하든 항상 신뢰된 인증(Trusted Authentication)을 사용하게 됩니다. Windows 자격 증명을 전달하려면 Windows 인증을 선택해야 합니다. 신뢰된 인증을 사용할 경우, 우리는 Windows 자격 증명에 의존하지 않고 SPUser 토큰을 전달합니다. 클래식 모드 사이트를 NTLM으로 구성했고 RS가 NTLM으로 설정된 경우에도 신뢰된 인증을 사용해야 합니다. Windows 인증을 사용하고 데이터 소스에 전달하려면 Kerberos가 필요합니다.**
+**간단히 말하면, 사이트에서 클레임 인증을 사용하는 경우 여기에서 선택한 항목에 관계없이 항상 신뢰할 수 있는 인증을 사용하게 됩니다. Windows 자격 증명을 전달하려면 Windows 인증을 선택해야 합니다. 신뢰할 수 있는 인증의 경우 Windows 자격 증명을 사용하지 않고 SPUser 토큰을 전달합니다. NTLM용 클래식 모드 사이트를 구성했고 RS가 NTLM용으로 설정된 경우에도 신뢰할 수 있는 인증을 사용하고 싶을 것입니다. Windows 인증을 사용하고 이를 데이터 소스에 전달하려면 Kerberos가 필요합니다.**
 
 {{% /alert %}}
 
@@ -46,54 +46,54 @@ SharePoint 통합 모드에서 Reporting Services에 대한 보안 개요**
 
 {{% alert color="primary" %}}
 
-**이 옵션을 사용하면 모든 사이트 컬렉션에 Reporting Services를 활성화하거나, 활성화하고 싶은 컬렉션을 선택할 수 있습니다. 이는 실제로 어떤 사이트가 Reporting Services를 사용할 수 있는지를 의미합니다. 완료되면 다음 결과가 표시되어야 합니다**
+**이렇게 하면 모든 사이트 모음에서 보고 서비스를 활성화할 수 있는 옵션이 제공됩니다. 또는 활성화하려는 모음을 선택할 수도 있습니다. 이는 실제로 보고 서비스를 사용할 수 있는 사이트를 의미합니다. 완료되면 다음 결과가 표시됩니다**
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_3.png)
+![Configuration-step3](reporting-services-and-sharepoint-configuration_3.png)
 
-**Image3:**- Reporting Services와 SharePoint 환경의 성공적인 통합
+**이미지3:**- Reporting Services와 SharePoint 환경의 성공적인 통합
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-ReportServer URL로 돌아가면 다음과 유사한 것을 볼 수 있어야 합니다
+ReportServer URL로 돌아가면 다음과 비슷한 내용이 표시됩니다.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_4.png)
+![Configuration-step4](reporting-services-and-sharepoint-configuration_4.png)
 
-**Image4:**- Reporting Services가 SharePoint 환경에 성공적으로 연결되었습니다
+**이미지4:**- Reporting Services가 SharePoint 환경과 성공적으로 연결되었습니다.
 
-**NOTE:** ***SharePoint 사이트가 SSL로 구성된 경우, 이 목록에 표시되지 않습니다. 이것은 알려진 문제이며 문제가 있다는 의미는 아닙니다. 보고서는 여전히 작동해야 합니다.***
+**참고:** ***SharePoint 사이트가 SSL용으로 구성된 경우 이 목록에 표시되지 않습니다. 이는 알려진 문제이며 문제가 있다는 의미는 아닙니다. 귀하의 보고서는 계속 작동할 것입니다.***
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-이제 두 제품을 성공적으로 통합했으므로 SharePoint 2010에서 Reporting Services를 사용할 준비가 되었습니다. 이전 버전과 같이 “Site Collection Feature”(Reporting Services Integration을 구성할 때 활성화됨)이라는 기능이 있습니다. 또한 설치 과정에서 우리 사이트에 추가할 3개의 콘텐츠 유형이 추가되었습니다. Image 7에서 두 개의 콘텐츠 유형이 문서 라이브러리에 추가되어 사용자 지정 보고서를 생성하는 데 사용되는 것을 볼 수 있으며, 아래 Image5에서도 확인할 수 있습니다.
+이제 두 제품을 성공적으로 통합했으므로 SharePoint 2010에서 보고 서비스를 사용할 준비가 되었습니다. 이전 버전에는 "사이트 모음 기능"에 기능(보고 서비스 통합을 구성할 때 활성화됨)이 있습니다. 또한 설치로 인해 사이트에 추가할 3가지 콘텐츠 유형이 추가되었습니다. 이미지 7에서는 아래 이미지 5에서 볼 수 있듯이 ing을 사용하여 사용자 지정 보고서를 만들기 위해 문서 라이브러리에 추가된 콘텐츠 유형 중 2개를 볼 수 있습니다.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_5.png)
+![Configuration-step5](reporting-services-and-sharepoint-configuration_5.png)
 
-**Image5:**- Report Builder
+**이미지5:**- 보고서 작성기
 
-“Reporter Builder”는 ActiveX 컨트롤이므로 아래 Image 6에서 볼 수 있듯이 서버를 통해 다운로드해야 합니다.
+"Reporter Builder"는 ActiveX 컨트롤이므로 아래 이미지 6에서 볼 수 있듯이 서버를 통해 다운로드해야 합니다.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_6.png)
+![Configuration-step6](reporting-services-and-sharepoint-configuration_6.png)
 
-**Image6:**- Report Builder 다운로드 및 설치
+**이미지6:**- 보고서 작성기 다운로드 및 설치
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-다운로드 과정이 완료되면 “Report Builder” 컨트롤을 로드합니다. 이제 아래 Image7에 표시된 대로 첫 번째 보고서를 디자인할 준비가 되었습니다.
+다운로드 프로세스가 완료되면 "보고서 작성기" 컨트롤을 로드합니다. 이제 아래 이미지 7과 같이 첫 번째 보고서를 디자인할 준비가 되었습니다.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_7.png)
+![Configuration-step7](reporting-services-and-sharepoint-configuration_7.png)
 
-**Image7:**- Report Builder – 새 보고서 생성 마법사
+**이미지7:**- 보고서 작성기 – 새 보고서 생성 마법사
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-보고서를 만든 후에는 SharePoint 2010에 보고서를 저장할 문서 라이브러리에 저장할 수 있습니다. 다른 콘텐츠 유형을 사용하여 데이터 소스로 공유 연결을 만들고 이를 SharePoint의 문서 라이브러리에 저장해야 합니다. 문서 라이브러리를 만들고 이 콘텐츠 유형을 추가하면 보고서의 데이터 소스를 변경할 수 있는 연결을 사용할 수 있게 됩니다.
+보고서를 만든 후에는 보고서를 SharePoint 2010에 넣기 위해 만든 문서 라이브러리에 저장할 수 있습니다. 다른 콘텐츠 형식을 사용하여 데이터 원본으로 공유 연결을 만들고 이를 SharePoint의 문서 라이브러리에 저장해야 합니다. 문서 라이브러리를 만들고 이 콘텐츠 유형을 추가한 후 연결을 사용하여 보고서의 데이터 원본을 변경할 수 있습니다.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_8.png)
+![Configuration-step8](reporting-services-and-sharepoint-configuration_8.png)
 
-**Image8:**- Aspose.PDF for Reporting Services와 MS SharePoint의 성공적인 통합
+**이미지8:**- 보고 서비스용 Aspose.PDF와 MS SharePoint의 성공적인 통합
 {{% /alert %}}
 

--- a/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
+++ b/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
@@ -4,12 +4,12 @@ linktitle: Reporting Services 및 SharePoint 구성
 type: docs
 weight: 40
 url: /ko/reportingservices/reporting-services-and-sharepoint-configuration/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-이제 SharePoint가 RS 서버에 설치되고 구성되었으며 RS가 Reporting Services Configuration Manager를 통해 설정되었으니, Central Admin 내의 구성으로 이동할 수 있습니다. RS 2008 R2는 이 과정을 정말 간소화했습니다. 이전에는 이를 작동시키기 위해 3단계 프로세스를 수행해야 했습니다. 이제는 한 단계만 있으면 됩니다.
+이제 SharePoint가 RS 서버에 설치되고 구성되었으며, RS가 Reporting Services Configuration Manager를 통해 설정되었으니, Central Admin 내에서의 구성으로 이동할 수 있습니다. RS 2008 R2는 이 프로세스를 크게 단순화했습니다. 이전에는 작업을 수행하려면 3단계 프로세스가 필요했습니다. 이제는 한 단계만 있으면 됩니다.
 
 {{% /alert %}}
 
@@ -18,27 +18,27 @@ lastmod: "2026-06-19"
 우리는 Central Administrator 웹 사이트로 이동한 다음 General Application Settings으로 들어갑니다. 아래쪽에 Reporting Services가 표시됩니다.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_1.png)
-**Image1**:- SharePoint 구성 대화 상자
+**Image1**:- SharePoint 구성 대화상자
 
 "Reporting Services Integration" 링크를 선택합니다. 다음 화면이 표시됩니다.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_2.png)
-**Image2**:- 보고 서비스 통합 자격 증명 지정
+**Image2**:- Reporting Services 통합 자격 증명을 지정하십시오
 
 {{% /alert %}}
 
-## 웹 서비스 URL:
+## Web 서비스 URL:
 
-**우리는 Reporting Services Configuration Manager에서 찾은 보고 서버의 URL을 제공할 것입니다.**
+**Reporting Services 구성 관리자에서 찾은 보고서 서버의 URL을 제공하겠습니다.**
 
 ## 인증 모드:
 
-**인증 모드도 선택합니다. 다음 MSDN 링크에서 이들에 대해 자세히 알아볼 수 있습니다.
-SharePoint 통합 모드에서 보고 서비스 보안 개요**
+**우리는 인증 모드도 선택합니다. 다음 MSDN 링크에서는 이것이 무엇인지 자세히 설명합니다.
+SharePoint 통합 모드에서 Reporting Services에 대한 보안 개요**
 
 {{% alert color="primary" %}}
 
-**요약하면, 사이트가 Claims 인증을 사용하고 있다면 여기에서 무엇을 선택하든 항상 Trusted Authentication을 사용하게 됩니다. Windows 자격 증명을 전달하려면 Windows Authentication을 선택해야 합니다. Trusted Authentication의 경우, 우리는 Windows 자격 증명에 의존하지 않고 SPUser 토큰을 전달합니다. 클래식 모드 사이트를 NTLM으로 구성하고 RS가 NTLM으로 설정된 경우에도 Trusted Authentication을 사용해야 합니다. Windows Authentication을 사용하고 데이터 원본에 이를 전달하려면 Kerberos가 필요합니다.**
+**간단히 말하면, 사이트가 클레임 인증을 사용하고 있다면 여기에서 무엇을 선택하든 항상 신뢰된 인증(Trusted Authentication)을 사용하게 됩니다. Windows 자격 증명을 전달하려면 Windows 인증을 선택해야 합니다. 신뢰된 인증을 사용할 경우, 우리는 Windows 자격 증명에 의존하지 않고 SPUser 토큰을 전달합니다. 클래식 모드 사이트를 NTLM으로 구성했고 RS가 NTLM으로 설정된 경우에도 신뢰된 인증을 사용해야 합니다. Windows 인증을 사용하고 데이터 소스에 전달하려면 Kerberos가 필요합니다.**
 
 {{% /alert %}}
 
@@ -46,7 +46,7 @@ SharePoint 통합 모드에서 보고 서비스 보안 개요**
 
 {{% alert color="primary" %}}
 
-**이 옵션을 사용하면 모든 사이트 컬렉션에 대해 Reporting Services를 활성화하거나, 활성화할 사이트를 선택할 수 있습니다. 이는 실제로 어떤 사이트가 Reporting Services를 사용할 수 있는지를 의미합니다. 완료되면 다음 결과가 표시됩니다**
+**이 옵션을 사용하면 모든 사이트 컬렉션에 Reporting Services를 활성화하거나, 활성화하고 싶은 컬렉션을 선택할 수 있습니다. 이는 실제로 어떤 사이트가 Reporting Services를 사용할 수 있는지를 의미합니다. 완료되면 다음 결과가 표시되어야 합니다**
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_3.png)
 
@@ -55,18 +55,18 @@ SharePoint 통합 모드에서 보고 서비스 보안 개요**
 
 {{% alert color="primary" %}}
 
-ReportServer URL로 돌아가면, 다음과 유사한 내용을 보게 됩니다
+ReportServer URL로 돌아가면 다음과 유사한 것을 볼 수 있어야 합니다
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_4.png)
 
 **Image4:**- Reporting Services가 SharePoint 환경에 성공적으로 연결되었습니다
 
-**NOTE:** ***SharePoint 사이트가 SSL로 구성된 경우 이 목록에 표시되지 않습니다. 이는 알려진 문제이며 문제가 있다는 의미는 아닙니다. 보고서는 여전히 작동해야 합니다.***
+**NOTE:** ***SharePoint 사이트가 SSL로 구성된 경우, 이 목록에 표시되지 않습니다. 이것은 알려진 문제이며 문제가 있다는 의미는 아닙니다. 보고서는 여전히 작동해야 합니다.***
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-이제 두 제품을 성공적으로 통합했으므로 SharePoint 2010에서 Reporting Services를 사용할 준비가 되었습니다. 이전 버전과 마찬가지로 “Site Collection Feature”(Reporting Services Integration을 구성할 때 활성화됨)이라는 기능이 있습니다. 또한 설치 시 사이트에 추가할 3개의 콘텐츠 유형이 추가되었습니다. Image 7에서는 문서 라이브러리에 추가된 두 개의 콘텐츠 유형을 볼 수 있으며, 이를 사용하여 사용자 지정 보고서를 생성합니다, 아래 Image5에서 볼 수 있듯이.
+이제 두 제품을 성공적으로 통합했으므로 SharePoint 2010에서 Reporting Services를 사용할 준비가 되었습니다. 이전 버전과 같이 “Site Collection Feature”(Reporting Services Integration을 구성할 때 활성화됨)이라는 기능이 있습니다. 또한 설치 과정에서 우리 사이트에 추가할 3개의 콘텐츠 유형이 추가되었습니다. Image 7에서 두 개의 콘텐츠 유형이 문서 라이브러리에 추가되어 사용자 지정 보고서를 생성하는 데 사용되는 것을 볼 수 있으며, 아래 Image5에서도 확인할 수 있습니다.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_5.png)
 
@@ -81,7 +81,7 @@ ReportServer URL로 돌아가면, 다음과 유사한 내용을 보게 됩니다
 
 {{% alert color="primary" %}}
 
-다운로드 과정이 완료되면 “Report Builder” 컨트롤을 로드합니다. 이제 아래 Image7에 표시된 것처럼 첫 번째 보고서를 디자인할 준비가 되었습니다.
+다운로드 과정이 완료되면 “Report Builder” 컨트롤을 로드합니다. 이제 아래 Image7에 표시된 대로 첫 번째 보고서를 디자인할 준비가 되었습니다.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_7.png)
 
@@ -90,11 +90,10 @@ ReportServer URL로 돌아가면, 다음과 유사한 내용을 보게 됩니다
 
 {{% alert color="primary" %}}
 
-보고서를 만든 후에는 SharePoint 2010에 보고서를 저장할 문서 라이브러리에 저장할 수 있습니다. 다른 콘텐츠 유형을 사용하여 데이터 원본으로 공유 연결을 만들고 이를 SharePoint의 문서 라이브러리에 저장해야 합니다. 문서 라이브러리를 만들고 해당 콘텐츠 유형을 추가한 다음, 보고서의 데이터 원본을 변경할 수 있는 연결을 사용할 수 있습니다.
+보고서를 만든 후에는 SharePoint 2010에 보고서를 저장할 문서 라이브러리에 저장할 수 있습니다. 다른 콘텐츠 유형을 사용하여 데이터 소스로 공유 연결을 만들고 이를 SharePoint의 문서 라이브러리에 저장해야 합니다. 문서 라이브러리를 만들고 이 콘텐츠 유형을 추가하면 보고서의 데이터 소스를 변경할 수 있는 연결을 사용할 수 있게 됩니다.
 
 ![todo:image_alt_text](reporting-services-and-sharepoint-configuration_8.png)
 
 **Image8:**- Aspose.PDF for Reporting Services와 MS SharePoint의 성공적인 통합
 {{% /alert %}}
-
 

--- a/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
+++ b/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
@@ -4,31 +4,31 @@ linktitle: Reporting Services 설정
 type: docs
 weight: 20
 url: /ko/reportingservices/setting-up-reporting-services/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-Reporting Services Server에서 우리의 첫 번째 목적지는 Reporting Services Configuration Manager입니다.
+Reporting Services 서버에서 우리의 첫 번째 목적지는 Reporting Services 구성 관리자입니다.
 
 {{% /alert %}}
 
 ## 서비스 계정:
 
-**보고 서비스에 사용하고 있는 서비스 계정을 반드시 이해하십시오. 문제가 발생하면 사용 중인 서비스 계정과 관련될 수 있습니다. 기본값은 Network Service입니다. 새 빌드를 배포할 때는 항상 Domain Accounts를 사용합니다, 왜냐하면 문제가 발생하기 쉬운 부분이기 때문입니다. 이 서버 인스턴스에서는 RSService라는 도메인 계정을 사용했습니다.**
+**보고 서비스에 사용하는 서비스 계정을 반드시 이해하십시오. 문제가 발생하면 사용 중인 서비스 계정과 관련될 수 있습니다. 기본값은 Network Service입니다. 새 빌드를 배포할 때는 항상 도메인 계정을 사용합니다. 이는 문제가 발생하기 쉬운 지점이기 때문입니다. 이 서버 인스턴스에서는 RSService라는 도메인 계정을 사용했습니다.**
 
 ![todo:image_alt_text](setting-up-reporting-services_1.png)
 
 **Image1:- 서비스 계정 설정**
 
-## Web 서비스 URL:
+## Web Service URL:
 
 {{% alert color="primary" %}}
 
-**Web Service URL을 구성해야 합니다. 이는 Web Services Reporting Services가 사용하는 Web Services를 호스팅하는 ReportServer 가상 디렉터리(vdir)이며, SharePoint가 통신하는 대상입니다. vdir의 속성(예: SSL, 포트, 호스트 헤더 등…)을 사용자 정의하려는 경우가 아니라면, 여기서 Apply를 클릭하면 바로 사용할 수 있습니다.**
+**Web Service URL을 구성해야 합니다. 이는 Reporting Services에서 사용하는 Web Services를 호스팅하는 ReportServer 가상 디렉터리(vdir)이며, SharePoint가 통신하는 대상입니다. vdir의 속성(예: SSL, 포트, 호스트 헤더 등)을 사용자 지정하려는 경우가 아니라면, 여기서 Apply를 클릭하면 바로 사용할 수 있어야 합니다.**
 ![todo:image_alt_text](setting-up-reporting-services_2.png)
 
-**Image2:- Web Service URL 설정 Web service URL이 설정되면 다음 결과를 확인할 수 있습니다**
+**Image2:- Web Service URL 설정 Web service URL이 설정되면, 다음 결과를 확인할 수 있어야 합니다**
 
 ![todo:image_alt_text](setting-up-reporting-services_3.png)
 
@@ -37,14 +37,14 @@ Reporting Services Server에서 우리의 첫 번째 목적지는 Reporting Serv
 
 ## 데이터베이스:
 
-**우리는 Reporting Services Catalog Database를 생성해야 합니다. 이는 SQL 2008 또는 SQL 2008 R2 Database Engine에서 사용될 수 있습니다. SQL11도 잘 작동하지만 아직 베타 버전입니다. 이 작업은 기본적으로 두 개의 데이터베이스, ReportServer와 ReportServerTempDB를 생성합니다.**
+**우리는 Reporting Services 카탈로그 데이터베이스를 생성해야 합니다. 이는 SQL 2008 또는 SQL 2008 R2 데이터베이스 엔진에 배치할 수 있습니다. SQL11도 괜찮게 작동하지만 아직 베타 단계입니다. 이 작업은 기본적으로 두 개의 데이터베이스인 ReportServer와 ReportServerTempDB를 생성합니다.**
 
 {{% alert color="primary" %}}
 **이와 관련된 또 다른 중요한 단계는 데이터베이스 유형으로 SharePoint Integrated를 선택했는지 확인하는 것입니다. 일단 이 선택을 하면 변경할 수 없습니다.**
 
 ![todo:image_alt_text](setting-up-reporting-services_4.png)
 
-**Image4:- 보고서 서버 데이터베이스 생성**
+**Image4:- 보고서 서버 데이터베이스 만들기**
 
 ![todo:image_alt_text](setting-up-reporting-services_5.png)
 
@@ -55,15 +55,15 @@ Reporting Services Server에서 우리의 첫 번째 목적지는 Reporting Serv
 **Image6:- 데이터베이스 이름 및 모드 설정**
 {{% /alert %}}
 
-**자격 증명의 경우, 이는 Report Server가 SQL Server와 통신하는 방식입니다. 선택한 계정은 RSExecRole을 통해 Catalog 데이터베이스 및 몇몇 시스템 데이터베이스에 특정 권한이 부여됩니다. MSDB는 SQL Agent를 사용하여 구독에 사용되는 데이터베이스 중 하나입니다.**
+**자격 증명에 대해, 이것은 보고서 서버가 SQL Server와 통신하는 방식입니다. 선택한 계정은 RSExecRole을 통해 카탈로그 데이터베이스와 몇몇 시스템 데이터베이스에 특정 권한이 부여됩니다. MSDB는 SQL Agent를 사용하여 구독에 활용되는 데이터베이스 중 하나입니다.**
 
 ![todo:image_alt_text](setting-up-reporting-services_7.png)
 
-**Image7:- Report Server 데이터베이스 자격 증명 설정**
+**Image7:- 보고서 서버 데이터베이스 자격 증명 설정**
 
 {{% alert color="primary" %}}
 
-**데이터베이스 자격 증명이 지정되면 아래에 지정된 대로 결과를 얻을 수 있어야 합니다.**
+**데이터베이스 자격 증명이 지정되면 아래에 명시된 결과를 얻을 수 있어야 합니다.**
 
 ![todo:image_alt_text](setting-up-reporting-services_8.png)
 
@@ -76,12 +76,12 @@ Reporting Services Server에서 우리의 첫 번째 목적지는 Reporting Serv
 
 ## 보고서 관리자 URL:
 
-**우리는 SharePoint 통합 모드에 있을 때 사용되지 않으므로 Report Manager URL을 건너뛸 수 있습니다. SharePoint가 우리의 프런트엔드입니다. Report Manager는 작동하지 않습니다.**
+**SharePoint 통합 모드에서는 Report Manager URL이 사용되지 않으므로 생략할 수 있습니다. SharePoint가 프런트엔드입니다. Report Manager는 작동하지 않습니다.**
 
 ## 암호화 키:
 
 {{% alert color="primary" %}}
-**암호화 키를 백업하고 보관 위치를 확인하세요. 데이터베이스를 마이그레이션하거나 복원해야 하는 상황이 발생하면 이 키가 필요합니다.**
+**암호화 키를 백업하고 보관 위치를 반드시 확인하십시오. 데이터베이스를 마이그레이션하거나 복원해야 하는 상황이 생기면 이 키가 필요합니다.**
 
 ![todo:image_alt_text](setting-up-reporting-services_10.png)
 
@@ -89,13 +89,12 @@ Reporting Services Server에서 우리의 첫 번째 목적지는 Reporting Serv
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**축하합니다! Configuration Manager를 사용하여 Reporting Services를 성공적으로 구성했습니다. 웹 서비스 URL 탭에서 URL을 탐색하면 다음과 유사한 화면이 표시됩니다.**
+**축하합니다! Configuration Manager를 사용하여 Reporting Services를 성공적으로 구성했습니다. Web Service URL 탭에서 URL을 탐색하면 다음과 유사한 내용이 표시됩니다.**
 
 ![todo:image_alt_text](setting-up-reporting-services_11.png)
 
-**Image11:- 설치 후 Report Server 접근**
+**Image11:- 설치 후 Report Server 액세스**
 
-**오류 원인: SharePoint가 우리 WFE에 설치되어 있고 Reporting Services 설정을 완료했습니다. 이 예에서는 Reporting Services와 SharePoint가 다른 머신에 있습니다. 동일한 머신에 있었다면 이 오류가 발생하지 않았을 것입니다. 실제로 RS Box에 SharePoint를 설치해야 합니다. 이는 IIS도 활성화된다는 의미입니다.**
+**오류 원인: SharePoint가 WFE에 설치되어 있고 Reporting Services 설정을 완료했습니다. 이 예에서는 Reporting Services와 SharePoint가 서로 다른 머신에 있습니다. 같은 머신에 있었다면 이 오류가 나타나지 않았을 것입니다. 기술적으로는 RS 박스에 SharePoint를 설치해야 합니다. 이는 IIS도 활성화된다는 의미입니다.**
 {{% /alert %}}
-
 

--- a/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
+++ b/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
@@ -1,100 +1,100 @@
 ---
-title: Reporting Services 설정
-linktitle: Reporting Services 설정
+title: 보고 서비스 설정
+linktitle: 보고 서비스 설정
 type: docs
 weight: 20
-url: /ko/reportingservices/setting-up-reporting-services/
-lastmod: "2026-07-29"
+url: /reportingservices/setting-up-reporting-services/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Reporting Services 서버에서 우리의 첫 번째 목적지는 Reporting Services 구성 관리자입니다.
+보고 서비스 서버에서 가장 먼저 수행할 작업은 보고 서비스 구성 관리자입니다.
 
 {{% /alert %}}
 
 ## 서비스 계정:
 
-**보고 서비스에 사용하는 서비스 계정을 반드시 이해하십시오. 문제가 발생하면 사용 중인 서비스 계정과 관련될 수 있습니다. 기본값은 Network Service입니다. 새 빌드를 배포할 때는 항상 도메인 계정을 사용합니다. 이는 문제가 발생하기 쉬운 지점이기 때문입니다. 이 서버 인스턴스에서는 RSService라는 도메인 계정을 사용했습니다.**
+**보고 서비스에 사용 중인 서비스 계정을 이해해야 합니다. 문제가 발생하면 사용 중인 서비스 계정과 관련이 있을 수 있습니다. 기본값은 네트워크 서비스입니다. 새 빌드를 배포할 때 문제가 발생할 가능성이 있는 도메인 계정을 항상 사용합니다. 이 서버 인스턴스에서는 RSService라는 도메인 계정을 사용했습니다.**
 
-![todo:image_alt_text](setting-up-reporting-services_1.png)
+![Set Up](setting-up-reporting-services_1.png)
 
-**Image1:- 서비스 계정 설정**
+**이미지1:- 서비스 계정 설정**
 
-## Web Service URL:
+## 웹 서비스 URL:
 
 {{% alert color="primary" %}}
 
-**Web Service URL을 구성해야 합니다. 이는 Reporting Services에서 사용하는 Web Services를 호스팅하는 ReportServer 가상 디렉터리(vdir)이며, SharePoint가 통신하는 대상입니다. vdir의 속성(예: SSL, 포트, 호스트 헤더 등)을 사용자 지정하려는 경우가 아니라면, 여기서 Apply를 클릭하면 바로 사용할 수 있어야 합니다.**
-![todo:image_alt_text](setting-up-reporting-services_2.png)
+**웹 서비스 URL을 구성해야 합니다. 이는 Reporting Services가 사용하는 웹 서비스를 호스팅하고 SharePoint가 통신하는 ReportServer 가상 디렉터리(vdir)입니다. vdir의 속성(예: SSL, 포트, 호스트 헤더 등)을 사용자 정의하려는 경우가 아니라면 여기에서 적용을 클릭하면 됩니다.**
+![Web Service URL](setting-up-reporting-services_2.png)
 
-**Image2:- Web Service URL 설정 Web service URL이 설정되면, 다음 결과를 확인할 수 있어야 합니다**
+**이미지2:- 웹 서비스 URL 설정 웹 서비스 URL이 설정되면 다음과 같은 결과를 볼 수 있습니다**
 
-![todo:image_alt_text](setting-up-reporting-services_3.png)
+![Web Service URL Results](setting-up-reporting-services_3.png)
 
-**Image3:- Web service URL 설정 성공**
+**이미지3:- 웹 서비스 URL 설정 성공**
 {{% /alert %}}
 
-## 데이터베이스:
+## 데이터 베이스:
 
-**우리는 Reporting Services 카탈로그 데이터베이스를 생성해야 합니다. 이는 SQL 2008 또는 SQL 2008 R2 데이터베이스 엔진에 배치할 수 있습니다. SQL11도 괜찮게 작동하지만 아직 베타 단계입니다. 이 작업은 기본적으로 두 개의 데이터베이스인 ReportServer와 ReportServerTempDB를 생성합니다.**
+**Reporting Services 카탈로그 데이터베이스를 만들어야 합니다. 이는 모든 SQL 2008 또는 SQL 2008 R2 데이터베이스 엔진에 배치될 수 있습니다. SQL11도 잘 작동하지만 아직 베타 버전입니다. 이 작업을 수행하면 기본적으로 ReportServer 및 ReportServerTempDB라는 두 개의 데이터베이스가 생성됩니다.**
 
 {{% alert color="primary" %}}
-**이와 관련된 또 다른 중요한 단계는 데이터베이스 유형으로 SharePoint Integrated를 선택했는지 확인하는 것입니다. 일단 이 선택을 하면 변경할 수 없습니다.**
+**이와 관련된 또 다른 중요한 단계는 데이터베이스 유형으로 SharePoint 통합을 선택했는지 확인하는 것입니다. 한번 선택하면 변경할 수 없습니다.**
 
-![todo:image_alt_text](setting-up-reporting-services_4.png)
+![Creating Report Server Database](setting-up-reporting-services_4.png)
 
-**Image4:- 보고서 서버 데이터베이스 만들기**
+**이미지4:- 보고서 서버 데이터베이스 만들기**
 
-![todo:image_alt_text](setting-up-reporting-services_5.png)
+![Setting up Database Server and Authentication Type](setting-up-reporting-services_5.png)
 
-**Image5:- 데이터베이스 서버 및 인증 유형 설정**
+**이미지5:- 데이터베이스 서버 및 인증 유형 설정**
 
-![todo:image_alt_text](setting-up-reporting-services_6.png)
+![Setting up Database Name and Mode](setting-up-reporting-services_6.png)
 
-**Image6:- 데이터베이스 이름 및 모드 설정**
+**이미지6:- 데이터베이스 이름 및 모드 설정**
 {{% /alert %}}
 
-**자격 증명에 대해, 이것은 보고서 서버가 SQL Server와 통신하는 방식입니다. 선택한 계정은 RSExecRole을 통해 카탈로그 데이터베이스와 몇몇 시스템 데이터베이스에 특정 권한이 부여됩니다. MSDB는 SQL Agent를 사용하여 구독에 활용되는 데이터베이스 중 하나입니다.**
+**자격 증명의 경우 보고서 서버가 SQL Server와 통신하는 방법입니다. 어떤 계정을 선택하든 RSExecRole을 통해 카탈로그 데이터베이스 및 일부 시스템 데이터베이스 내의 특정 권한이 부여됩니다. MSDB는 SQL 에이전트를 사용할 때 구독 사용을 위한 데이터베이스 중 하나입니다.**
 
-![todo:image_alt_text](setting-up-reporting-services_7.png)
+![Setting up Report Server database credentials](setting-up-reporting-services_7.png)
 
-**Image7:- 보고서 서버 데이터베이스 자격 증명 설정**
+**이미지7:- 보고서 서버 데이터베이스 자격 증명 설정**
 
 {{% alert color="primary" %}}
 
-**데이터베이스 자격 증명이 지정되면 아래에 명시된 결과를 얻을 수 있어야 합니다.**
+**데이터베이스 자격 증명이 지정되면 아래 지정된 결과를 얻을 수 있습니다.**
 
-![todo:image_alt_text](setting-up-reporting-services_8.png)
+![Report Server database creation progress](setting-up-reporting-services_8.png)
 
-**Image8:- Report Server 데이터베이스 생성 진행 상황**
+**이미지8:- 보고서 서버 데이터베이스 생성 진행률**
 
-![todo:image_alt_text](setting-up-reporting-services_9.png)
+![Report Server database completion summary](setting-up-reporting-services_9.png)
 
-**Image9:- Report Server 데이터베이스 완료 요약**
+**이미지9:- 보고서 서버 데이터베이스 완료 요약**
 {{% /alert %}}
 
 ## 보고서 관리자 URL:
 
-**SharePoint 통합 모드에서는 Report Manager URL이 사용되지 않으므로 생략할 수 있습니다. SharePoint가 프런트엔드입니다. Report Manager는 작동하지 않습니다.**
+**SharePoint 통합 모드에서는 보고서 관리자 URL이 사용되지 않으므로 건너뛸 수 있습니다. SharePoint는 우리의 프런트엔드입니다. 보고서 관리자가 작동하지 않습니다.**
 
-## 암호화 키:
+## Encryption Keys:
 
 {{% alert color="primary" %}}
-**암호화 키를 백업하고 보관 위치를 반드시 확인하십시오. 데이터베이스를 마이그레이션하거나 복원해야 하는 상황이 생기면 이 키가 필요합니다.**
+**암호화 키를 백업하고 어디에 보관하는지 확인하세요. 데이터베이스를 마이그레이션하거나 복원해야 하는 상황에 처하게 되면 이것이 필요합니다.**
 
-![todo:image_alt_text](setting-up-reporting-services_10.png)
+![Report Server Encryption key backup](setting-up-reporting-services_10.png)
 
-**Image10:- Report Server 암호화 키 백업**
+**이미지10:- 보고서 서버 암호화 키 백업**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**축하합니다! Configuration Manager를 사용하여 Reporting Services를 성공적으로 구성했습니다. Web Service URL 탭에서 URL을 탐색하면 다음과 유사한 내용이 표시됩니다.**
+**축하합니다! Configuration Manager를 사용하여 보고 서비스를 성공적으로 구성했습니다. 웹 서비스 URL 탭에서 URL을 탐색하면 다음과 유사한 내용이 표시됩니다.**
 
-![todo:image_alt_text](setting-up-reporting-services_11.png)
+![Report Server access after installation](setting-up-reporting-services_11.png)
 
-**Image11:- 설치 후 Report Server 액세스**
+**이미지11:- 설치 후 보고서 서버 액세스**
 
-**오류 원인: SharePoint가 WFE에 설치되어 있고 Reporting Services 설정을 완료했습니다. 이 예에서는 Reporting Services와 SharePoint가 서로 다른 머신에 있습니다. 같은 머신에 있었다면 이 오류가 나타나지 않았을 것입니다. 기술적으로는 RS 박스에 SharePoint를 설치해야 합니다. 이는 IIS도 활성화된다는 의미입니다.**
+**오류 원인: SharePoint가 WFE에 설치되었으며 보고 서비스 설정이 완료되었습니다. 이 예에서 Reporting Services와 SharePoint는 서로 다른 컴퓨터에 있습니다. 동일한 컴퓨터에 있었다면 이 오류가 표시되지 않았을 것입니다. 기술적으로 RS Box에 SharePoint를 설치해야 합니다. 이는 IIS도 활성화된다는 의미입니다.**
 {{% /alert %}}
 

--- a/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
+++ b/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
@@ -1,19 +1,19 @@
 ---
-title: 보고 서비스 서버에 SharePoint 설정
-linktitle: 보고 서비스 서버에 SharePoint 설정
+title: Reporting Services Server에서 SharePoint 설정
+linktitle: Reporting Services Server에서 SharePoint 설정
 type: docs
 weight: 30
 url: /ko/reportingservices/setting-up-sharepoint-on-reporting-services-server/
-lastmod: "2026-06-19"
+lastmod: "2026-07-29"
 ---
 
 {{% alert color="primary" %}}
 
-이제 SharePoint WFE에서 수행한 것과 유사한 단계를 진행해야 합니다. 첫 번째는 Prereq uisites 설치를 수행하고, 완료되면 SharePoint setup을 시작합니다.
+이제 SharePoint WFE에서 수행한 것과 유사한 단계를 수행해야 합니다. 첫 번째 단계는 Prereq uisites 설치를 진행하고, 완료되면 SharePoint 설치를 시작하는 것입니다.
 
 {{% /alert %}}
 
-설정을 위해 저는 Server Farm을 선택하고 SharePoint Box에 맞게 전체 설치를 합니다. SharePoint에 대한 독립형 설치를 원하지 않기 때문입니다.
+설정을 위해 저는 Server Farm을 선택하고 SharePoint Box에 맞게 전체 설치를 선택했습니다. SharePoint에 대한 독립형 설치는 원하지 않기 때문입니다.
 
 ## SharePoint 구성
 
@@ -28,7 +28,7 @@ lastmod: "2026-06-19"
 
 {{% alert color="primary" %}}
 
-**그런 다음 우리 팜이 사용 중인 SharePoint_Config 데이터베이스를 지정합니다. 이 위치를 모른다면 중앙 관리에서 시스템 설정 -> Manager Servers 를 통해 이 팜에서 확인할 수 있습니다.**
+**그런 다음 이를 우리 팜이 사용 중인 SharePoint_Config 데이터베이스로 지정합니다. 이 위치를 모른다면, Central Admin의 System Settings -> Manager Servers를 통해 확인할 수 있습니다.**
 
 ![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_2.png)
 
@@ -41,10 +41,9 @@ lastmod: "2026-06-19"
 
 {{% alert color="primary" %}}
 
-**마법사가 완료되면 현재는 Report Server 박스에서 해야 할 일은 이것뿐입니다. ReportServer URL로 돌아가면 또 다른 오류가 보이게 되는데, 이는 중앙 관리자(Central Administrator)를 통해 구성하지 않았기 때문입니다.**
+**마법사가 완료되면, 현재는 Report Server 박스에서 해야 할 일은 이것뿐입니다. ReportServer URL로 돌아가면 또 다른 오류가 표시되는데, 이는 Central Administrator를 통해 구성하지 않았기 때문입니다.**
 
 ![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_4.png)
 
 **Image4:- 보고서 서버 오류**
 {{% /alert %}}
-

--- a/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
+++ b/ko/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
@@ -1,49 +1,49 @@
 ---
-title: Reporting Services Server에서 SharePoint 설정
-linktitle: Reporting Services Server에서 SharePoint 설정
+title: Reporting Services 서버에서 SharePoint 설정
+linktitle: Reporting Services 서버에서 SharePoint 설정
 type: docs
 weight: 30
-url: /ko/reportingservices/setting-up-sharepoint-on-reporting-services-server/
-lastmod: "2026-07-29"
+url: /reportingservices/setting-up-sharepoint-on-reporting-services-server/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-이제 SharePoint WFE에서 수행한 것과 유사한 단계를 수행해야 합니다. 첫 번째 단계는 Prereq uisites 설치를 진행하고, 완료되면 SharePoint 설치를 시작하는 것입니다.
+이제 SharePoint WFE에서 했던 것과 유사한 단계를 수행해야 합니다. 가장 먼저 해야 할 일은 필수 구성 요소 설치를 진행하고 완료되면 SharePoint 설정을 시작하는 것입니다.
 
 {{% /alert %}}
 
-설정을 위해 저는 Server Farm을 선택하고 SharePoint Box에 맞게 전체 설치를 선택했습니다. SharePoint에 대한 독립형 설치는 원하지 않기 때문입니다.
+저는 SharePoint용 독립 실행형 설치를 원하지 않기 때문에 설정을 위해 Server Farm과 SharePoint Box에 맞는 전체 설치를 선택했습니다.
 
 ## SharePoint 구성
 
 {{% alert color="primary" %}}
 
-**SharePoint 구성 마법사에서 기존 팜에 연결하고자 합니다.**
+**SharePoint 구성 마법사에서 기존 팜에 연결하려고 합니다.**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_1.png)
+![SharePoint Configuration Wizard](setting-up-sharepoint-on-reporting-services-server_1.png)
 
-**Image1:- SharePoint 구성 마법사**
+**이미지1:- SharePoint 구성 마법사**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**그런 다음 이를 우리 팜이 사용 중인 SharePoint_Config 데이터베이스로 지정합니다. 이 위치를 모른다면, Central Admin의 System Settings -> Manager Servers를 통해 확인할 수 있습니다.**
+**그런 다음 팜에서 사용하는 SharePoint_Config 데이터베이스를 가리킵니다. 이곳이 어디에 있는지 모르신다면 중앙관리자에서 시스템 설정 -> 이 팜의 관리자 서버를 통해 확인하실 수 있습니다.**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_2.png)
+![SharePoint Configuration Database](setting-up-sharepoint-on-reporting-services-server_2.png)
 
-**Image2:- 데이터베이스 구성 설정 지정**
+**이미지2:- 데이터베이스 구성 설정 지정**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_3.png)
+![SharePoint Configuration Wizard](setting-up-sharepoint-on-reporting-services-server_3.png)
 
-**Image3:- SharePoint 구성 마법사**
+**이미지3:- SharePoint 구성 마법사**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**마법사가 완료되면, 현재는 Report Server 박스에서 해야 할 일은 이것뿐입니다. ReportServer URL로 돌아가면 또 다른 오류가 표시되는데, 이는 Central Administrator를 통해 구성하지 않았기 때문입니다.**
+**마법사가 완료되면 지금은 보고서 서버 상자에서 수행해야 할 작업이 전부입니다. ReportServer URL로 돌아가면 또 다른 오류가 표시됩니다. 이는 중앙 관리자를 통해 구성하지 않았기 때문입니다.**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_4.png)
+![SharePoint Configuration Error](setting-up-sharepoint-on-reporting-services-server_4.png)
 
-**Image4:- 보고서 서버 오류**
+**이미지4:- 보고서 서버 오류**
 {{% /alert %}}


### PR DESCRIPTION
## Summary
- rebuild ko/reportingservices from en/reportingservices
- regenerate Markdown translations with the Hugo translation CLI
- preserve the locale asset set and backfill five CLI restoration failures from the existing Korean pages to keep the folder complete

## Validation
- matched English eportingservices file and Markdown counts
- checked that no @@DOC_TRANSLATE_ placeholders remain
