### PR TITLE
Translate reportingservices to Portuguese

### DIFF
--- a/pt/reportingservices/_index.md
+++ b/pt/reportingservices/_index.md
@@ -4,19 +4,19 @@ linktitle:  Aspose.PDF for Reporting Services
 second_title: Aspose.PDF for Reporting Services
 type: docs
 weight: 120
-url: /pt/reportingservices/
-description: Descubra o Aspose.PDF for Reporting Services. Gere relatórios PDF diretamente do SQL Server Reporting Services (SSRS) com personalização avançada.
+url: /reportingservices/
+description: Descubra Aspose.PDF para Reporting Services. Gere relatórios em PDF diretamente do SQL Server Reporting Services (SSRS) com personalização avançada.
 is_root: true
-lastmod: "2026-06-19"
+lastmod: "2024-05-05"
 ---
 
 {{% alert color="primary" %}}
 
-![Aspose.PDF for Reporting Services Logotipo](home_5.png)
+![Aspose.PDF para logotipo do Reporting Services](home_5.png)
 
-## Bem-vindo ao Aspose.PDF for Reporting Services
+## Bem-vindo ao Aspose.PDF para Reporting Services
 
-Microsoft SQL Server Reporting Services atende a uma necessidade que muitas organizações têm: a necessidade de criar soluções de inteligência empresarial e de relatórios. Até agora, os desenvolvedores eram obrigados a incorporar relatórios em suas aplicações, ou as organizações eram obrigadas a comprar soluções de relatórios de terceiros caras e, às vezes, problemáticas. Agora, o Microsoft SQL Server Reporting Services oferece uma solução completa para distribuir relatórios em toda a empresa; permitindo que as empresas tomem decisões melhores e mais rápidas.
+O Microsoft SQL Server Reporting Services atende a uma necessidade que muitas organizações têm: a necessidade de criar soluções de business intelligence e relatórios. Até agora, os desenvolvedores eram obrigados a incorporar relatórios em seus aplicativos ou as organizações eram obrigadas a comprar soluções de relatórios de terceiros caras e às vezes problemáticas. Agora, o Microsoft SQL Server Reporting Services oferece uma solução completa para distribuição de relatórios em toda a empresa; permitindo que as empresas tomem decisões melhores e mais rápidas.
 
 {{% /alert %}}
 
@@ -24,25 +24,24 @@ Microsoft SQL Server Reporting Services atende a uma necessidade que muitas orga
 
 - [Visão geral do produto](/pdf/pt/reportingservices/product-overview/)
 - [Formatos de arquivo suportados](/pdf/pt/reportingservices/supported-file-formats/)
-- [Recursos](/pdf/pt/reportingservices/features/)
-- [Galeria de Relatórios de Exemplo](/pdf/pt/reportingservices/sample-reports-gallery/)
-- [Instalar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [Licenciar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [Configurar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/configure-aspose-pdf-for-reporting-services/)
-- [Expandir Propriedades dos Itens de Relatório](/pdf/pt/reportingservices/expand-report-items-properties/)
-- [Avaliar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
+- [Características](/pdf/pt/reportingservices/features/)
+- [Galeria de exemplos de relatórios](/pdf/pt/reportingservices/sample-reports-gallery/)
+- [Instale Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [Licença Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [Configurar Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [Expanda Propriedades de Itens de Relatório](/pdf/pt/reportingservices/expand-report-items-properties/)
+- [Avalie Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
 
-## Aspose.PDF for Reporting Services Recursos
+## Aspose.PDF para recursos do Reporting Services
 
-- [Aspose.PDF for Reporting Services Visão geral do produto](/pdf/pt/reportingservices/product-overview/)
-- [Aspose.PDF for Reporting Services Formatos de arquivo suportados](/pdf/pt/reportingservices/supported-file-formats/)
-- [Aspose.PDF for Reporting Services Funcionalidades](/pdf/pt/reportingservices/features/)
-- [Aspose.PDF for Reporting Services Notas de versão](https://releases.aspose.com/pdf/reportingservices/release-notes/)
-- [Baixar Aspose.PDF for Reporting Services](https://releases.aspose.com/pdf/reportingservices/)
-- [Galeria de Relatórios de Exemplo Aspose.PDF for Reporting Services](/pdf/pt/reportingservices/sample-reports-gallery/)
-- [Instalar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/install-aspose-pdf-for-reporting-services/)
-- [Licenciar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/license-aspose-pdf-for-reporting-services/)
-- [Configurar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/configure-aspose-pdf-for-reporting-services/)
-- [Expandir Propriedades dos Itens de Relatório](/pdf/pt/reportingservices/expand-report-items-properties/)
-- [Avaliar Aspose.Pdf para Reporting Services](/pdf/pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/)
-
+- [Aspose.PDF para visão geral do produto Reporting Services](/pdf/pt/reportingservices/product-overview/)
+- [Aspose.PDF para formatos de arquivo suportados pelo Reporting Services](/pdf/pt/reportingservices/supported-file-formats/)
+- [Aspose.PDF para recursos do Reporting Services](/pdf/pt/reportingservices/features/)
+- [Aspose.PDF para notas de versão do Reporting Services](https://releases.aspose.com/pdf/reportingservices/release-notes/)
+- [Baixe Aspose.PDF para Reporting Services](https://releases.aspose.com/pdf/reportingservices/)
+- [Galeria de exemplos de relatórios Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/sample-reports-gallery/)
+- [Instale Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/install-aspose-pdf-for-reporting-services/)
+- [Licença Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/license-aspose-pdf-for-reporting-services/)
+- [Configurar Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/configure-aspose-pdf-for-reporting-services/)
+- [Expanda Propriedades de Itens de Relatório](/pdf/pt/reportingservices/expand-report-items-properties/)
+- [Avalie Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/)

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/_index.md
@@ -1,16 +1,15 @@
 ---
 title: Configurar
-linktitle: Configurar
+linktitle: Configure
 
 type: docs
 weight: 80
-url: /pt/reportingservices/configure-aspose-pdf-for-reporting-services/
-description: Saiba como configurar o Aspose.PDF for Reporting Services para personalizar as configurações de saída do PDF nos seus relatórios SSRS de forma eficiente.
-lastmod: "2026-06-19"
+url: /reportingservices/configure-aspose-pdf-for-reporting-services/
+description: Aprenda como configurar o Aspose.PDF para Reporting Services para personalizar as configurações de saída de PDF para seus relatórios SSRS com eficiência.
+lastmod: "2021-06-05"
 ---
 
 ## Esta seção inclui os seguintes tópicos:
 
 - [Definir parâmetros](/pdf/pt/reportingservices/setting-parameters/)
 - [Parâmetros suportados](/pdf/pt/reportingservices/supported-parameters/)
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/setting-parameters/_index.md
@@ -1,27 +1,26 @@
 ---
-title: Definir Parâmetros
-linktitle: Definir Parâmetros
+title: Definir parâmetros
+linktitle: Setting Parameters
 type: docs
 weight: 10
-url: /pt/reportingservices/setting-parameters/
-description: Descubra como definir parâmetros para a renderização de PDF no Aspose.PDF for Reporting Services e obter controle preciso sobre a saída.
-lastmod: "2026-07-29"
+url: /reportingservices/setting-parameters/
+description: Descubra como definir parâmetros para renderização de PDF em Aspose.PDF para Reporting Services. Obtenha controle preciso sobre a produção.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Você pode especificar determinados parâmetros de configuração que afetam a forma como o Aspose.PDF for Reporting Services gera documentos. Esta seção descreve esse processo.
+Você pode especificar determinados parâmetros de configuração que afetam como o Aspose.PDF for Reporting Services gera documentos. Esta seção descreve esse processo.
 
 {{% /alert %}}
 
-Para configurar o Aspose.PDF for Reporting Services, você precisa editar o arquivo `C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config`. Esse é um arquivo XML, e a configuração do renderizador fica dentro do elemento ```<Extension>``` correspondente ao renderizador Aspose.PDF.
+Para configurar Aspose.Pdf para Reporting Services, você precisa editar o arquivo `C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\rsreportserver.config`. Este é um arquivo XML e a configuração do renderizador está dentro do elemento `<Extension>` correspondente ao renderizador Aspose.PDF.
 
-**Exemplo**
+## Exemplo
 
-{{< highlight csharp >}}
-
+```xml
 <Render>
-...
+…
 <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
 <!--Insert configuration elements for exporting to PDF here. The following is an example
 For PageOrientation -->
@@ -30,20 +29,18 @@ For PageOrientation -->
     </Configuration>
 </Extension>
 </Render>
-
-{{< /highlight >}}
+```
 
 {{% alert color="primary" %}}
 
-Se você quiser definir parâmetros para um arquivo de relatório específico, mas não para todos os relatórios no servidor, poderá adicionar um parâmetro de relatório para esse relatório no Report Builder seguindo as etapas abaixo. Neste exemplo, adicionaremos o parâmetro `IsLandscape` mostrado anteriormente.
+Se desejar definir parâmetros para um arquivo de relatório específico, mas não para todos os relatórios no servidor, você poderá adicionar um parâmetro de relatório para o relatório específico no Report Builder conforme as etapas a seguir (por exemplo, adicionaremos um parâmetro 'IsLandscape' mostrado anteriormente):
 
-1. Abra o relatório no Report Designer, clique com o botão direito na pasta `Parameters` no painel `Report Data` e selecione `Add Parameter...` (ou, alternativamente, abra a lista `New` e selecione `Parameter...`).
- 
-![todo:image_alt_text](setting-parameters_1.png)
+1. Abra o relatório no Report Designer, clique com o botão direito na pasta 'Parâmetros' no painel 'Dados do relatório' e selecione 'Adicionar parâmetro...' (ou, alternativamente, abra a lista 'Novo' e selecione 'Parâmetro...').
 
-1. Na caixa de diálogo `Report Parameter Properties`, crie o parâmetro chamado `IsLandscape`, defina o tipo de dado como Boolean e adicione o valor True na guia `Default Values`.
+![Parameters set up. Step 1](setting-parameters_1.png)
 
-![todo:image_alt_text](setting-parameters_2.png)
+1. Na caixa de diálogo 'Propriedades do parâmetro do relatório', crie o parâmetro denominado 'IsLandscape', com o tipo de dados Booleano, e adicione o valor True na guia 'Valores padrão'.
+
+![Parameters set up. Step 2](setting-parameters_2.png)
 
 {{% /alert %}}
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/_index.md
@@ -1,28 +1,25 @@
 ---
 title: Parâmetros suportados
-linktitle: Parâmetros suportados
+linktitle: Supported Parameters
 type: docs
 weight: 20
-url: /pt/reportingservices/supported-parameters/
-description: Explore os parâmetros suportados no Aspose.PDF for Reporting Services para controlar e personalizar a renderização de PDF com facilidade.
-lastmod: "2026-06-19"
+url: /reportingservices/supported-parameters/
+description: Explore os parâmetros suportados no Aspose.PDF for Reporting Services para controlar e personalizar sua renderização de PDF com facilidade.
+lastmod: "2021-06-05"
 ---
 
-Um relatório parametrizado é um relatório que aceita valores de entrada usados no processamento do relatório. Com um relatório parametrizado, você pode variar a saída de um relatório com base nos valores definidos quando o relatório é executado. Aspose.Pdf for Reporting Services suporta dois tipos de parâmetros: parâmetros do servidor de relatórios e parâmetros do relatório. Os parâmetros do servidor de relatórios são usados para todos os relatórios no servidor de relatórios. Se você quiser tornar alguns parâmetros adequados para relatórios específicos, deve usar os parâmetros do relatório.
+Um relatório parametrizado é um relatório que aceita valores de entrada usados ​​no processamento de relatórios. Com um relatório parametrizado, você pode variar a saída de um relatório com base nos valores definidos quando o relatório é executado. Aspose.PDF for Reporting Services oferece suporte a dois tipos de parâmetros: parâmetros do servidor de relatório e parâmetros de relatório. Os parâmetros do servidor de relatórios são usados ​​para todos os relatórios no servidor de relatórios. Se quiser tornar alguns parâmetros adequados para relatórios específicos, você deve usar parâmetros de relatório.
 
-Atualmente, o renderizador Aspose.Pdf suporta uma ampla variedade de parâmetros, como:
+Atualmente, o renderizador Aspose.Pdf oferece suporte a uma ampla gama de parâmetros, como:
 
 **Esta seção inclui os seguintes tópicos:**
 
 - [Orientação da página](/pdf/pt/reportingservices/page-orientation/)
 - [Formatação HTML](/pdf/pt/reportingservices/html-formatting/)
-- [Configuração de Segurança](/pdf/pt/reportingservices/security-setting/)
-- [A Fonte Está Incorporada](/pdf/pt/reportingservices/isfontembedded/)
-- [Tamanho da Página](/pdf/pt/reportingservices/pagesize/)
+- [Configuração de segurança](/pdf/pt/reportingservices/security-setting/)
+- [IsFontEmbedded](/pdf/pt/reportingservices/isfontembedded/)
+- [Tamanho da página](/pdf/pt/reportingservices/pagesize/)
 - [Tamanho da margem da página](/pdf/pt/reportingservices/page-margin-size/)
 - [Metadados XMP](/pdf/pt/reportingservices/xmp-metadata/)
-- [Informação de depuração](/pdf/pt/reportingservices/debug-information/)
+- [Informações de depuração](/pdf/pt/reportingservices/debug-information/)
 - [Conformidade PDF_A](/pdf/pt/reportingservices/pdf_a-conformance/)
-
-
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/debug-information/_index.md
@@ -1,27 +1,30 @@
 ---
 title: Informações de depuração
-linktitle: Informações de depuração
+linktitle: Debug Information
 type: docs
 weight: 90
-url: /pt/reportingservices/debug-information/
-description: Acesse e analise informações de depuração da renderização de PDF no Aspose.PDF for Reporting Services para solucionar problemas de forma eficaz.
-lastmod: "2026-06-19"
+url: /reportingservices/debug-information/
+description: Acesse e analise informações de depuração para renderização de PDF no Aspose.PDF for Reporting Services para solucionar problemas de maneira eficaz.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-É inevitável que algo esteja errado com a renderização ou com o resultado renderizado. Por razões como sigilo ou privacidade, não podemos obter a fonte de dados usada no relatório do usuário, portanto não conseguimos reproduzir o erro no relatório. Para tornar a comunicação entre clientes e desenvolvedores mais fácil e fluida, adicionamos este parâmetro. Se você encontrar problemas ao renderizar seu relatório com Aspose.PDF for Reporting Services, defina este parâmetro de relatório; assim você receberá o documento renderizado no formato XML. Em seguida, publique o arquivo XML para nós no fórum do produto.
+É inevitável que haja algo errado com a renderização ou com o resultado renderizado. Por alguns motivos, como sigilo ou privacidade, não conseguimos obter a fonte de dados utilizada no relatório do usuário e, portanto, não conseguimos reproduzir o erro no relatório. Para tornar a comunicação entre clientes e desenvolvedores mais fácil e tranquila, adicionamos este parâmetro. Se você encontrar problemas ao renderizar seu relatório com Aspose.PDF para Reporting Services, defina este parâmetro de relatório, então você obterá o documento renderizado com o formato XML. Depois disso, poste o arquivo XML para nós no fórum do produto.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Nome do Parâmetro**: SavingXmlFormat  
-**Tipo de Data**: Boolean  
-**Valores suportados**: True, False (padrão)  
 
-**Exemplo**
-{{< highlight csharp >}}
+```txt
+Parameter Name: SavingXmlFormat
+Date Type: Boolean  
+Values supported**: True, False (default)
+```
 
+## Exemplo
+
+```xml
 <Render>
 ...
 <Extension Name="APPDF" Type=" Aspose.PDF.ReportingServices.Renderer,Aspose.PDF.ReportingServices">
@@ -30,8 +33,6 @@ lastmod: "2026-06-19"
 </Configuration>
 </Extension>
 </Render>
-
-{{< /highlight >}}
+```
 
 {{% /alert %}}
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/html-formatting/_index.md
@@ -1,20 +1,20 @@
 ---
 title: Formatação HTML
-linktitle: Formatação HTML
+linktitle: HTML Formatting
 type: docs
 weight: 20
-url: /pt/reportingservices/html-formatting/
-description: Habilite a formatação HTML em relatórios PDF usando Aspose.PDF for Reporting Services. Adicione estilos e estrutura com facilidade.
-lastmod: "2026-06-19"
+url: /reportingservices/html-formatting/
+description: Habilite a formatação HTML em relatórios PDF usando Aspose.PDF para Reporting Services. Adicione estilos e estrutura com facilidade.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Às vezes, você pode desejar exportar texto em caixas de texto com formatação. Infelizmente, o Reporting Services não oferece suporte a isso. No entanto, ainda é possível implementá‑lo usando Aspose.PDF for Reporting Services. Basta habilitar um modo especial no qual todo o texto nas caixas de texto é tratado como HTML e inserir as tags HTML necessárias para formatar o texto no documento de saída. Por exemplo, para ter texto normal, em negrito e itálico na mesma caixa de texto, insira o seguinte valor na caixa de texto:
+Às vezes você pode querer exportar texto em caixas de texto com formatação. Infelizmente, o Reporting Services não oferece suporte para isso. No entanto, você ainda pode implementá-lo usando Aspose.PDF para Reporting Services. Basta ativar um modo especial no qual todo o texto nas caixas de texto é tratado como HTML e colocar as tags HTML necessárias para formatar o texto no documento de saída. Por exemplo, para ter texto normal, em negrito e itálico na mesma caixa de texto, insira o seguinte valor de caixa de texto:
 
-Alguma parte deste texto é ```<b>bold</b>``` e outro texto é ```<i>italic</i>```.
+Parte deste texto é `<b>bold</b>` e outro texto é `<i>italic</i>`.
 
-Ao exportar, o texto ficará assim: parte deste texto está **bold** e outro texto está *italic*.
+Quando exportado, o texto terá a aparência de parte deste texto em **negrito** e outro texto em *itálico*.
 
 Observe que esta abordagem tem algumas limitações
 
@@ -22,18 +22,19 @@ Observe que esta abordagem tem algumas limitações
 
 {{% alert color="primary" %}}
 
-- A formatação não é visível no tempo de design (no Report Builder, no portal web do Reporting Services etc.). Em vez disso, você verá o texto HTML na forma de texto simples com tags.
-- A extensão de renderização Aspose.PDF for Reporting Services reconhece e formata corretamente o código HTML em caixas de texto. O renderizador PDF padrão do Reporting Services exportará essa marcação como texto simples.
+- A formatação não é visível em tempo de design (no Report Builder, no portal da Web Reporting Services etc.). Em vez disso, você verá o texto HTML na forma de texto simples com tags.
+- A extensão de renderização Aspose.PDF para Reporting Services reconhece e formata corretamente o código HTML em caixas de texto. O renderizador de PDF padrão do Reporting Services exportará essa marcação como texto simples.
 
-**Nome do Parâmetro**: IsHtmlTagSupported  
-**Tipo de Dados**: Boolean  
-**Valores suportados**: True, False (padrão)   
+```text
+Parameter Name: IsHtmlTagSupported  
+Date Type: Boolean  
+Values supported: True, False (default)   
+```
 
-**Exemplo**
+## Exemplo
 
-{{< highlight csharp >}}
-
- <Render>
+```xml
+<Render>
 ...
     <Extension Name="APPDF" Type=" Aspose.PDF.ReportingServices.Renderer,Aspose.PDF.ReportingServices ">
     <Configuration>
@@ -41,13 +42,10 @@ Observe que esta abordagem tem algumas limitações
     </Configuration>
     </Extension>
 </Render>
+```
 
-{{< /highlight >}}
+Se desejar adicionar esse parâmetro no Report Designer, use o tipo de dados `Boolean`.
 
-Se você quiser adicionar este parâmetro no Report Designer, use o tipo de dados 'Boolean'.
-
- 
-Atualmente Aspose.Pdf for Reporting Services suporta um subconjunto de todas as tags HTML. Você pode encontrar mais informações na documentação do Aspose.PDF [Documentação](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
+Atualmente Aspose.Pdf para Reporting Services oferece suporte a um subconjunto de todas as tags HTML. Você pode encontrar mais informações no Aspose.PDF [Documentation](https://docs.aspose.com/pdf/net/add-text-to-pdf-file/#add-html-string-using-dom).
 
 {{% /alert %}}
-

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/isfontembedded/_index.md
@@ -3,34 +3,31 @@ title: IsFontEmbedded
 linktitle: IsFontEmbedded
 type: docs
 weight: 50
-url: /pt/reportingservices/isfontembedded/
-lastmod: "2026-06-19"
+url: /reportingservices/isfontembedded/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-O designer do RS não oferece suporte à fonte incorporada para texto; com o Aspose.PDF for Reporting Services você pode incorporar facilmente informações de fontes em seu documento PDF.
+O designer RS ​​não oferece suporte à fonte incorporada para texto; com Aspose.PDF for Reporting Services você pode incorporar facilmente informações de fonte em seu documento PDF.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**Nome do Parâmetro**: IsFontEmbedded  
-**Tipo de Dados**: Boolean  
-**Valores suportados**: True, False (padrão)  
+```txt
+Parameter Name: IsFontEmbedded  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**Exemplo**
-{{< highlight csharp >}}
+## Exemplo
 
+```xml
 <Render>
-…
+...
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
     <Configuration>
     <IsFontEmbedded>True</IsFontEmbedded>
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
-
+```

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-margin-size/_index.md
@@ -1,44 +1,46 @@
 ---
 title: Tamanho da margem da página
-linktitle: Tamanho da margem da página
+linktitle: Page margin size
 type: docs
 weight: 70
-url: /pt/reportingservices/page-margin-size/
-description: Ajuste os tamanhos das margens da página em relatórios PDF com Aspose.PDF for Reporting Services para melhorar a legibilidade e o layout.
-lastmod: "2026-06-19"
+url: /reportingservices/page-margin-size/
+description: Ajuste os tamanhos das margens das páginas em relatórios PDF com Aspose.PDF para Reporting Services para melhorar a legibilidade e o layout.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-O designer de relatórios do Reporting Services não suporta a definição do tamanho das margens da página. Aspose.Pdf for Reporting Services fornece quatro parâmetros para definir o tamanho correspondente da margem da página, que são:
+O designer de relatórios do Reporting Services não dá suporte à configuração do tamanho das margens da página. Aspose.PDF para Reporting Services fornece quatro parâmetros para definir o tamanho da margem da página correspondente, são eles:
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-1)  
-**Nome do parâmetro**: PageMarginLeft  
-**Tipo de Dados**: Float  
-**Valores suportados**:  Qualquer número positivo ou zero
+```text
+Parameter Name: PageMarginLeft  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-2)  
-**Nome do Parâmetro**: PageMarginRight  
-**Tipo de Dados**: Float  
-**Valores suportados**:  Qualquer número positivo ou zero
+```text
+Parameter Name: PageMarginRight  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-3)  
-**Nome do Parâmetro**: PageMarginTop  
-**Tipo de Dados**: Float  
-**Valores suportados**:  Qualquer número positivo ou zero
+```text
+Parameter Name: PageMarginTop  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-4)  
-**Nome do Parâmetro**: PageMarginBottom  
-**Tipo de Dados**: Float  
-**Valores suportados**:  Qualquer número positivo ou zero
+```text
+Parameter Name: PageMarginBottom  
+Date Type: Float  
+Values supported:  Any positive number or zero
+```
 
-**Exemplo**
+## Exemplo
 
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type=" Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices ">
@@ -50,8 +52,4 @@ O designer de relatórios do Reporting Services não suporta a definição do ta
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
-
+```

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/page-orientation/_index.md
@@ -1,28 +1,29 @@
 ---
-title: Orientação da Página
-linktitle: Orientação da Página
+title: Orientação da página
+linktitle: Page Orientation
 type: docs
 weight: 10
-url: /pt/reportingservices/page-orientation/
-description: Configure a orientação da página para relatórios PDF no Aspose.PDF for Reporting Services. Personalize layouts para melhor apresentação.
-lastmod: "2026-06-19"
+url: /reportingservices/page-orientation/
+description: Configure a orientação da página para relatórios PDF em Aspose.PDF para Reporting Services. Personalize layouts para uma melhor apresentação.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Report Definition Language não permite especificar a orientação das páginas no relatório explicitamente. Com Aspose.Pdf for Reporting Services você pode instruir facilmente o exportador a gerar documentos PDF com orientação de página paisagem. A orientação padrão é retrato.
+A linguagem de definição de relatório não permite especificar explicitamente a orientação das páginas do relatório. Com Aspose.PDF for Reporting Services você pode facilmente instruir o exportador a produzir documentos PDF com orientação de página paisagem. A orientação padrão é retrato.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+The default orientation is portrait.
+Parameter Name: IsLandscape
+Date Type: Boolean
+Values supported: True, False (default)
+```
 
-A orientação padrão é retrato.
-**Nome do parâmetro**: IsLandscape
-**Tipo de dado**: Boolean
-**Valores suportados**: True, False (default)
+## Exemplo
 
-**Exemplo**
-{{< highlight csharp >}}
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
@@ -31,8 +32,5 @@ A orientação padrão é retrato.
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```
 

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pagesize/_index.md
@@ -1,29 +1,28 @@
 ---
-title: PageSize
+title: Tamanho da página
 linktitle: PageSize
 type: docs
 weight: 60
-url: /pt/reportingservices/pagesize/
-description: Personalize os tamanhos de página para relatórios PDF no Aspose.PDF for Reporting Services para atender a requisitos específicos de documento.
-lastmod: "2026-06-19"
+url: /reportingservices/pagesize/
+description: Personalize tamanhos de página para relatórios PDF no Aspose.PDF for Reporting Services para atender a requisitos específicos de documentos.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-O designer de relatórios do Reporting Services não suporta tamanhos de página comuns, como A4, B5, Letter e assim por diante. Com o Aspose.Pdf for Reporting Services, você pode obtê-lo como no exemplo a seguir.
+O designer de relatórios do Reporting Services não oferece suporte a tamanhos de página comuns, como A4, B5, Carta e assim por diante. Com Aspose.PDF for Reporting Services, você pode obtê-lo como no exemplo a seguir.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+Parameter Name: PageSize  
+Date Type: String  
+Values supported: A0, A1, A2, A3, A4, A5, A6, B5, Letter, Legal, Ledger, P11x17  
+```
 
-**Nome do parâmetro**: PageSize  
-**Tipo de Data**: String  
-**Valores suportados**: A0, A1, A2, A3, A4, A5, A6, B5, Letter, Legal, Ledger, P11x17  
+## Exemplo
 
-**Exemplo**
-
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
@@ -32,8 +31,4 @@ O designer de relatórios do Reporting Services não suporta tamanhos de página
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
-
+```

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/pdf_a-conformance/_index.md
@@ -1,31 +1,30 @@
 ---
 title: Conformidade PDF_A
-linktitle: Conformidade PDF_A
+linktitle: PDF_A Conformance
 type: docs
 weight: 100
-url: /pt/reportingservices/pdf_a-conformance/
-description: Habilite a conformidade PDF/A no Aspose.PDF for Reporting Services. Crie documentos compatíveis com arquivamento sem esforço.
-lastmod: "2026-06-19"
+url: /reportingservices/pdf_a-conformance/
+description: Habilite a conformidade com PDF/A em Aspose.PDF para Reporting Services. Crie documentos compatíveis com arquivamento sem esforço.
+lastmod: "2025-05-22"
 ---
 
 {{% alert color="primary" %}}
 
-Você pode obter uma introdução à Conformidade PDF/A (PDF Arquivável) na documentação do Aspose.PDF.
+Você pode obter uma introdução à conformidade com PDF/A (PDF arquivável) na documentação do Aspose.PDF.
 
-Se você quiser criar um documento PDF/A, adicione o seguinte parâmetro de relatório.
+Se você deseja criar um documento PDF/A, adicione o seguinte parâmetro de relatório.
 
 {{% /alert %}}
 
+```text
+Parameter Name: PdfConformance  
+Date Type: String  
+Values supported: PdfA1A, PdfA1B, PdfA2A, PdfA2B, PdfA2U, PdfA3A, PdfA3B, PdfA3U, PdfA4, PdfA4E, PdfA4F  
+```
 
-{{% alert color="primary" %}}
+## Exemplo
 
-**Nome do Parâmetro**: PdfConformance  
-**Tipo de Dados**: String  
-**Valores suportados**: PdfA1A, PdfA1B, PdfA2A, PdfA2B, PdfA2U, PdfA3A, PdfA3B, PdfA3U, PdfA4, PdfA4E, PdfA4F  
-
-**Exemplo**
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
@@ -34,7 +33,4 @@ Se você quiser criar um documento PDF/A, adicione o seguinte parâmetro de rela
     </Configuration>
     </Extension>
 </Render>
-{{< /highlight >}}
-
-{{% /alert %}}
-
+```

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/security-setting/_index.md
@@ -1,54 +1,63 @@
 ---
-title: Configuração de Segurança
-linktitle: Configuração de Segurança
+title: Configuração de segurança
+linktitle: Security Setting
 type: docs
 weight: 30
-url: /pt/reportingservices/security-setting/
-lastmod: "2026-06-19"
+url: /reportingservices/security-setting/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-A segurança sempre foi a questão mais importante em todos os campos, seja na proteção de uma rede ou de um documento PDF. Os documentos são protegidos por muitos motivos possíveis: o autor do documento pode querer manter o conteúdo do documento seguro e não querer permitir que outros o alterem, etc.
+A segurança sempre foi a questão mais importante em todos os campos, seja na proteção de uma rede ou de um documento PDF. Os documentos são protegidos por vários motivos possíveis: o redator do documento pode querer manter o conteúdo do documento seguro e não querer permitir que outros o alterem, etc.
 
-Aspose.Pdf for Reporting Services tem se preocupado muito com esses aspectos de segurança, oferecendo esses recursos aos desenvolvedores que podem ser úteis para proteger seus documentos PDF. Portanto, ele contém diversos parâmetros que permitem aos desenvolvedores aplicar diferentes medidas de segurança aos documentos PDF.
+Aspose.PDF for Reporting Services cuidou muito desses aspectos de segurança, fornecendo esses recursos aos desenvolvedores que podem ser úteis para proteger seus documentos PDF. Portanto, contém uma série de parâmetros que permitem aos desenvolvedores aplicar diferentes medidas de segurança aos documentos PDF.
 
-Uma dessas medidas é proteger o documento PDF com senha durante a criptografia. Você também pode restringir ou permitir a modificação do conteúdo, a cópia do conteúdo, a impressão do documento ou habilitar/desabilitar o preenchimento de formulários. Esses recursos no momento não são suportados pelo Exportador PDF padrão do SQL Reporting Services, mas você pode implementá-los usando o Aspose.Pdf for Reporting Services. Basta adicionar os parâmetros de segurança correspondentes a um relatório ou ao arquivo de configuração do servidor de relatórios, e você poderá criar documentos PDF seguros com privilégios limitados.
+Uma dessas medidas é proteger o documento PDF com senha durante a criptografia. Você também pode restringir ou permitir modificação de conteúdo, cópia de conteúdo, impressão de documentos ou permitir/desabilitar preenchimento de formulários. No momento, esses recursos não são suportados pelo SQL Reporting Services PDF Exporter padrão, mas você pode implementar esses recursos usando Aspose.PDF para Reporting Services. Basta adicionar parâmetros de segurança correspondentes a um relatório ou arquivo de configuração do servidor de relatório e você poderá criar documentos PDF seguros com privilégios limitados.
 
-Atualmente, o renderizador Aspose.Pdf for Reporting Services suporta os seguintes atributos de segurança:
+Atualmente, o renderizador Aspose.PDF para Reporting Services dá suporte aos seguintes atributos de segurança:
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+```text
+Parameter Name: User Password  
+Date Type: String  
+Values supported: Any plain text
+```
 
-**Nome do parâmetro**: Senha do Usuário  
-**Tipo de data**: String  
-**Valores suportados**: Qualquer texto simples
+```text
+Parameter Name: Master Password  
+Date Type: String  
+Values supported: Any plain text 
+```
 
-**Nome do parâmetro**: Senha mestre  
-**Tipo de data**: String  
-**Valores suportados**: Qualquer texto simples 
+```text
+Parameter Name: IsCopyingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default) 
+```
 
-**Nome do Parâmetro**: IsCopyingAllowed  
-**Tipo de Dados**: Boolean  
-**Valores suportados**: True, False (default)  
+```text
+Parameter Name: IsPrintingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**Nome do Parâmetro**: IsPrintingAllowed  
-**Tipo de Dados**: Boolean  
-**Valores suportados**: True, False (default)  
+```text
+Parameter Name: IsContentsModifyingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default) 
+```
 
-**Nome do Parâmetro**: IsContentsModifyingAllowed  
-**Tipo de Dados**: Boolean  
-**Valores suportados**: True, False (default)  
+```text
+Parameter Name: IsFormFillingAllowed  
+Date Type: Boolean  
+Values supported: True, False (default)  
+```
 
-**Nome do Parâmetro**: IsFormFillingAllowed  
-**Tipo de Dados**: Boolean  
-**Valores suportados**: True, False (default)  
+## Exemplo
 
-**Exemplo**
-
-{{< highlight csharp >}}
-
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices">
@@ -59,8 +68,5 @@ Atualmente, o renderizador Aspose.Pdf for Reporting Services suporta os seguinte
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```
 

--- a/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
+++ b/pt/reportingservices/configure-aspose-pdf-for-reporting-services/supported-parameters/xmp-metadata/_index.md
@@ -1,39 +1,46 @@
 ---
 title: Metadados XMP
-linktitle: Metadados XMP
+linktitle: XMP Metadata
 type: docs
 weight: 80
-url: /pt/reportingservices/xmp-metadata/
-description: Aprenda a gerenciar metadados XMP em relatórios PDF usando Aspose.PDF for Reporting Services. Aprimore o gerenciamento de metadados de documentos.
-lastmod: "2026-06-19"
+url: /reportingservices/xmp-metadata/
+description: Aprenda a gerenciar metadados XMP em relatórios PDF usando Aspose.PDF para Reporting Services. Aprimore o manuseio de metadados de documentos.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-O designer de relatórios do Reporting Services não oferece suporte à incorporação de metadados XMP no documento. Aspose.Pdf for Reporting Services fornece quatro parâmetros para definir os metadados XMP correspondentes, que são:
+O designer de relatórios do Reporting Services não dá suporte à incorporação de metadados XMP no documento. Aspose.PDF para Reporting Services fornece quatro parâmetros para definir os metadados XMP correspondentes, são eles:
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**Nome do parâmetro**: CreationDate  
-**Tipo de Data**: String  
-**Valores suportados**: Data em um dos formatos de data
+```text
+**Parameter Name: CreationDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats
+```
 
-**Nome do Parâmetro**: ModifyDate  
-**Tipo de Data**: String  
-**Valores suportados**: Data em um dos formatos de data 
+```text
+**Parameter Name: ModifyDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats 
+```
 
-**Nome do Parâmetro**: MetaDataDate  
-**Tipo de Data**: String  
-**Valores suportados**: Data em um dos formatos de data 
+```text
+**Parameter Name: MetaDataDate  
+**Date Type: String  
+**Values supported: Date in one of the date formats 
+```
 
-**Nome do Parâmetro**: CreatorTool  
-**Tipo de Data**: String  
-**Valores suportados**: Qualquer texto simples  
+```text
+**Parameter Name: CreatorTool  
+**Date Type: String  
+**Values supported: Any plain text  
+```
 
-**Exemplo**
-{{< highlight csharp >}}
+## Exemplo
 
+```xml
 <Render>
 …
     <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer, Aspose.Pdf.ReportingServices">
@@ -41,13 +48,10 @@ O designer de relatórios do Reporting Services não oferece suporte à incorpor
     <CreationDate>2017-12-10</CreationDate>
     <ModifyDate>2018-1-12</ModifyDate>
     <MetaDataDate>2018-3-7</MetaDataDate>
-    <CreatorTool>Aspose.Pdf for Reporting Services</CreatorTool>
+    <CreatorTool>Aspose.PDF for Reporting Services</CreatorTool>
     </Configuration>
     </Extension>
 </Render>
-
-{{< /highlight >}}
-
-{{% /alert %}}
+```
 
 

--- a/pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/_index.md
@@ -1,26 +1,25 @@
 ---
 title: Avalie Aspose.Pdf
-linktitle: Avalie Aspose.Pdf
+linktitle: Evaluate Aspose.Pdf
 type: docs
 weight: 110
-url: /pt/reportingservices/evaluate-aspose-pdf-for-reporting-services/
-description: Experimente Aspose.PDF for Reporting Services gratuitamente. Aprenda como avaliar seus recursos antes de tomar uma decisão de compra.
-lastmod: "2026-06-19"
+url: /reportingservices/evaluate-aspose-pdf-for-reporting-services/
+description: Experimente o Aspose.PDF para Reporting Services gratuitamente. Aprenda como avaliar suas características antes de tomar uma decisão de compra.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Esta página indica a diferença entre a versão licenciada e a versão de avaliação do Aspose.PDF for Reporting Services
+Esta página indica a diferença entre a versão licenciada e a versão de avaliação do Aspose.PDF para Reporting Services
 
 {{% /alert %}}
 
-Você pode baixar facilmente [Aspose.PDF for Reporting Services](https://downloads.aspose.com/pdf/reportingservices) para avaliação. O download de avaliação é o mesmo que o download adquirido. A versão de avaliação simplesmente se torna licenciada quando você coloca o arquivo de licença na pasta que contém Aspose.PDF.ReportingServices.dll ou algumas linhas de código para inicializar a licença ao usar o componente com o Report Viewer no modo local. A versão de avaliação do Aspose.PDF for Reporting Services (sem uma licença especificada) fornece toda a funcionalidade do produto, mas insere uma marca d'água de avaliação no topo do documento ao renderizar o arquivo .RDL para o formato PDF. Você pode visitar a página a seguir para mais instruções sobre [Como licenciar Aspose.PDF for Reporting Services](/pdf/pt/reportingservices/license-aspose-pdf-for-reporting-services/)
+Você pode baixar facilmente [Aspose.PDF para serviços de relatórios](https://downloads.aspose.com/pdf/reportingservices) para avaliação. O download de avaliação é igual ao download adquirido. A versão de avaliação simplesmente se torna licenciada quando você coloca o arquivo de licença na pasta que contém Aspose.PDF.ReportingServices.dll ou algumas linhas de código para inicializar a licença ao usar o componente com Report Viewer em modo local. A versão de avaliação do Aspose.PDF para Reporting Services (sem licença especificada) fornece funcionalidade completa do produto, mas insere uma marca d'água de avaliação na parte superior do documento ao renderizar o arquivo .RDL para o formato PDF. Você pode visitar a página a seguir para obter mais instruções sobre [como licenciar Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/license-aspose-pdf-for-reporting-services/)
 
-![todo:image_alt_text](evaluate-aspose-pdf-for-reporting-services_1.png)
+![Avaliação](evaluate-aspose-pdf-for-reporting-services_1.png)
 
 {{% alert color="primary" %}}
 
-Se você quiser testar o Aspose.PDF for Reporting Services sem as limitações da versão de avaliação, pode também solicitar uma Licença Temporária de 30 dias. Por favor, consulte [Como obter uma Licença Temporária?](<https://about.aspose.com/>)
+Se quiser testar o Aspose.PDF para Reporting Services sem as limitações da versão de avaliação, você também pode solicitar uma licença temporária de 30 dias. Consulte [Como obter uma Licença Temporária?](<https://about.aspose.com/>)
 
 {{% /alert %}}
-

--- a/pt/reportingservices/expand-report-items-properties/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/_index.md
@@ -1,15 +1,14 @@
 ---
-title: Expandir Propriedades dos Itens do Relatório
-linktitle: Expandir Propriedades dos Itens do Relatório
+title: Expandir propriedades de itens de relatório
+linktitle: Expand Report Items Props
 type: docs
 weight: 90
-url: /pt/reportingservices/expand-report-items-properties/
-description: Melhore relatórios SSRS com Aspose.PDF. Aprenda como expandir as propriedades dos itens do relatório para uma personalização detalhada de PDF.
-lastmod: "2026-06-19"
+url: /reportingservices/expand-report-items-properties/
+description: Aprimore os relatórios SSRS com Aspose.PDF. Saiba como expandir as propriedades do item de relatório para personalização detalhada do PDF.
+lastmod: "2021-06-05"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
-- [Adicionando Propriedades Personalizadas](/pdf/pt/reportingservices/adding-custom-properties/)
-- [Propriedades Personalizadas Suportadas](/pdf/pt/reportingservices/custom-properties-supported/)
-
+- [Adicionando propriedades personalizadas](/pdf/pt/reportingservices/adding-custom-properties/)
+- [Propriedades personalizadas suportadas](/pdf/pt/reportingservices/custom-properties-supported/)

--- a/pt/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/adding-custom-properties/_index.md
@@ -1,35 +1,32 @@
 ---
-title: Adicionando Propriedades Personalizadas
-linktitle: Adicionando Propriedades Personalizadas
+title: Adicionando propriedades personalizadas
+linktitle: Adding Custom Properties
 type: docs
 weight: 10
-url: /pt/reportingservices/adding-custom-properties/
-description: Aprenda como adicionar propriedades personalizadas a relatórios PDF com Aspose.PDF for Reporting Services. Personalize seus documentos de forma eficiente.
-lastmod: "2026-06-19"
+url: /reportingservices/adding-custom-properties/
+description: Aprenda como adicionar propriedades personalizadas a relatórios PDF com Aspose.PDF para Reporting Services. Personalize seus documentos com eficiência.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Você pode adicionar propriedades personalizadas para alguns itens de relatório para expandir seu uso, como ToC, setas de linha e assim por diante. Esta seção descreve esse processo.
+Você pode adicionar propriedades personalizadas a alguns itens de relatório para expandir seu uso, como ToC, setas de linha e assim por diante. Esta seção descreve esse processo.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+Você pode adicionar propriedades personalizadas a alguns itens de relatório para expandir seu uso, como Índice, setas de linha e assim por diante. Esta seção descreve esse processo.
 
-Você pode adicionar propriedades personalizadas para alguns itens de relatório para expandir seu uso, como Índice, setas de linha e assim por diante. Esta seção descreve esse processo.
+Para adicionar propriedades customizadas, você precisa editar o arquivo de código do documento RDL nas seguintes etapas:
 
-Para adicionar propriedades personalizadas, você precisa editar o arquivo de código do documento RDL nas seguintes etapas:
+1. Como na figura a seguir, abra seu projeto, navegue até o gerenciador de soluções, clique com o botão direito no arquivo de relatório selecionado e selecione o item de menu 'Exibir código'.
 
-1. Conforme na figura a seguir, abra seu projeto, navegue até o Solution Explorer e clique com o botão direito no arquivo de relatório selecionado, então selecione o item de menu 'View Code'.
+![Adicionar propriedades personalizadas](adding-custom-properties_1.png)
 
-![todo:image_alt_text](adding-custom-properties_1.png)
+2. Edite o arquivo de código XML. Por exemplo, se desejar adicionar uma propriedade customizada para o item de relatório gráfico, será necessário adicionar o código semelhante ao texto em vermelho no exemplo a seguir.
 
-2. Edite o arquivo de código XML. Por exemplo, se você quiser adicionar uma propriedade personalizada para o item de relatório de gráfico, você precisa adicionar o código semelhante ao texto em vermelho no exemplo a seguir.
+## Exemplo
 
-**Exemplo**
-
-{{< highlight csharp >}}
-
+```xml
 <chart Name="chart1">
     <Left>5.5cm</Left>
     <Top>0.5cm</Top>
@@ -44,10 +41,7 @@ Para adicionar propriedades personalizadas, você precisa editar o arquivo de c�
       </CustomProperty>
     </CustomProperties>
 </chart> 
+```
 
-{{< /highlight >}}
-
-Neste exemplo de fragmento de código, o nome da propriedade personalizada é IsInList e o valor é 'True'.
-
-{{% /alert %}}
+Neste exemplo de fragmento de código, o nome da propriedade customizada é IsInList e o valor é `True`.
 

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/_index.md
@@ -1,17 +1,16 @@
 ---
-title: Propriedades Personalizadas Suportadas
-linktitle: Propriedades Personalizadas Suportadas
+title: Propriedades personalizadas suportadas
+linktitle: Custom Properties Supported
 type: docs
 weight: 20
-url: /pt/reportingservices/custom-properties-supported/
-description: Verifique as propriedades personalizadas suportadas no Aspose.PDF for Reporting Services. Maximize a flexibilidade nas suas saídas PDF.
-lastmod: "2026-06-19"
+url: /reportingservices/custom-properties-supported/
+description: Verifique as propriedades personalizadas suportadas em Aspose.PDF para Reporting Services. Maximize a flexibilidade em suas saídas de PDF.
+lastmod: "2021-06-05"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
-- [Sumário Lista de Tabelas ou Figuras](/pdf/pt/reportingservices/table-of-contents-list-of-tables-or-figures/)
-- [Setas de Linha](/pdf/pt/reportingservices/line-arrows/)
-- [Nota de Rodapé Nota de Fim](/pdf/pt/reportingservices/footnote-endnote/)
-- [Justificar Alinhamento de Texto FullJustify](/pdf/pt/reportingservices/justify-fulljustify-text-alignment/)
-
+- [Índice Lista de tabelas ou figuras](/pdf/pt/reportingservices/table-of-contents-list-of-tables-or-figures/)
+- [Setas de linha](/pdf/pt/reportingservices/line-arrows/)
+- [Nota final](/pdf/pt/reportingservices/footnote-endnote/)
+- [Justificar FullJustify Alinhamento de Texto](/pdf/pt/reportingservices/justify-fulljustify-text-alignment/)

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/footnote-endnote/_index.md
@@ -1,33 +1,34 @@
 ---
-title: Nota de rodapé Nota de fim
-linktitle: Nota de rodapé Nota de fim
+title: Nota final
+linktitle: Footnote Endnote
 type: docs
 weight: 30
-url: /pt/reportingservices/footnote-endnote/
-description: Adicione notas de rodapé e notas de fim aos seus relatórios PDF com Aspose.PDF for Reporting Services. Forneça referências detalhadas de documentos.
-lastmod: "2026-06-19"
+url: /reportingservices/footnote-endnote/
+description: Adicione notas de rodapé e notas finais aos seus relatórios PDF com Aspose.PDF for Reporting Services. Forneça referências detalhadas de documentos.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-O Report Builder não pode definir a nota de rodapé ou a nota de fim para caixas de texto. Com Aspose.Pdf for Reporting Services, você pode fazer isso facilmente adicionando propriedades personalizadas.
+O Report Builder não pode definir notas de rodapé ou notas finais para caixas de texto. Com Aspose.PDF for Reporting Services, você pode fazer isso facilmente adicionando propriedades personalizadas.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-Nota de rodapé
-**Propriedade Personalizada** **Nome**: Nota de rodapé
-**Valor da Propriedade Personalizada**: *o* *valor* *deve* *ser* *uma* *string*
+```text
+Footnote
+Custom Property `Name`: Footnote
+Custom Property Value: `the` `value` `should` `be` `a` `string`
+```
 
-Nota de fim
-**Propriedade Personalizada** **Nome**: Nota de fim
-**Valor da Propriedade Personalizada**: *o* *valor* *deve* *ser* *uma* *string*
+```text
+Endnote
+Custom Property `Name`: Endnote
+Custom Property Value: `the` `value` `should` `be` `a` `string`
+```
 
-{{% alert color="primary" %}}
-No exemplo a seguir, o relatório contém uma Textbox com o valor 'AsposePdf4RS', e queremos adicionar uma descrição suplementar na forma de uma nota de rodapé com o texto "Um renderizador PDF opcional para SSRS da Aspose Pty. Ltd.".
-{{% /alert %}}
+No exemplo a seguir, o relatório contém uma caixa de texto com o valor `AsposePdf4RS`, e queremos adicionar uma descrição suplementar na forma de uma nota de rodapé com o texto "Um renderizador PDF opcional para SSRS da Aspose Pty. Ltd.".
 
-**Exemplo**
+## Exemplo
 
 ```cs
 <Textbox Name="Textbox1">
@@ -53,5 +54,3 @@ No exemplo a seguir, o relatório contém uma Textbox com o valor 'AsposePdf4RS'
 </Paragraphs>
 </Textbox>
 ```
-{{% /alert %}}
-

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/justify-fulljustify-text-alignment/_index.md
@@ -1,29 +1,30 @@
 ---
-title: Justify FullJustify Alinhamento de Texto
-linktitle: Justify FullJustify Alinhamento de Texto
+title: Justificar FullJustify Alinhamento de Texto
+linktitle: Justify FullJustify Text Alignment
 type: docs
 weight: 40
-url: /pt/reportingservices/justify-fulljustify-text-alignment/
-description: Alcance um alinhamento de texto perfeito em relatórios PDF com Aspose.PDF for Reporting Services. Suporte para as opções justify e full justify.
-lastmod: "2026-06-19"
+url: /reportingservices/justify-fulljustify-text-alignment/
+description: Obtenha alinhamento de texto perfeito em relatórios PDF com Aspose.PDF for Reporting Services. Suporte para opções de justificação e justificação completa.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-O construtor de relatórios não suporta a capacidade de especificar o alinhamento de texto para a caixa de texto “Justify” e “FullJustify”. Com Aspose.Pdf for Reporting Services, você pode fazer isso facilmente adicionando propriedades personalizadas.
+O construtor de relatórios não suporta a capacidade de especificar o alinhamento de texto para caixa de texto `Justify` e `FullJustify`. Com Aspose.PDF for Reporting Services, você pode fazer isso facilmente adicionando propriedades personalizadas.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-**Nome da Propriedade Personalizada** : TextAlignment  
-**Tipo de Propriedade Personalizada** : String  
-**Valores da Propriedade Personalizada** : Justify, FullJustify  
+```text
+Custom Property `Name`: TextAlignment  
+Custom Property `Type`: String  
+Custom Property `Values`: Justify, FullJustify  
+```
 
-No relatório, o código deve ser como o seguinte:
+No relatório o código deve ficar assim:
 
-**Exemplo**
+## Exemplo
 
-{{< highlight csharp >}}
+```xml
 <Textbox Name="textbox1">
 <value> AsposePdf4RS </value>     
   <CustomProperties>
@@ -33,6 +34,4 @@ No relatório, o código deve ser como o seguinte:
    </CustomProperty>
   </CustomProperties>
 </Textbox>
-{{< /highlight >}}
-{{% /alert %}}
-
+```

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/line-arrows/_index.md
@@ -1,36 +1,38 @@
 ---
-title: Setas de Linha
-linktitle: Setas de Linha
+title: Setas de linha
+linktitle: Line Arrows
 type: docs
 weight: 20
-url: /pt/reportingservices/line-arrows/
-description: Aprenda a adicionar setas de linha em relatórios PDF usando Aspose.PDF for Reporting Services. Melhore os visuais dos relatórios sem esforço.
-lastmod: "2026-06-19"
+url: /reportingservices/line-arrows/
+description: Aprenda a adicionar setas de linha em relatórios PDF usando Aspose.PDF para Reporting Services. Aprimore o visual do relatório sem esforço.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-A especificação RDL não especifica setas para o elemento de linha, portanto o report builder não oferece suporte à configuração de setas para linhas. Com Aspose.Pdf for Reporting Services você pode fazer isso facilmente.
+A especificação RDL não especifica as setas sobre o elemento de linha, portanto, o construtor de relatórios não suporta a configuração de setas para linha. Com Aspose.PDF for Reporting Services você pode fazer isso facilmente.
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
+Atualmente, o renderizador Aspose.PDF oferece suporte à adição de setas no início ou no final das linhas, adicionando propriedades personalizadas.
 
-Atualmente, o renderizador Aspose.PDF suporta a adição de setas no início ou no final de linhas adicionando propriedades personalizadas.
+```text
+Add Start Arrow for Line  
+Custom Property `Name`: HasArrowAtStart  
+Custom Property `Value`: True  
+```
 
-Adicionar seta inicial para a linha  
-**Propriedade Personalizada** **Nome**: HasArrowAtStart  
-**Valor da Propriedade Personalizada**: True  
+```text
+Add End Arrow for Line  
+Custom Property `Name`: HasArrowAtEnd  
+Custom Property `Value`: True  
+```
 
-Adicionar seta final para a linha  
-**Propriedade Personalizada** **Nome**: HasArrowAtEnd  
-**Valor da Propriedade Personalizada**: True  
+Por exemplo, existem duas linhas nomeadas `line1` e `line2` no arquivo de relatório atual, e a linha1 possui a seta inicial, a linha2 possui as setas inicial e final. Para atender a esses requisitos, você pode adicionar propriedades customizadas como no fragmento de código a seguir.
 
-Por exemplo, há duas linhas chamadas ‘line1’ e ‘line2’ no arquivo de relatório atual, e a line1 tem a seta inicial, a line2 tem as setas inicial e final; para atender a esses requisitos, você pode adicionar propriedades personalizadas como no fragmento de código a seguir.
+## Exemplo
 
-**Exemplo**
-
-{{< highlight csharp >}}
+```xml
  <Line Name="line1">
     <Style>
       ......
@@ -58,7 +60,5 @@ Por exemplo, há duas linhas chamadas ‘line1’ e ‘line2’ no arquivo de re
       </CustomProperty>
     </CustomProperties>
 </Line>
-
-{{< /highlight >}}
-{{% /alert %}}
+```
 

--- a/pt/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
+++ b/pt/reportingservices/expand-report-items-properties/custom-properties-supported/table-of-contents-list-of-tables-or-figures/_index.md
@@ -1,25 +1,24 @@
 ---
-title: Sumário Lista de Tabelas ou Figuras
-linktitle: Sumário Lista de Tabelas ou Figuras
+title: Índice Lista de tabelas ou figuras
+linktitle: Table of Contents List of Tables or Figures
 type: docs
 weight: 10
-url: /pt/reportingservices/table-of-contents-list-of-tables-or-figures/
-description: Aprenda como adicionar um Sumário, Lista de Tabelas ou Figuras em relatórios PDF usando Aspose.PDF for Reporting Services.
-lastmod: "2026-06-19"
+url: /reportingservices/table-of-contents-list-of-tables-or-figures/
+description: Aprenda como adicionar um índice, uma lista de tabelas ou figuras em relatórios PDF usando Aspose.PDF para Reporting Services.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-O Report Designer não suporta a adição de sumário para documentos de relatório. Com Aspose.Pdf for Reporting Services você pode instruir facilmente o renderizador de PDF a gerar documentos PDF com Sumário, ou Lista de Tabelas ou Figuras. Você pode fazer isso nos passos a seguir:
+O Designer de Relatórios não oferece suporte à adição de sumário para documentos de relatório. Com Aspose.PDF for Reporting Services você pode facilmente instruir o renderizador de PDF para produzir documentos PDF com Índice ou Lista de Tabelas ou Figuras. Você pode fazer isso nas seguintes etapas:
 
 {{% /alert %}}
 
-{{% alert color="primary" %}}
-Certifique-se de que o arquivo Aspose.Pdf.ListSectionStyle.xml existe em ```<Instance>```/bin, onde ```<Instance>``` é o diretório do Report Server. Se o arquivo não existir, crie-o em ```<Instance>```diretório /bin e coloque a marcação a seguir dentro.
+Certifique-se de que o arquivo Aspose.Pdf.ListSectionStyle.xml exista no diretório ```<Instance>```/bin, where ```<Instance>``` is the directory of the Report Server. If the file does not exist, create it in the ```<Instance>```/bin e coloque a seguinte marcação dentro dele.
 
-## Sumário
+## Índice
 
-**Exemplo**
+### Exemplo
 
 ```cs
 <ListSection ListType="TableOfContents">
@@ -43,7 +42,7 @@ Certifique-se de que o arquivo Aspose.Pdf.ListSectionStyle.xml existe em ```<Ins
 
 ##  Lista de Tabelas
 
-**Exemplo**
+### Exemplo
 
 ```cs
 <ListSection ListType="ListOfTables">
@@ -55,7 +54,7 @@ Certifique-se de que o arquivo Aspose.Pdf.ListSectionStyle.xml existe em ```<Ins
 
 ## Lista de Figuras
 
-**Exemplo**
+### Exemplo
 
 ```cs
  <ListSection ListType="ListOfFigures">
@@ -66,41 +65,29 @@ Certifique-se de que o arquivo Aspose.Pdf.ListSectionStyle.xml existe em ```<Ins
 
 ```
 
-Consulte a seção 'Working with TOC' da documentação online do Aspose.Pdf.
+Consulte a seção 'Trabalhando com TOC' da documentação online do Aspose.Pdf.
 
-**2-** Adicione o parâmetro de relatório 'IsListSectionSupported' e defina o valor como True, conforme mostrado no parágrafo 'List Section'.
-**3-** Adicione uma propriedade personalizada para o item de relatório que você deseja que seja listado no Sumário, na Lista de Tabelas ou na Lista de Figuras.
+**2-** Adicione o parâmetro de relatório `IsListSectionSupported` e defina o valor como True conforme mostrado no parágrafo `List Section`.
+**3-** Adicione uma propriedade personalizada para o item do relatório que você deseja que seja listado no Índice, Lista de Tabelas ou Figuras.
 
-{{% /alert %}}
+```text
+Custom Property Name: IsInList
+Property Value: Boolean
+Custom Property Value: True or False
+```
 
-{{% alert color="primary" %}}
+Marca o item do relatório atual como listado por índice no índice ou na lista de tabelas ou figuras.
 
-**Nome da Propriedade Personalizada** :IsInList
-**Valor da Propriedade** :Boolean
-**Valor da Propriedade Personalizada** : Verdadeiro ou Falso
+```text
+Custom Property Name: Title
+Custom Property Type: String
+```
 
-{{% alert color="primary" %}}
+O título do item exibido no índice, lista de tabelas ou figuras.
 
-Marca o item de relatório atual como listado por índice no sumário, ou na lista de tabelas ou figuras.
+```text
+Custom Property Name: ListLevel
+Custom Property Type: Integer
+```
 
-{{% /alert %}}
-
-**Nome da Propriedade Personalizada** : Title
-**Tipo da Propriedade Personalizada** : String
-
-{{% alert color="primary" %}}
-
-O título do item exibido no sumário, lista de tabelas ou figuras.
-{{% /alert %}}
-
-**Nome da Propriedade Personalizada** : ListLevel
-**Tipo de Propriedade Personalizada** : Inteiro
-
-{{% alert color="primary" %}}
-
-O nível dos itens listados exibidos no sumário.
-
-{{% /alert %}}
-
-{{% /alert %}}
-
+O nível dos itens listados exibidos no índice.

--- a/pt/reportingservices/features/_index.md
+++ b/pt/reportingservices/features/_index.md
@@ -1,17 +1,17 @@
 ---
-title: Recursos
-linktitle: Recursos
+title: Características
+linktitle: Features
 type: docs
 weight: 30
-url: /pt/reportingservices/features/
-description: Descubra os principais recursos do Aspose.PDF for Reporting Services. Aprimore os relatórios SSRS com recursos avançados de renderização de PDF e personalização.
-lastmod: "2026-06-19"
+url: /reportingservices/features/
+description: Descubra os principais recursos do Aspose.PDF para Reporting Services. Aprimore os relatórios SSRS com recursos avançados de renderização e personalização de PDF.
+lastmod: "2021-06-05"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
-- [Suporte abrangente a RDL](/pdf/pt/reportingservices/comprehensive-rdl-support/)
-- [Suporte a Relatórios Parametrizados](/pdf/pt/reportingservices/parameterized-report-support/)
-- [Suporte a Itens de Relatório Personalizados](/pdf/pt/reportingservices/custom-report-item-support/)
-- [Implantação fácil e leve](/pdf/pt/reportingservices/easy-and-lightweight-deployment/)
-- [Suporte técnico gratuito de classe mundial](/pdf/pt/reportingservices/world-class-free-technical-support/)
 
+- [Suporte RDL abrangente](/pdf/pt/reportingservices/comprehensive-rdl-support/)
+- [Suporte a relatórios parametrizados](/pdf/pt/reportingservices/parameterized-report-support/)
+- [Suporte a item de relatório personalizado](/pdf/pt/reportingservices/custom-report-item-support/)
+- [Implantação fácil e leve](/pdf/pt/reportingservices/easy-and-lightweight-deployment/)
+- [Suporte Técnico Gratuito de Classe Mundial](/pdf/pt/reportingservices/world-class-free-technical-support/)

--- a/pt/reportingservices/features/comprehensive-rdl-support/_index.md
+++ b/pt/reportingservices/features/comprehensive-rdl-support/_index.md
@@ -1,24 +1,24 @@
 ---
-title: Suporte abrangente a RDL
-linktitle: Suporte abrangente a RDL
+title: Suporte RDL abrangente
+linktitle: Comprehensive RDL Support
 type: docs
 weight: 10
-url: /pt/reportingservices/comprehensive-rdl-support/
-description: Descubra o suporte abrangente a RDL no Aspose.PDF for Reporting Services. Renderize relatórios complexos do SQL Server em PDFs profissionais.
-lastmod: "2026-06-19"
+url: /reportingservices/comprehensive-rdl-support/
+description: Descubra suporte RDL abrangente em Aspose.PDF para Reporting Services. Renderize relatórios complexos do SQL Server em PDFs profissionais.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.Pdf for Reporting Services suporta a especificação RDL. Isso significa:
+Aspose.PDF para Reporting Services oferece suporte à especificação RDL. Isso significa:
 
-* Não é necessário redesenhar ou personalizar relatórios existentes.
-* Não é necessário usar um designer de relatórios específico. Você pode usar qualquer designer de relatórios RDL e o relatório será exportado exatamente da maneira como você o projetou.
+* Não há necessidade de redesenhar ou personalizar relatórios existentes.
+* Não há necessidade de usar um designer de relatório específico. Você pode usar qualquer designer de relatório RDL e o relatório será exportado exatamente da maneira que você o projetou.
 
 {{% /alert %}}
 
-## **Elementos RDL suportados**
-Aspose.PDF for Reporting Services suporta os seguintes elementos RDL:
+## Elementos RDL Suportados
+Aspose.PDF para Reporting Services oferece suporte aos seguintes elementos RDL:
 
 - Seções
 - Cabeçalhos, rodapés
@@ -31,7 +31,6 @@ Aspose.PDF for Reporting Services suporta os seguintes elementos RDL:
 - Estilos
 - Retângulos
 - Linhas
-- Sub Relatório
-- Painel de medidor (RS2008)
+- Sub-relatório
+- Painel de medição (RS2008)
 - Tablix (RS2008)
-

--- a/pt/reportingservices/features/custom-report-item-support/_index.md
+++ b/pt/reportingservices/features/custom-report-item-support/_index.md
@@ -1,22 +1,21 @@
 ---
-title: Suporte a Itens de Relatório Personalizados
-linktitle: Suporte a Itens de Relatório Personalizados
+title: Suporte a item de relatório personalizado
+linktitle: Custom Report Item Support
 type: docs
 weight: 30
-url: /pt/reportingservices/custom-report-item-support/
-description: Aproveite o suporte a itens de relatório personalizados no Aspose.PDF for Reporting Services. Produza PDFs sob medida e de alta qualidade sem esforço.
-lastmod: "2026-06-19"
+url: /reportingservices/custom-report-item-support/
+description: Aproveite o suporte a itens de relatório personalizados no Aspose.PDF para Reporting Services. Obtenha saídas de PDF personalizadas e de alta qualidade sem esforço.
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Na especificação RDL para RS2016, RS2017, RS2019, RS2022 e Power BI, quase todo item de relatório pode ser estendido adicionando propriedades personalizadas. Atualmente, o Aspose.PDF for Reporting Services 2016, 2017, 2019, 2022 e Power BI suporta três dessas propriedades, nomeadamente:
+Na especificação RDL para RS2016, RS2017, RS2019, RS2022 e Power BI, quase todos os itens de relatório podem ser estendidos adicionando propriedades personalizadas. Atualmente Aspose.PDF para Reporting Services 2016, 2017, 2019, 2022 e Power BI oferece suporte a três dessas propriedades, a saber:
 
-- Sumário, lista de tabelas ou figuras.
+- Índice, lista de tabelas ou figuras.
 - Setas de linha.
-- Nota de rodapé/Fim de nota.
+- Nota de rodapé/nota final.
 
-Descubra como usá‑los no [Expandir Propriedades dos Itens de Relatório](/pdf/pt/reportingservices/expand-report-items-properties/) artigo.
+Saiba como usá-los no [Expanda Propriedades de Itens de Relatório](/pdf/pt/reportingservices/expand-report-items-properties/) artigo.
 
 {{% /alert %}}
-

--- a/pt/reportingservices/features/easy-and-lightweight-deployment/_index.md
+++ b/pt/reportingservices/features/easy-and-lightweight-deployment/_index.md
@@ -1,22 +1,21 @@
 ---
-title: Implantação Fácil e Leve
-linktitle: Implantação Fácil e Leve
+title: Implantação fácil e leve
+linktitle: Easy and Lightweight Deployment
 type: docs
 weight: 40
-url: /pt/reportingservices/easy-and-lightweight-deployment/
-description: Aprenda como implantar o Aspose.PDF for Reporting Services com o mínimo esforço. A configuração leve garante rápida implementação e eficiência.
-lastmod: "2026-06-19"
+url: /reportingservices/easy-and-lightweight-deployment/
+description: Aprenda como implantar Aspose.PDF para Reporting Services com esforço mínimo. A configuração leve garante implementação rápida e eficiência.
+lastmod: "2021-06-05"
 ---
 
-**Aspose.Pdf for Reporting Services** é uma extensão de renderização personalizada para Microsoft SQL Server 2016/2017/2019/2022 Reporting Services e Power BI Report Server. O Aspose.Pdf for Reporting Services é fornecido como um único instalador MSI que pode ser instalado nos computadores que executam um dos seguintes:
+**Aspose.PDF for Reporting Services** é uma extensão de renderização personalizada para Microsoft SQL Server 2016/2017/2019/2022 Reporting Services e Power BI Report Server. Aspose.PDF para Reporting Services é fornecido como um único instalador MSI que pode ser instalado nos computadores que executam um dos seguintes:
 
-- Microsoft SQL Server 2016 Reporting Services  
-- Microsoft SQL Server 2017 Reporting Services  
-- Microsoft SQL Server 2019 Reporting Services  
-- Microsoft SQL Server 2022 Reporting Services  
-- Microsoft Power BI Report Server
+- Serviços de relatórios do Microsoft SQL Server 2016  
+- Serviços de relatórios do Microsoft SQL Server 2017  
+- Serviços de relatórios do Microsoft SQL Server 2019  
+- Serviços de relatório do Microsoft SQL Server 2022  
+- Servidor de relatórios do Microsoft Power BI
  
-Aspose.Pdf for Reporting Services é fácil de implantar e gerenciar, pois é composto por apenas um assembly .NET Aspose.Pdf.ReportingServices.dll, escrito completamente em C#, compatível com CLS e contendo apenas código gerenciado seguro. É necessário ter o .NET Framework 4.8.1 instalado no servidor.
+Aspose.PDF para Reporting Services é fácil de implantar e gerenciar, pois é composto por apenas um assembly .NET Aspose.Pdf.ReportingServices.dll, escrito completamente em C#, compatível com CLS e contendo apenas código gerenciado seguro. É necessário ter o .NET Framework 4.8.1 instalado no servidor.
 
-Aspose.Pdf.ReportingServices.dll deve ser copiado para o diretório ReportServer\\bin e o arquivo de configuração deve ser atualizado para que o Reporting Services reconheça a nova extensão de renderização. Essas etapas são realizadas pelo instalador do Aspose.Pdf for Reporting Services, mas você também pode executá‑las manualmente conforme descrito mais adiante nesta documentação.
-
+Aspose.Pdf.ReportingServices.dll deve ser copiado para o diretório ReportServer\bin e o arquivo de configuração deve ser atualizado para que o Reporting Services esteja ciente da nova extensão de renderização. Essas etapas são executadas pelo instalador do Aspose.PDF for Reporting Services, mas você também pode executá-las manualmente, conforme descrito mais adiante nesta documentação.

--- a/pt/reportingservices/features/parameterized-report-support/_index.md
+++ b/pt/reportingservices/features/parameterized-report-support/_index.md
@@ -1,28 +1,27 @@
 ---
-title: Suporte a Relatórios Parametrizados
-linktitle: Suporte a Relatórios Parametrizados
+title: Suporte a relatórios parametrizados
+linktitle: Parameterized Report Support
 type: docs
 weight: 20
-url: /pt/reportingservices/parameterized-report-support/
-lastmod: "2026-06-19"
+url: /reportingservices/parameterized-report-support/
+lastmod: "2021-06-05"
 ---
 
-Um relatório parametrizado é um relatório que aceita valores de entrada usados no processamento do relatório. Com um relatório parametrizado, você pode variar a saída de um relatório com base em valores que são definidos quando o relatório é executado. Aspose.Pdf for Reporting Services suporta dois tipos de parâmetros: parâmetros do servidor de relatórios e parâmetros de relatório. Os parâmetros do servidor de relatórios são usados para todos os relatórios no servidor de relatórios. Se você quiser tornar alguns parâmetros adequados para relatórios específicos, deve usar parâmetros de relatório.
+Um relatório parametrizado é um relatório que aceita valores de entrada usados ​​no processamento de relatórios. Com um relatório parametrizado, você pode variar a saída de um relatório com base nos valores definidos quando o relatório é executado. Aspose.PDF for Reporting Services oferece suporte a dois tipos de parâmetros: parâmetros do servidor de relatório e parâmetros de relatório. Os parâmetros do servidor de relatórios são usados ​​para todos os relatórios no servidor de relatórios. Se quiser tornar alguns parâmetros adequados para relatórios específicos, você deve usar parâmetros de relatório.
 
-Atualmente, o renderizador Aspose.Pdf suporta uma ampla variedade de parâmetros, como:
+Atualmente, o renderizador Aspose.Pdf oferece suporte a uma ampla gama de parâmetros, como:
 
-## **Parâmetros Suportados**
-Na versão atual, o Aspose.PDF render suporta diversos aspectos dos parâmetros, que são:
+## Parâmetros suportados
+Na versão atual, a renderização Aspose.PDF suporta muitos aspectos de parâmetros, que são:
 
 - Orientação da página
 - Formatação HTML
 - Atributos de segurança
 - Tamanho da página
 - Tamanho das margens da página
-- Incorporação de fontes
-- Conformidade PDF/A
-- metadados XMP
-- informações de depuração
+- Incorporação de fonte
+- Conformidade com PDF/A
+- Metadados XMP
+- Informações de depuração
 
-Saiba mais sobre os parâmetros a partir do [Configure Aspose.PDF for Reporting Services](/pdf/pt/reportingservices/configure-aspose-pdf-for-reporting-services/) artigo.
-
+Saiba mais sobre os parâmetros do [Configurar Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/configure-aspose-pdf-for-reporting-services/) artigo.

--- a/pt/reportingservices/features/world-class-free-technical-support/_index.md
+++ b/pt/reportingservices/features/world-class-free-technical-support/_index.md
@@ -1,21 +1,21 @@
 ---
 title: Suporte Técnico Gratuito de Classe Mundial
-linktitle: Suporte Técnico Gratuito de Classe Mundial
+linktitle: World Class Free Technical Support
 type: docs
 weight: 50
-url: /pt/reportingservices/world-class-free-technical-support/
-description: Desfrute de suporte técnico gratuito de classe mundial para Aspose.PDF for Reporting Services. Receba assistência especializada sempre que precisar.
-lastmod: "2026-06-19"
+url: /reportingservices/world-class-free-technical-support/
+description: Aproveite suporte técnico gratuito de classe mundial para Aspose.PDF for Reporting Services. Obtenha assistência especializada sempre que precisar.
+lastmod: "2021-06-05"
 ---
 
-A Aspose é reconhecida por seu suporte técnico gratuito e ilimitado, que conta com artigos técnicos, manuais, fóruns e suporte sempre disponível, além dos desenvolvedores de produto. Se houver uma nova versão ou um Hot Fix de um produto lançada, todas as novas versões estão disponíveis gratuitamente se você tiver uma assinatura ativa.
+Aspose é conhecida por seu suporte técnico gratuito e ilimitado, que é apoiado por artigos técnicos, manuais, fóruns e suporte sempre pronto e desenvolvedores de produtos. Se houver uma nova versão ou um Hot Fix de um produto for lançado, todos os novos lançamentos estarão disponíveis gratuitamente se você tiver uma assinatura ativa.
 
-**Aspose.Support Forums** é o local não apenas para resolver problemas técnicos, mas também para participar de discussões de desenvolvimento com a comunidade vibrante e crescente de usuários da Aspose. Atualmente, há mais de 129.000 usuários registrados no site da Aspose.
+**Aspose.Support Forums** é o lugar não apenas para resolver problemas técnicos, mas também para participar de discussões de desenvolvimento com a comunidade vibrante e crescente de usuários do Aspose. Atualmente existem mais de 129.000 usuários registrados no site Aspose.
 
-Aspose.Blogs é o local para procurar informações sobre os lançamentos mais recentes e o que os desenvolvedores da Aspose têm a dizer.
+Aspose.Blogs é o lugar para procurar informações sobre os últimos lançamentos e sobre o que os desenvolvedores do Aspose têm a dizer.
 
-Há muita atividade nos Aspose.Support Forums:
+Há muita atividade nos Fóruns Aspose.Support:
 
-![todo:image_alt_text](world-class-free-technical-support.png)
+![Suporte Técnico Gratuito](world-class-free-technical-support.png)
 
  

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/_index.md
@@ -1,20 +1,17 @@
 ---
-title: Instalar Aspose.PDF
-linktitle: Instalar Aspose.PDF
+title: Instale Aspose.PDF
+linktitle: Install Aspose.PDF
 type: docs
 weight: 50
-url: /pt/reportingservices/install-aspose-pdf-for-reporting-services/
-description: Saiba como instalar o Aspose.PDF para Reporting Services. Siga este guia passo a passo para habilitar a funcionalidade de exportação de PDF no SSRS.
-lastmod: "2026-06-19"
+url: /reportingservices/install-aspose-pdf-for-reporting-services/
+description: Aprenda como instalar o Aspose.PDF para Reporting Services. Siga este guia passo a passo para ativar a funcionalidade de exportação de PDF no SSRS.
+lastmod: "2021-06-05"
 ---
-
-{{% alert color="primary" %}}
 
 **Esta seção inclui os seguintes tópicos:**
 
-- [Instalar com instalador MSI](/pdf/pt/reportingservices/install-with-msi-installer/)
-- [Instalar manualmente](/pdf/pt/reportingservices/install-manually/)
-- [Instalar com a Ferramenta de Configuração](/pdf/pt/reportingservices/install-with-configuring-tool/)
+- [Install with MSI Installer](/pdf/reportingservices/install-with-msi-installer/)
+- [Install Manually](/pdf/reportingservices/install-manually/)
+- [Install with Configuring Tool](/pdf/reportingservices/install-with-configuring-tool/)
 
-{{% /alert %}}
 

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/_index.md
@@ -1,14 +1,13 @@
 ---
 title: Instalar manualmente
-linktitle: Instalar manualmente
+linktitle: Install Manually
 type: docs
 weight: 20
-url: /pt/reportingservices/install-manually/
-lastmod: "2026-06-19"
+url: /reportingservices/install-manually/
+lastmod: "2021-06-05"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
-- [Instalar no Report Server](/pdf/pt/reportingservices/install-to-report-server/)
-
+- [Instalar no servidor de relatório](/pdf/pt/reportingservices/install-to-report-server/)
 

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-manually/install-to-report-server/_index.md
@@ -1,60 +1,46 @@
 ---
-title: Instalar no Report Server
-linktitle: Instalar no Report Server
+title: Instalar no servidor de relatório
+linktitle: Install to Report Server
 type: docs
 weight: 10
-url: /pt/reportingservices/install-to-report-server/
-lastmod: "2026-06-19"
+url: /reportingservices/install-to-report-server/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Você só precisa seguir estas etapas se instalar o Aspose.PDF for Reporting Services manualmente, não usando o instalador MSI. O instalador MSI executa todas as ações necessárias de instalação e registro automaticamente.
+Você só precisará seguir essas etapas se instalar o Aspose.PDF para Reporting Services manualmente, sem usar o instalador MSI. O instalador MSI executa todas as ações necessárias de instalação e registro automaticamente.
 
 {{% /alert %}}
 
-Nas etapas seguintes, você precisará copiar e modificar arquivos no diretório onde o Microsoft SQL Server Reporting Services está instalado. O assembly do SSRS 2016 está localizado no diretório \Bin\SSRS2016 do pacote zip; o assembly do SSRS 2017 está localizado no diretório \Bin\SSRS2017; o assembly do SSRS 2019 está localizado no diretório \Bin\SSRS2019; o assembly do SSRS 2022 está localizado no diretório \Bin\SSRS2022; o assembly do Power BI Report Server está localizado no diretório \Bin\PowerBI. 
+Nas etapas a seguir, você precisará copiar e modificar arquivos no diretório onde o Microsoft SQL Server Reporting Services está instalado. O assembly do SSRS 2016 está localizado no diretório \Bin\SSRS2016 do pacote zip; o assembly SSRS 2017 está localizado no diretório \Bin\SSRS2017; o assembly SSRS 2019 está localizado no diretório \Bin\SSRS2019; o assembly SSRS 2022 está localizado no diretório \Bin\SSRS2022; o assembly do Servidor de Relatórios do Power BI está localizado no diretório \Bin\PowerBI.
 
-{{% alert color="primary" %}}
+**Etapa 1.** Localize o diretório de instalação do Report Server. O diretório raiz do Microsoft SQL Server geralmente é C:\Program Files\Microsoft SQL Server. O processo adicional é um pouco diferente para o Reporting Services 2016, o Reporting Services 2017 e posterior e o Power BI Report Server:
 
-**Etapa 1.** Localize o diretório de instalação do Report Server. O diretório raiz do Microsoft SQL Server geralmente é C:\Program Files\Microsoft SQL Server. O processo posterior é um pouco diferente para Reporting Services 2016, Reporting Services 2017 e posteriores, e para o Power BI Report Server:
+- O Report Server 2016, por padrão, é instalado no diretório C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer. Se você estiver usando instâncias nomeadas personalizadas em vez da padrão, o caminho padrão será C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
+- O Report Server 2017 e posterior, por padrão, é instalado no diretório C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer.
+- Por padrão, o Power BI Report Server é instalado no diretório C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer.
 
-- O Report Server 2016, por padrão, é instalado no diretório C:\Program Files\Microsoft SQL Server\MSRS13.MSSQLSERVER\Reporting Services\ReportServer. Se você estiver usando instâncias com nomes personalizados em vez da padrão, o caminho padrão será C:\Program Files\Microsoft SQL Server\MSRS13.[SSRSInstanceName]\Reporting Services\ReportServer
-- O Report Server 2017 e versões posteriores, por padrão, são instalados no diretório C:\Program Files\Microsoft SQL Server Reporting Services\SSRS\ReportServer.
-- O Power BI Report Server, por padrão, é instalado no diretório C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer.
+No texto a seguir, o diretório de instalação do Reporting Services (um dos caminhos mencionados acima) será referenciado como `<Instance>`.
 
-No texto a seguir, o diretório de instalação do Reporting Services (um dos caminhos mencionados) será referenciado como ```<Instance>```.
-{{% /alert %}}
+**Etapa 2.** Copie Aspose.Pdf.ReportingServices.dll da versão SSRS correspondente para a pasta `<Instance>\bin`.
 
-{{% alert color="primary" %}}
-**Etapa 2.** Copie Aspose.Pdf.ReportingServices.dll para a versão correspondente do SSRS para ```<Instance>```pasta \bin.
-{{% /alert %}}
+**Etapa 3.** Registre Aspose.PDF para Reporting Services como uma extensão de renderização. Abra o arquivo `<Instance>\rsreportserver.config` e adicione as seguintes linhas ao elemento `<Render>`:
 
-{{% alert color="primary" %}}
-**Etapa 3.** Registre o Aspose.Pdf for Reporting Services como uma extensão de renderização. Abra o ```<Instance>```\rsreportserver.config file e adicione as linhas a seguir no ```<Render>``` elemento:
-{{% /alert %}}
+## Exemplo
 
-**Exemplo**
-
-{{< highlight csharp >}}
-
- <Render>
+```xml
+<Render>
 ...
-<!--Start here.-->
-
 <Extension Name="APPDF" Type="Aspose.Pdf.ReportingServices.Renderer,Aspose.Pdf.ReportingServices"/>
-
 </Render>
+```
 
-{{< /highlight >}}
+**Etapa 4.** Forneça ao Aspose.PDF para Reporting Services permissões de execução. Abra o arquivo `<Instance>\rssrvpolicy.config` e adicione o seguinte texto como o último item no segundo elemento externo `<CodeGroup>` que deve ser `<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):`
 
-{{% alert color="primary" %}}
-**Etapa 4.** Forneça o Aspose.Pdf for Reporting Services com permissões para executar. Abra o ```<Instance>```arquivo \\rssrvpolicy.config e adicione o texto a seguir como o último item no segundo ao externo ```<CodeGroup>``` elemento (que deve ser ```<CodeGroup class="FirstMatchCodeGroup" version="1" PermissionSetName="Execution" Description="This code group grants MyComputer code Execution permission. ">):```
-{{% /alert %}}
+## Exemplo
 
-**Exemplo**
-
-{{< highlight csharp >}}
+```xml
 
  <CodeGroup>
 ...
@@ -77,23 +63,14 @@ Name="Aspose.Pdf_for_Reporting_Services" Description="This code group grants ful
 </CodeGroup>
 
 </CodeGroup>
+```
 
-{{< /highlight >}}
+**Etapa 5.** Verifique se o Aspose.PDF para Reporting Services foi instalado com êxito. Abra o portal da Web Reporting Services e verifique a lista de formatos de exportação disponíveis para um relatório. Você pode iniciar o portal da web iniciando um navegador da web e digitando o URL do portal da web do Reporting Services na barra de endereço (por padrão é http://`<Reporting_Services_server_name>`/reports/). Selecione um dos relatórios disponíveis em seu portal da web e abra a lista suspensa Exportar. Você deverá ver a lista de formatos de exportação, incluindo aqueles fornecidos pela extensão Aspose.PDF para Reporting Services. Selecione PDF por meio do item Aspose.PDF.
 
-{{% alert color="primary" %}}
-**Etapa 5.** Verifique se o Aspose.Pdf for Reporting Services foi instalado com sucesso. Abra o portal web do Reporting Services e verifique a lista de formatos de exportação disponíveis para um relatório. Você pode iniciar o portal web iniciando um navegador e digitando a URL do portal web do Reporting Services na barra de endereço (por padrão, ela é http://```<Reporting_Services_server_name>```/reports/). Selecione um dos relatórios disponíveis em seu portal da Web e abra a lista suspensa Exportar. Você deve ver a lista de formatos de exportação, incluindo os fornecidos pela extensão Aspose.Pdf for Reporting Services. Selecione o item PDF via Aspose.PDF.
+![Install to report server](install-to-report-server_1.png)
 
- 
-{{% /alert %}}
+Clique no item selecionado. Ele irá gerar o relatório no formato selecionado, enviá-lo ao cliente e, dependendo das configurações do seu navegador, mostrar a caixa de diálogo Salvar arquivo para escolher onde salvar o relatório exportado ou baixar automaticamente o arquivo para sua pasta Downloads.
 
-![todo:image_alt_text](install-to-report-server_1.png)
-
-Clique no item selecionado. Ele gerará o relatório no formato selecionado, enviará ao cliente e, dependendo das configurações do seu navegador, exibirá a caixa de diálogo Salvar arquivo para escolher onde salvar o relatório exportado ou baixará automaticamente o arquivo para a sua pasta Downloads.
-
-{{% alert color="primary" %}}
-Parabéns, você instalou o Aspose.Pdf for Reporting Services com sucesso e exportou um relatório como documento PDF!
-{{% /alert %}}
-
-
+Parabéns, você instalou com sucesso o Aspose.PDF for Reporting Services e exportou um relatório como um documento PDF!
 
 

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-with-configuring-tool/_index.md
@@ -1,25 +1,23 @@
 ---
-title: Instalar com a Ferramenta de Configuração
-linktitle: Instalar com a Ferramenta de Configuração
+title: Instalar com ferramenta de configuração
+linktitle: Install with Configuring Tool
 type: docs
 weight: 30
-url: /pt/reportingservices/install-with-configuring-tool/
-description: Guia passo a passo para instalar o Aspose.PDF for Reporting Services usando a ferramenta de configuração para integração perfeita.
-lastmod: "2026-06-19"
+url: /reportingservices/install-with-configuring-tool/
+description: Guia passo a passo para instalar o Aspose.PDF para Reporting Services usando a ferramenta de configuração para integração perfeita.
+lastmod: "2021-06-05"
 ---
 
-O Aspose.Pdf for Reporting Services Configuring Tool pode ajudá-lo a configurar a extensão Aspose.Pdf for Reporting Services para qualquer uma das versões suportadas do Report Server (RS). Atualmente, ele suporta RS2016, RS2017, RS2019, RS2022 e Power BI Report Server. O Configuring Tool requer .NET Framework 4.8.
+A ferramenta de configuração Aspose.PDF for Reporting Services pode ajudá-lo a configurar a extensão Aspose.PDF for Reporting Services para qualquer uma das versões suportadas do Report Server (RS). Atualmente ele oferece suporte a RS2016, RS2017, RS2019, RS2022 e Power BI Report Server. A ferramenta de configuração requer o .NET Framework 4.8.
 
-Se você quiser instalar a extensão e registrá‑la no Report Server, selecione o tipo de ação 'Register'. Para cancelar o registro e desinstalar a extensão, selecione o tipo de ação 'Unregister'.
+Se desejar instalar a extensão e registrá-la no Report Server, selecione a opção `Register` tipo de ação. Para cancelar o registro e desinstalar a extensão, selecione o `Unregister` tipo de ação.
 
-![todo:image_alt_text](install-with-configuring-tool_1.png)
+![Instalar com ferramenta de configuração](install-with-configuring-tool_1.png)
 
-**Os passos a seguir descrevem como usá‑lo em detalhes:**
+**As etapas a seguir descrevem como usá-lo em detalhes:**
 
-1. Insira ou procure o caminho do arquivo DLL para a extensão Aspose.Pdf for Reporting Services;
-1. Selecione o tipo de ação correspondente: Register ou Unregister;
-1. Selecione a aba correspondente à versão do Report Server que você deseja configurar. Certifique‑se de que selecionou o arquivo DLL destinado à sua versão do RS. Se a versão solicitada do produto não estiver instalada na máquina, a ferramenta de configuração lhe informará com dicas. Se estiver configurando a extensão para a instância nomeada RS2016 (não a padrão 'MSSQLSERVER'), insira o nome da instância personalizada e, em seguida, pressione o botão 'Refresh'.
-1. Certifique‑se de que os caminhos e nomes dos arquivos de configuração exibidos nas caixas de texto inferiores estejam corretos. Se não estiverem, você pode pressionar o botão 'Refresh' para tentar localizar a instância do RS novamente, ou pode procurá‑los manualmente.
-1. Pressione o botão 'Config'. A ferramenta agora tentará aplicar a configuração solicitada e informará se a configuração foi bem‑sucedida ou não.
- 
-
+1. Insira ou procure o caminho do arquivo DLL para a extensão Aspose.PDF para Reporting Services;
+1. Selecione o tipo de ação correspondente: Cadastrar ou Descadastrar;
+1. Selecione a guia correspondente à versão do Report Server que você deseja configurar. Certifique-se de ter selecionado o arquivo DLL destinado à sua versão RS. Caso a versão solicitada do produto não esteja instalada na máquina, a ferramenta de configuração informará com dicas. Se você estiver configurando a extensão para a instância RS2016 nomeada (não a padrão 'MSSQLSERVER'), insira o nome da instância personalizada e pressione o botão 'Atualizar'.
+1. Certifique-se de que os caminhos e nomes dos arquivos de configuração mostrados nas caixas de texto inferiores estejam corretos. Se não estiverem, você pode pressionar o botão 'Atualizar' para tentar encontrar a instância RS novamente ou pode procurá-los manualmente.
+1. Pressione o botão 'Configurar'. A ferramenta agora tentará fazer a configuração solicitada e informará se a configuração foi bem-sucedida ou não.

--- a/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
+++ b/pt/reportingservices/install-aspose-pdf-for-reporting-services/install-with-msi-installer/_index.md
@@ -1,24 +1,23 @@
 ---
-title: Instalar com Instalador MSI
-linktitle: Instalar com Instalador MSI
+title: Instalar com o instalador MSI
+linktitle: Install with MSI Installer
 type: docs
 weight: 10
-url: /pt/reportingservices/install-with-msi-installer/
-description: Aprenda como instalar o Aspose.PDF for Reporting Services usando o instalador MSI. Um guia simples para uma configuração rápida.
-lastmod: "2026-06-19"
+url: /reportingservices/install-with-msi-installer/
+description: Aprenda como instalar o Aspose.PDF para Reporting Services usando o instalador MSI. Um guia simples para configuração rápida.
+lastmod: "2021-06-05"
 ---
 
-Você pode instalar o Aspose.Pdf for Reporting Services usando um instalador MSI. Execute Aspose.Pdf.ReportingServices.msi e siga as etapas oferecidas pelo instalador. O instalador copiará o assembly e outros arquivos para o diretório especificado e instalará o produto na instância padrão do Reporting Services. Você não precisa copiar ou modificar nenhum arquivo manualmente, a menos que deseje adicionar parâmetros de configuração especiais conforme descrito na seção ‘Configure Aspose.Pdf for Reporting Services’.
+Você pode instalar o Aspose.PDF para Reporting Services usando um instalador MSI. Execute Aspose.Pdf.ReportingServices.msi e siga as etapas oferecidas pelo instalador. O instalador copiará o assembly e outros arquivos para o diretório especificado e instalará o produto na instância padrão do Reporting Services. Você não precisa copiar ou modificar nenhum arquivo manualmente, a menos que queira adicionar parâmetros de configuração especiais, conforme descrito na seção 'Configurar Aspose.PDF para Reporting Services'.
 
-A instalação automática é a melhor opção, que funciona na maioria dos casos. Contudo, pode ser necessário instalar o produto manualmente em algumas situações, como:
- 
-- A instalação automática falha devido a problemas de segurança de I/O.
+A instalação automática é a melhor opção que funciona na maioria dos casos. No entanto, pode ser necessário instalar o produto manualmente em algumas situações como:
+
+- A instalação automática falha devido a problemas de segurança de E/S.
 - Você precisa instalar o produto em uma instância nomeada (não padrão) do Reporting Services 2016 ou em várias instâncias.
-- Você atualiza para a versão mais recente e deseja apenas substituir o assembly em vez de desinstalar a versão antiga e instalar a nova usando o instalador MSI.
+- Você atualiza para a versão mais recente e deseja apenas substituir a montagem em vez de desinstalar a versão antiga e instalar a nova usando o instalador MSI.
  
 {{% alert color="primary" %}}
 
-Observação: Note que, no último caso, você pode acabar com outros componentes (como a documentação offline) que não foram atualizados para a versão correspondente.
+Nota: Observe que neste último caso você pode acabar com outros componentes (como a documentação offline) não atualizados para a versão correspondente.
 
 {{% /alert %}}
-

--- a/pt/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/license-aspose-pdf-for-reporting-services/_index.md
@@ -1,53 +1,50 @@
 ---
 title: Licença
-linktitle: Licença
+linktitle: License
 
 type: docs
 weight: 70
-url: /pt/reportingservices/license-aspose-pdf-for-reporting-services/
-description: Entenda as opções de licenciamento para Aspose.PDF for Reporting Services. Descubra como ativar sua licença e desbloquear todas as funcionalidades.
-lastmod: "2026-06-19"
+url: /reportingservices/license-aspose-pdf-for-reporting-services/
+description: Entenda as opções de licenciamento do Aspose.PDF para Reporting Services. Descubra como ativar sua licença e desbloquear todas as funcionalidades.
+lastmod: "2021-06-05"
 ---
 
-**Aspose.Pdf for Reporting Services** versão de avaliação fornece o mesmo conjunto de recursos presente na versão Licenciada, exceto pela marca d'água de avaliação no PDF resultante ao usar a versão de avaliação. Por favor, visite nosso site e faça o download da versão do produto e comece a explorar nosso produto com o conjunto completo de recursos em modo de avaliação.
+A versão de avaliação **Aspose.PDF for Reporting Services** fornece o mesmo conjunto de recursos presente na versão licenciada, exceto pela marca d'água de avaliação no PDF resultante ao usar a versão de avaliação. Visite nosso site e baixe a versão do produto e comece a explorar nosso produto com um conjunto completo de recursos em modo de avaliação.
 
-Quando estiver satisfeito com sua avaliação, [compre uma licença](https://purchase.aspose.com/buy). Antes de comprar, certifique-se de que entende e concorda com os termos da assinatura da licença.
+Quando você estiver satisfeito com sua avaliação, [buy a license](https://purchase.aspose.com/buy). Antes de comprar, certifique-se de compreender e concordar com os termos de assinatura da licença.
 
-A licença estará disponível para download na página de pedido após o pagamento do pedido. A licença é um arquivo XML em texto simples, assinado digitalmente. A licença contém informações como o nome do cliente, o produto adquirido e o tipo da licença. Não modifique o conteúdo do arquivo de licença, pois isso invalidará a licença.
+A licença estará disponível para download na página do pedido após o pagamento do pedido. A licença é um arquivo XML de texto não criptografado e assinado digitalmente. A licença contém informações como o nome do cliente, o produto adquirido e o tipo de licença. Não modifique o conteúdo do arquivo de licença, pois isso invalidará a licença.
 
-## Licenciando um Servidor
+## Licenciamento de um servidor
 
-Baixe o arquivo de licença e copie-o para C:\Program Files\Microsoft SQL Server\```<Instance>``\Reporting Services\ReportServer\bin, or C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin, or C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin folder on the server (the same folder where the Aspose.Pdf.ReportingServices.dll is placed).
+Baixe o arquivo de licença e copie-o para a pasta C:\Program Files\Microsoft SQL Server\<Instance>\Reporting Services\ReportServer\bin ou C:\Program Files\Microsoft SQL Server\SSRS\ReportServer\bin ou C:\Program Files\Microsoft Power BI Report Server\PBIRS\ReportServer\bin no servidor (a mesma pasta onde está o Aspose.Pdf.ReportingServices.dll é colocado).
 
-```<Instance>``` is the subdirectory name that corresponds to the Microsoft SQL Server 2016 instance you want to license.
+`<Instance>` é o nome do subdiretório que corresponde à instância do Microsoft SQL Server 2016 que você deseja licenciar.
 
-The default instance directory for Microsoft SQL Server 2016 is MSRS13.MSSQLSERVER.
-For the Microsoft SQL Server 2017 and later the default instance path is C:\Program Files\Microsoft SQL Server\SSRS.
-For the Power BI Report Server the default instance path is C:\Program Files\Microsoft Power BI Report Server\PBIRS.
+O diretório de instância padrão do Microsoft SQL Server 2016 é MSRS13.MSSQLSERVER.
+Para o Microsoft SQL Server 2017 e posterior, o caminho da instância padrão é C:\Program Files\Microsoft SQL Server\SSRS.
+Para o Servidor de Relatórios do Power BI, o caminho da instância padrão é C:\Arquivos de Programas\Microsoft Power BI Report Server\PBIRS.
 
-**PDF generated using “Territory sales drilldown” report**
+**PDF gerado usando o relatório "Detalhamento de vendas por território"**
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_1.png)
+![License-Territory sales drilldown](license-aspose-pdf-for-reporting-services_1.png)
 
+**PDF gerado usando o relatório "Detalhes do pedido de vendas"**
 
-**PDF generated using “Sales Order details” report**
+![License-Sales Order details](license-aspose-pdf-for-reporting-services_2.png)
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_2.png)
+Se houver algum problema ao inicializar a licença, uma marca d’água de avaliação será exibida no documento PDF resultante, conforme especificado abaixo.
 
-If there is a problem while initializing the license, an evaluation watermark is displayed in the resultant PDF document as specified below.
+**Documento PDF gerado usando "Detalhamento de Vendas por Território" com marca d'água**
 
-**PDF document generated using “Territory Sales Drilldown” with watermark**
+![License-Territory Sales Drilldown](license-aspose-pdf-for-reporting-services_3.png)
 
-![todo:image_alt_text](license-aspose-pdf-for-reporting-services_3.png)
+Observe que os nomes dos arquivos de licença suportados são Aspose.PDF.ReportingServices.lic, Aspose.Total.ReportingServices.lic e Aspose.Total.Product.Family.lic. Se o arquivo tiver outro nome, renomeie-o.
 
-Please note that that supported license file names are Aspose.PDF.ReportingServices.lic, Aspose.Total.ReportingServices.lic and Aspose.Total.Product.Family.lic. If the file has any other name, please rename it.
-
-
-## Temporary License
+## Licença Temporária
 
 {{% alert color="primary" %}}
 
-You may also request a 30 days temporary license to test the product. Please visit the following link for more information on how to get Temporary license. [Get a Temporary License](https://purchase.aspose.com/temporary-license).
+Você também pode solicitar uma licença temporária de 30 dias para testar o produto. Visite o link a seguir para obter mais informações sobre como obter licença temporária. [Get a Temporary License](https://purchase.aspose.com/temporary-license).
 
 {{% /alert %}}
-

--- a/pt/reportingservices/product-overview/_index.md
+++ b/pt/reportingservices/product-overview/_index.md
@@ -1,11 +1,11 @@
 ---
 title: Visão geral do produto
-linktitle: Visão geral do produto
+linktitle: Product Overview
 type: docs
 weight: 10
-url: /pt/reportingservices/product-overview/
+url: /reportingservices/product-overview/
 description: Uma visão geral do Aspose.PDF for Reporting Services – uma solução abrangente para renderizar relatórios SSRS em PDF com recursos avançados de layout.
-lastmod: "2026-06-19"
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
@@ -14,18 +14,17 @@ lastmod: "2026-06-19"
 
 {{% /alert %}}
 
-## Bem-vindo ao Aspose.PDF for Reporting Services!
+## Bem-vindo ao Aspose.PDF para Reporting Services!
 
-Microsoft SQL Server Reporting Services atende a uma necessidade que muitas organizações enfrentam - a necessidade de construir soluções de inteligência de negócios e de relatórios. Até agora, os desenvolvedores precisavam incorporar relatórios em suas aplicações, ou as organizações precisavam adquirir soluções de relatórios de terceiros caras e às vezes problemáticas. Agora, Microsoft SQL Server Reporting Services oferece uma solução completa para distribuir relatórios em toda a empresa; permitindo que os negócios tomem decisões melhor e mais rapidamente.
+O Microsoft SQL Server Reporting Services atende a uma necessidade que muitas organizações enfrentam: a necessidade de criar soluções de business intelligence e relatórios. Até agora, os desenvolvedores eram obrigados a incorporar relatórios em seus aplicativos ou as organizações eram obrigadas a adquirir soluções de relatórios de terceiros caras e às vezes problemáticas. Agora, o Microsoft SQL Server Reporting Services oferece uma solução completa para distribuição de relatórios em toda a empresa; permitindo que as empresas tomem decisões melhores e mais rápidas.
 
-**Aspose.Pdf for Reporting Services** é outra solução única da Aspose, que torna possível a geração de relatórios PDF no Microsoft SQL Server 2016/2017/2019/2022 Reporting Services e no Power BI Report Server. Todos os recursos de relatório RDL, incluindo tabelas, matrizes, gráficos e imagens, são convertidos com o mais alto grau de precisão para PDF.
+**Aspose.PDF for Reporting Services** é outra solução exclusiva da Aspose, que possibilita a geração de relatórios em PDF no Microsoft SQL Server 2016/2017/2019/2022 Reporting Services e no Power BI Report Server. Todos os recursos do relatório RDL, incluindo tabelas, matrizes, gráficos e imagens, são convertidos para PDF com o mais alto grau de precisão.
 
-Microsoft SQL Server Reporting Services tem habilidades integradas para exportar relatórios como documentos PDF, mas carece de oferecer o suporte técnico necessário para o usuário final. Aspose.Pdf se esforça para fornecer um suporte técnico supremo e eficiente.
+O Microsoft SQL Server Reporting Services possui recursos integrados para exportar relatórios como documentos PDF, mas não fornece o suporte técnico necessário para o usuário final. Aspose.Pdf se esforça para fornecer um suporte técnico supremo e eficiente.
 
-Aspose.Pdf for Reporting Services cria documentos no servidor sem utilizar o Adobe.Pdf SDK. Aspose.Pdf for Reporting Services usa internamente o Aspose.Pdf for .NET – o componente de classe mundial para processamento e conversões de documentos no lado do servidor.
+Aspose.PDF para Reporting Services cria documentos no servidor sem utilizar Adobe.Pdf SDK. O Aspose.PDF for Reporting Services usa internamente o Aspose.PDF for .NET – o componente de classe mundial para processamento e conversões de documentos no servidor.
 
-## Aspose.PDF for Reporting Services torna possível exportar qualquer relatório no formato PDF
+## Aspose.PDF for Reporting Services permite exportar qualquer relatório em formato PDF
 
-![todo:image_alt_text](product-overview_2.png)
-
+![Product Overview](product-overview_2.png)
 

--- a/pt/reportingservices/sample-reports-gallery/_index.md
+++ b/pt/reportingservices/sample-reports-gallery/_index.md
@@ -1,38 +1,37 @@
 ---
-title: Galeria de Relatórios de Exemplo
-linktitle: Galeria de Relatórios de Exemplo
+title: Galeria de exemplos de relatórios
+linktitle: Sample Reports Gallery
 type: docs
 weight: 40
-url: /pt/reportingservices/sample-reports-gallery/
-description: Explore relatórios de exemplo gerados usando Aspose.PDF for Reporting Services. Veja como seus relatórios SSRS podem se transformar em saídas PDF refinadas.
-lastmod: "2026-06-19"
+url: /reportingservices/sample-reports-gallery/
+description: Explore exemplos de relatórios gerados usando Aspose.PDF para Reporting Services. Veja como seus relatórios SSRS podem se transformar em saídas de PDF sofisticadas.
+lastmod: "2024-05-05"
 ---
 
 {{% alert color="primary" %}}
 
-Esta galeria demonstra relatórios PDF exportados pelo Aspose.Pdf for Reporting Services.
+Esta galeria demonstra relatórios em PDF exportados por Aspose.PDF para Reporting Services.
 
 {{% /alert %}}
 
-A maioria dos relatórios mostrados aqui vem do banco de dados Adventure Works. Adventure Works é um banco de dados de exemplo para o Microsoft SQL Server, disponível para download da Microsoft [aqui](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
+A maioria dos relatórios mostrados aqui vem do banco de dados Adventure Works. Adventure Works é um banco de dados de exemplo para Microsoft SQL Server, disponível para download na Microsoft [aqui](http://www.microsoft.com/downloads/details.aspx?familyid=E719ECF7-9F46-4312-AF89-6AD8702E4E6E&displaylang=en).
 
-## Vendas da Empresa
+## Vendas da empresa
 
-![Vendas da Empresa  relatório em PDF](sample-reports-gallery_1.png)
+![Relatório de vendas da empresa em PDF](sample-reports-gallery_1.png)
 
-## Resumo de Vendas do Empregado
+## Resumo de vendas de funcionários
 
-![Relatório de Resumo de Vendas do Empregado em PDF](sample-reports-gallery_2.png)
+![Relatório de resumo de vendas de funcionários em PDF](sample-reports-gallery_2.png)
 
 ## Catálogo de Produtos
 
-![Relatório de Catálogo de Produtos em PDF](sample-reports-gallery_3.png)
+![Relatório de catálogo de produtos em PDF](sample-reports-gallery_3.png)
 
-## Vendas da Linha de Produto
+## Vendas de linha de produtos
 
-![Relatório de Vendas da Linha de Produto em PDF](sample-reports-gallery_4.png)
+![Relatório de vendas da linha de produtos em PDF](sample-reports-gallery_4.png)
 
-## Detalhe do Pedido de Venda
+## Detalhe do pedido de vendas
 
-![Relatório de Detalhe do Pedido de Venda em PDF](sample-reports-gallery_5.png)
-
+![Relatório de detalhes do pedido de vendas em PDF](sample-reports-gallery_5.png)

--- a/pt/reportingservices/supported-file-formats/_index.md
+++ b/pt/reportingservices/supported-file-formats/_index.md
@@ -1,30 +1,29 @@
 ---
-title: Formatos de Arquivo Compatíveis
-linktitle: Formatos de Arquivo Compatíveis
+title: Formatos de arquivo suportados
+linktitle: Supported File Formats
 type: docs
 weight: 20
-url: /pt/reportingservices/supported-file-formats/
-description: Confira os formatos de arquivo compatíveis do Aspose.PDF for Reporting Services. Renderize seus relatórios SSRS para PDF, DOC, XLS e muito mais com facilidade.
-lastmod: "2026-06-19"
+url: /reportingservices/supported-file-formats/
+description: Confira os formatos de arquivo suportados pelo Aspose.PDF para Reporting Services. Renderize seus relatórios SSRS em PDF, DOC, XLS e muito mais com facilidade.
+lastmod: "2021-06-05"
 ---
 
-## Formatos de Carregamento Compatíveis
+## Formatos de carregamento suportados
 
-A tabela a seguir indica os formatos de arquivo que o Aspose.PDF for Reporting Services pode carregar.
+A tabela a seguir indica os formatos de arquivo que Aspose.PDF para Reporting Services pode carregar.
 
-|**Formato**|**Descrição**|
+|**Formatar**|**Descrição**|
 | :- | :- |
-|RDL|Linguagem de Definição de Relatório|
-|[HTML](https://docs.fileformat.com/web/html/)|Linguagem de Marcação de Hipertexto|
+|RDL|Linguagem de definição de relatório|
+|[HTML](https://docs.fileformat.com/web/html/)|Linguagem de marcação de hipertexto|
 
-## Formatos de Salvar Compatíveis
+## Formatos de salvamento suportados
 
-A tabela a seguir indica os formatos de arquivo nos quais o documento pode ser salvo usando o Aspose.PDF for Reporting Services. 
+A tabela a seguir indica os formatos de arquivo nos quais o documento pode ser salvo usando Aspose.PDF para Reporting Services. 
 
-|**Formato**|**Descrição**|
+|**Formatar**|**Descrição**|
 | :- | :- |
-|[PDF](https://docs.fileformat.com/pdf/)|Salva o documento no formato PDF|
+|[PDF](https://docs.fileformat.com/pdf/)|Salva o documento em formato PDF|
 |PDF/A |Salva o documento no formato PDF/A|
 |[XPS](https://docs.fileformat.com/page-description-language/xps/)|Salva o documento no formato XML Paper Specification|
-|EPUB|Salva o documento no formato de arquivo de e‑book|
-
+|EPUB|Salva o documento em formato de arquivo de e-book|

--- a/pt/reportingservices/technical-articles/_index.md
+++ b/pt/reportingservices/technical-articles/_index.md
@@ -1,14 +1,14 @@
 ---
 title: Artigos Técnicos
-linktitle: Artigos Técnicos
+linktitle: Technical Articles
 type: docs
 weight: 120
-url: /pt/reportingservices/technical-articles/
-description: Explore artigos técnicos para Aspose.PDF for Reporting Services. Obtenha insights aprofundados e dicas práticas para renderização eficaz de PDF.
-lastmod: "2026-06-19"
+url: /reportingservices/technical-articles/
+description: Explore artigos técnicos do Aspose.PDF para Reporting Services. Obtenha insights detalhados e dicas práticas para uma renderização eficaz de PDF.
+lastmod: "2021-06-05"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
-- [Migração do SQL Reporting Services para Aspose.Pdf for Reporting Services](/pdf/pt/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
-- [Integração do SQL Reporting Services com MS SharePoint](/pdf/pt/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/)
 
+- [Migração do SQL Reporting Services para Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/)
+- [Integração do SQL Reporting Services com MS SharePoint](/pdf/pt/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/)

--- a/pt/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/_index.md
@@ -1,14 +1,13 @@
 ---
-title: Migração do SQL Reporting Services para Aspose.Pdf for Reporting Services
-linktitle: Migração do SQL Reporting Services para Aspose.Pdf for Reporting Services
+title: Migração do SQL Reporting Services para Aspose.PDF para Reporting Services
+linktitle: Migration from SQL Reporting Services to Aspose.PDF for Reporting Services
 type: docs
 weight: 10
-url: /pt/reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/
+url: /reportingservices/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/
 description: Saiba como migrar do SQL Reporting Services para Aspose.PDF for Reporting Services. Atualize seu processo de geração de PDF.
-lastmod: "2026-06-19"
+lastmod: "2024-05-05"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
-- [Por que escolher Aspose.PDF for Reporting Services](/pdf/pt/reportingservices/why-choose-aspose-pdf-for-reporting-services/)
-
+- [Por que escolher Aspose.PDF para Reporting Services](/pdf/pt/reportingservices/why-choose-aspose-pdf-for-reporting-services/)

--- a/pt/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
+++ b/pt/reportingservices/technical-articles/migration-from-sql-reporting-services-to-aspose-pdf-for-reporting-services/why-choose-aspose-pdf-for-reporting-services/_index.md
@@ -1,36 +1,36 @@
 ---
-title: Por que escolher Aspose.Pdf para Reporting Services
-linktitle: Por que escolher Aspose.Pdf para Reporting Services
+title: Por que escolher Aspose.PDF para Reporting Services
+linktitle: Why choose Aspose.PDF for Reporting Services
 type: docs
 weight: 10
-url: /pt/reportingservices/why-choose-aspose-pdf-for-reporting-services/
-lastmod: "2026-06-19"
+url: /reportingservices/why-choose-aspose-pdf-for-reporting-services/
+lastmod: "2021-06-05"
 ---
 
-**Aspose.Pdf for Reporting Services** é uma solução .NET robusta que permite produzir relatórios PDF usando o Microsoft SQL Server 2016, 2017, 2019 e 2022 Reporting Services, e o Microsoft Power BI Report Server. Aspose.Pdf for Reporting Services não opera de forma independente, mas é uma extensão de renderização para o SQL Reporting Services. Não só suporta os elementos básicos de relatório, como tabelas, gráficos, imagens, Cabeçalhos/Rodapés, linhas etc., como também fornece a capacidade de adicionar propriedades personalizadas que lhe dão uma alavancagem extra sobre o SQL Reporting Services. Ao usar essas propriedades, você pode gerar Lista de Conteúdos, que não é suportada pelo Report Designer. Você pode ter Notas de Rodapé/Notas de Fim no documento PDF resultante, que nativamente não são suportadas pelo Report Builder. Outra funcionalidade interessante é ter Setas de Linha, que também não são suportadas pelo SQL Reporting Services, mas Aspose.Pdf for Reporting Services pode fornecer a capacidade de adicionar setas no início ou no final do elemento de linha. Além disso, Aspose.Pdf for Reporting Services fornece a funcionalidade de especificar o alinhamento de texto (Justify ou FullJustify) que não é suportado pelo Report Designer. Esses modos de texto tornam o documento resultante melhor formatado e de fácil leitura.
+**Aspose.PDF for Reporting Services** é uma solução .NET robusta que permite produzir relatórios em PDF usando o Microsoft SQL Server 2016, 2017, 2019 e 2022 Reporting Services e o Microsoft Power BI Report Server. Aspose.PDF for Reporting Services não opera de forma independente, mas é uma extensão de renderização para o SQL Reporting Services. Ele não apenas oferece suporte aos elementos básicos do relatório, como tabelas, gráficos, imagens, cabeçalhos/rodapés, linhas, etc., mas também fornece a capacidade de adicionar propriedades personalizadas, o que proporciona uma vantagem extra no SQL Reporting Services. Ao usar essas propriedades, você pode gerar uma Lista de Conteúdo que não é suportada pelo Designer de Relatórios. Você pode ter notas de rodapé/notas finais no documento PDF resultante que não são nativamente suportadas pelo Report Builder. Outro recurso interessante é ter setas de linha, que também não são suportadas pelo SQL Reporting Services, mas o Aspose.PDF para Reporting Services pode fornecer a capacidade de adicionar setas no início ou no final do elemento de linha. Além disso, Aspose.PDF para Reporting Services fornece a funcionalidade para especificar as informações de alinhamento de texto (Justify ou FullJustify) que não são suportadas pelo Report Designer. Esses modos de texto tornam o documento resultante melhor formatado e de fácil leitura.
 
-Juntamente com os recursos mencionados anteriormente, você também pode definir alguns outros parâmetros de configuração para os relatórios, para obter recursos que não são nativamente suportados pelo SQL Reporting Services. A seguir, uma breve descrição desses recursos oferecidos pelo Aspose.Pdf for Reporting Services
+Juntamente com os recursos mencionados anteriormente, você também pode definir outros parâmetros de configuração para os relatórios, para obter recursos que não são suportados nativamente pelo SQL Reporting Services. A seguir está um breve resumo desses recursos oferecidos pelo Aspose.PDF para Reporting Services
 
-## Configurações de Segurança
+## Configurações de segurança
 
-Às vezes você pode desejar exportar um documento PDF protegido com uma senha, com privilégios limitados de cópia de texto e impressão. Infelizmente, o Reporting Services não oferece suporte a essa possibilidade. No entanto, você ainda pode implementá-la usando o Aspose.Pdf for Reporting Services. Basta adicionar os parâmetros de segurança correspondentes ao relatório ou ao servidor de relatórios para obter um documento PDF seguro com privilégios limitados. Para mais informações, consulte a seção 'Security Setting'.
+Às vezes você pode querer exportar documentos PDF protegidos por senha, com privilégios limitados de cópia e impressão de texto. Infelizmente, o Reporting Services não oferece suporte a essa possibilidade. No entanto, você ainda pode implementá-lo usando Aspose.PDF para Reporting Services. Basta adicionar parâmetros de segurança correspondentes ao relatório ou servidor de relatório para obter um documento PDF seguro com privilégios limitados. Para obter mais informações, consulte a seção 'Configuração de segurança'.
 
-## Incorporação de Fonte Personalizada
+## Incorporação de fonte personalizada
 
-O designer do Reporting Services não suporta a incorporação de fonte para texto; com o Aspose.Pdf for Reporting Services você pode facilmente incorporar informações de fonte ao seu documento PDF. Para mais informações, consulte a seção 'IsFontEmbedded'.
+O designer do Reporting Services não dá suporte à fonte incorporada para texto; com Aspose.PDF for Reporting Services você pode incorporar facilmente informações de fonte em seu documento PDF. Para obter mais informações, consulte a seção 'IsFontEmbedded'.
 
 ## Metadados XMP
 
-O designer do Reporting Services não suporta a incorporação dos metadados XMP. Aspose.Pdf for Reporting Services fornece quatro parâmetros (CreationDate, ModifyDate, MetaDataDate e CreatorTool) para definir os metadados XMP correspondentes. Para mais informações, consulte a seção 'XMP Metadata'.
+O designer do Reporting Services não oferece suporte à incorporação de metadados XMP. Aspose.PDF para Reporting Services fornece quatro parâmetros (CreationDate, ModifyDate, MetaDataDate e CreatorTool) para definir os metadados XMP correspondentes. Para obter mais informações, consulte a seção 'Metadados XMP'.
 
 ## PDF/A
 
-Ao usar o SQL Server Reporting Services, você pode gerar o documento PDF apenas em formato simples, enquanto a geração de documentos PDF/A não é suportada. Mas o Aspose.Pdf for Reporting Services oferece o recurso de criar documentos compatíveis com PDF/A com a adição de um único parâmetro de configuração. Para mais informações, consulte a seção 'PDF Conformance'.
+Ao usar o SQL Server Reporting Services, você só pode gerar o documento PDF em formato simples, enquanto a geração de documentos PDF/A não é suportada. Mas Aspose.PDF for Reporting Services fornece o recurso para criar documentos compatíveis com PDF/A com a adição de um único parâmetro de configuração. Para obter mais informações, consulte a seção 'Conformidade com PDF'.
 
-## Ângulo de Rotação da Página
+## Ângulo de rotação da página
 
-Ao usar o Aspose.Pdf for Reporting Services, você pode definir o número de graus pelos quais a página deve ser girada no sentido horário ao ser exibida ou impressa. Para mais informações, consulte a seção 'Page Rotating Angle'.
+Ao usar Aspose.PDF para Reporting Services, você pode definir o número de graus em que a página deve ser girada no sentido horário quando exibida ou impressa. Para obter mais informações, consulte a seção 'Ângulo de rotação da página'.
 
-## Tamanho da Margem da Página
+## Tamanho da margem da página
 
-O designer do Reporting Services não suporta a definição do tamanho das margens da página. O Aspose.Pdf for Reporting Services, por outro lado, fornece quatro parâmetros para definir o tamanho correspondente da margem da página. Eles são PageMarginLeft, PageMarginRight, PageMarginTop e PageMarginBottom. Para mais informações, consulte a seção 'Page Margin Size'.
+O designer do Reporting Services não dá suporte à configuração do tamanho das margens da página. Aspose.PDF for Reporting Services, por outro lado, fornece quatro parâmetros para definir o tamanho da margem da página correspondente. Eles são PageMarginLeft, PageMarginRight, PageMarginTop e PageMarginBottom. Para obter mais informações, consulte a seção 'Tamanho da margem da página'.

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/_index.md
@@ -1,16 +1,15 @@
 ---
 title: Integração do SQL Reporting Services com MS SharePoint
-linktitle: Integração do SQL Reporting Services com MS SharePoint
+linktitle: SQL Reporting Services Integration with MS SharePoint
 type: docs
 weight: 20
-url: /pt/reportingservices/sql-reporting-services-integration-with-ms-sharepoint/
-lastmod: "2026-06-19"
+url: /reportingservices/sql-reporting-services-integration-with-ms-sharepoint/
+lastmod: "2021-06-05"
 ---
 
 **Esta seção inclui os seguintes tópicos:**
 
 - [Introdução](/pdf/pt/reportingservices/introduction/)
 - [Configurando o Reporting Services](/pdf/pt/reportingservices/setting-up-reporting-services/)
-- [Configurando o SharePoint no servidor Reporting Services](/pdf/pt/reportingservices/setting-up-sharepoint-on-reporting-services-server/)
-- [Configuração do Reporting Services e SharePoint](/pdf/pt/reportingservices/reporting-services-and-sharepoint-configuration/)
-
+- [Configurando o SharePoint no Reporting Services Server](/pdf/pt/reportingservices/setting-up-sharepoint-on-reporting-services-server/)
+- [Configuração do Reporting Services e do SharePoint](/pdf/pt/reportingservices/reporting-services-and-sharepoint-configuration/)

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/introduction/_index.md
@@ -1,15 +1,15 @@
 ---
 title: Introdução
-linktitle: Introdução
+linktitle: Introduction
 type: docs
 weight: 10
-url: /pt/reportingservices/introduction/
-lastmod: "2026-06-19"
+url: /reportingservices/introduction/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Aspose.PDF for Reporting Services tem sido muito notável para a geração de PDF através do SQL Reporting Services há muitos anos e fornece diversas opções de configuração e parametrização que não são suportadas por padrão no SQL Reporting Services. Recentemente recebemos algumas solicitações sobre a Integração do Aspose.PDF for Reporting Services com o SharePoint. Neste artigo, vamos nos concentrar no MS SharePoint 2010. Antes de prosseguirmos, assumimos que você já tem um SharePoint Farm configurado. Neste exemplo, usaremos o SharePoint Cloud completo. Contudo, as etapas são semelhantes para o SharePoint Foundation Server.
+Aspose.PDF para Reporting Services tem sido notável na geração de PDF por meio do SQL Reporting Services há muitos anos e fornece diversas opções de configuração e parametrização que não são suportadas por padrão no SQL Reporting Services. Recentemente, recebemos algumas solicitações relacionadas ao Aspose.PDF para integração do Reporting Services com o SharePoint. Neste artigo, vamos nos concentrar no MS SharePoint 2010. Antes de prosseguirmos, presumimos que você já tenha uma configuração do Farm do SharePoint. Neste exemplo, usaremos o SharePoint Cloud completo. No entanto, as etapas são semelhantes para o SharePoint Foundation Server.
 
 {{% /alert %}}
 
@@ -17,38 +17,37 @@ Aspose.PDF for Reporting Services tem sido muito notável para a geração de PD
 
 Antes de prosseguirmos, vamos dar uma olhada nos tópicos de referência que consultamos durante a preparação deste artigo.
 
-- [Visão geral da integração das tecnologias Reporting Services e SharePoint](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
-- [Topologias de Implantação para Reporting Services no Modo Integrado do SharePoint](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
-- [Configurando Reporting Services para Integração com SharePoint 2010](http://msdn.microsoft.com/en-us/library/bb326356.aspx)
+- [Overview of Reporting Services and SharePoint Technology Integration](http://msdn.microsoft.com/en-us/library/bb326358.aspx)
+- [Deployment Topologies for Reporting Services in SharePoint Integrated Mode](http://msdn.microsoft.com/en-us/library/bb510781.aspx)
+- [Configuring Reporting Services for SharePoint 2010 Integration](http://msdn.microsoft.com/en-us/library/bb326356.aspx)
 
 {{% /alert %}}
 
-## Configuração do Ambiente
+## Configuração do ambiente
 
-Nossa configuração consiste em 4 servidores. Inclui um Controlador de Domínio, um SQL Server, um Servidor SharePoint e um servidor para Reporting Services. Você pode optar por ter SharePoint e Reporting Services na mesma máquina, o que simplificará um pouco e eu apontarei algumas das diferenças.
+A configuração externa consiste em 4 servidores. Inclui um Controlador de Domínio, um SQL Server, um SharePoint Server e um servidor para Reporting Services. Você pode optar por ter o SharePoint e o Reporting Services na mesma caixa, o que simplificará um pouco isso e apontarei algumas das diferenças.
 
-## Pré-requisitos de Instalação
+## Pré-requisitos de instalação
 
 {{% alert color="primary" %}}
 
-O Add-In Reporting Services para SharePoint é um dos componentes principais para que a Integração funcione corretamente. O Add-In precisa ser instalado em qualquer um dos Web Front Ends (WFE) que estejam na sua fazenda SharePoint, juntamente com o servidor Central Admin. Uma das novas mudanças com SQL 2008 R2 & SharePoint 2010 é que o Add-In 2008 R2 agora é um pré-requisito para a Instalação do SharePoint. Isso significa que o Add-In RS será instalado quando você for instalar o SharePoint. Isso foi mostrado e destacado na figura abaixo. Isso realmente evita muitos problemas que vimos com SP 2007 e RS 2008 ao instalar o Add-In.
+O suplemento Reporting Services para SharePoint é um dos principais componentes para que a integração funcione corretamente. O suplemento precisa ser instalado em qualquer Web Front Ends (WFE) que esteja em seu farm do SharePoint junto com o servidor Central Admin. Uma das novas mudanças no SQL 2008 R2 e no SharePoint 2010 é que o complemento 2008 R2 agora é um pré-requisito para a instalação do SharePoint. Isso significa que o suplemento RS será instalado quando você instalar o SharePoint. Ele foi mostrado e destacado na figura abaixo. Na verdade, isso evita muitos problemas que vimos com o SP 2007 e o RS 2008 ao instalar o complemento.
 
-![todo:image_alt_text](introduction_1.png)
+![Introduction](introduction_1.png)
 
-**Image1 :- Complemento do Reporting Services para Share Point**
+**Imagem1: - Suplemento Reporting Services para Share Point**
 {{% /alert %}}
 
 ## Autenticação do SharePoint
 
-**Antes de mergulharmos nas partes de Integração do RS, uma coisa que quero destacar sobre o Farm do SharePoint é como você configura o Site. Mais especificamente, como você configura a autenticação para o site. Se será Classic ou Claims. Essa escolha é importante no início. Não acredito que você possa mudar essa opção depois de concluída. Se você puder mudá-la, não será um processo simples.**
+**Antes de entrarmos nas partes da Integração RS, uma coisa que quero destacar sobre o Farm do SharePoint é como você configura o Site. Mais especificamente como você configura a autenticação do site. Seja Clássico ou Claims. Essa escolha é importante no começo. Não acredito que você possa alterar essa opção depois de concluída. Se você pudesse mudar isso, não seria um processo simples.
 
-NOTE: ***Reporting Services 2008 R2 NÃO é compatível com Claims***
+NOTA: ***O Reporting Services 2008 R2 NÃO tem reconhecimento de reivindicações***
 
-Mesmo se você escolher seu site SharePoint para usar Claims, o Reporting Services em si não tem consciência de Claims. Dito isso, ele afeta como a autenticação funciona com o Reporting Services. Então, qual é a diferença do ponto de vista do Reporting Services? Tudo se resume a se você deseja encaminhar Credenciais de Usuário para a fonte de dados. Classic:- Pode usar Kerberos e encaminhar as credenciais do usuário para sua fonte de dados de back end (será necessário usar Kerberos para isso). Claims:- Um token Claims é usado e não um token do Windows. O RS sempre usará Trusted Authentication neste cenário e terá acesso apenas ao token SPUser. Você precisará armazenar suas credenciais dentro da sua fonte de dados.
+Mesmo que você escolha seu site do SharePoint para usar Declarações, o Reporting Services em si não reconhece as Declarações. Dito isto, isso afeta o modo como a autenticação funciona com o Reporting Services. Então, qual é a diferença da perspectiva do Reporting Services? A questão é se você deseja encaminhar as credenciais do usuário para a fonte de dados. Clássico: - Pode usar Kerberos e encaminhar as credenciais do usuário para sua fonte de dados back-end (será necessário usar Kerberos para isso). Reivindicações: - Um token de reivindicações é usado e não um token do Windows. O RS sempre usará autenticação confiável neste cenário e terá acesso apenas ao token SPUser. Você precisará armazenar suas credenciais em sua fonte de dados.
 
-Classic :- Pode usar Kerberos e encaminhar as credenciais do usuário para sua fonte de dados de back end (será necessário usar Kerberos para isso.
+Clássico: - Pode usar Kerberos e encaminhar as credenciais do usuário para sua fonte de dados de back-end (será necessário usar Kerberos para isso.
 
-Claims :- Um token Claims é usado e não um token do Windows. O RS sempre usará Trusted Authentication neste cenário e terá acesso apenas ao token SPUser. Você precisará armazenar suas credenciais dentro da sua fonte de dados.
+Reivindicações: - Um token de reivindicações é usado e não um token do Windows. O RS sempre usará autenticação confiável neste cenário e terá acesso apenas ao token SPUser. Você precisará armazenar suas credenciais em sua fonte de dados.
 
-Por enquanto, queremos apenas nos concentrar na configuração do RS. Neste ponto, o SharePoint está instalado na minha SharePoint Box e configurado com um site Classic Auth na porta 80. No servidor RS, acabei de instalar o Reporting Services e é só.
-
+Por enquanto, queremos apenas nos concentrar na configuração do RS. Neste ponto, o SharePoint está instalado em meu SharePoint Box e configurado com um Classic Auth Site na porta 80. No servidor RS, acabei de instalar o Reporting Services e pronto.

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/reporting-services-and-sharepoint-configuration/_index.md
@@ -1,44 +1,44 @@
 ---
-title: Configuração do Reporting Services e SharePoint
-linktitle: Configuração do Reporting Services e SharePoint
+title: Configuração do Reporting Services e do SharePoint
+linktitle: Reporting Services and SharePoint configuration
 type: docs
 weight: 40
-url: /pt/reportingservices/reporting-services-and-sharepoint-configuration/
-lastmod: "2026-06-19"
+url: /reportingservices/reporting-services-and-sharepoint-configuration/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Agora que o SharePoint está instalado e configurado no servidor RS e o RS está configurado através do Reporting Services Configuration Manager, podemos passar para a configuração no Central Admin. O RS 2008 R2 simplificou muito esse processo. Antes tínhamos um processo de 3 etapas que precisávamos executar para que isso funcionasse. Agora temos apenas uma etapa.
+Agora que o SharePoint está instalado e configurado no servidor RS e o RS está instalado e configurado por meio do Reporting Services Configuration Manager, podemos passar para a configuração no Central Admin. O RS 2008 R2 realmente simplificou esse processo. Costumávamos ter um processo de três etapas que você precisava executar para que isso funcionasse. Agora só temos um passo.
 
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Queremos acessar o site Central Administrator e, em seguida, entrar em Configurações Gerais do Aplicativo. Mais para baixo, veremos Reporting Services.
+Queremos ir para o site do Administrador Central e depois para Configurações Gerais do Aplicativo. Na parte inferior, veremos Reporting Services.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_1.png)
-**Image1**:- diálogo de configuração do SharePoint
+![Configuration-step1](reporting-services-and-sharepoint-configuration_1.png)
+**Imagem1**: - Caixa de diálogo de configuração do SharePoint
 
-Selecione "Reporting Services Integration" link. A tela a seguir será exibida.
+Selecione o link "Integração do Reporting Services". A tela a seguir será exibida.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_2.png)
-**Image2**:- Especifique as credenciais de integração do Reporting Services
+![Configuration-step2](reporting-services-and-sharepoint-configuration_2.png)
+**Imagem2**: - Especifique as credenciais de integração do Reporting Services
 
 {{% /alert %}}
 
-## URL do Serviço Web:
+## URL do serviço web:
 
-**Forneceremos a URL do Report Server que encontramos no Reporting Services Configuration Manager.**
+**Forneceremos a URL do Servidor de Relatórios que encontramos no Reporting Services Configuration Manager.**
 
-## Modo de Autenticação:
+## Modo de autenticação:
 
-**Também selecionaremos um modo de autenticação. O link MSDN a seguir detalha o que são esses modos.
-Visão geral de segurança para Reporting Services no modo SharePoint Integrated**
+**Também selecionaremos um modo de autenticação. O link do MSDN a seguir explica detalhadamente o que são.
+Visão geral de segurança do Reporting Services no modo integrado do SharePoint**
 
 {{% alert color="primary" %}}
 
-**Em resumo, se o seu site usa Claims Authentication, você sempre usará Trusted Authentication independentemente da escolha aqui. Se você quiser passar credenciais do Windows, deverá escolher Windows Authentication. Para Trusted Authentication, passaremos o token SPUser e não dependeremos da credencial do Windows. Você também desejará usar Trusted Authentication se configurou seus sites Classic Mode para NTLM e o RS está configurado para NTLM. Kerberos seria necessário para usar Windows Authentication e passar isso para sua fonte de dados.**
+**Resumindo, se o seu site estiver usando autenticação de declarações, você sempre usará autenticação confiável, independentemente do que escolher aqui. Se quiser passar credenciais do Windows, você deverá escolher Autenticação do Windows. Para autenticação confiável, passaremos o token SPUser e não dependeremos da credencial do Windows. Você também desejará usar a autenticação confiável se tiver configurado seus sites no modo clássico para NTLM e o RS estiver configurado para NTLM. O Kerberos seria necessário para usar a autenticação do Windows e transmiti-la para sua fonte de dados.**
 
 {{% /alert %}}
 
@@ -46,55 +46,54 @@ Visão geral de segurança para Reporting Services no modo SharePoint Integrated
 
 {{% alert color="primary" %}}
 
-**Isso lhe dá a opção de ativar o Reporting Services em todas as coleções de sites, ou você pode escolher em quais deseja ativá-lo. Isso realmente significa quais sites poderão usar o Reporting Services. Quando concluído, você deverá ver os seguintes resultados**
+**Isso oferece a opção de ativar o Reporting Services em todos os conjuntos de sites ou você pode escolher em quais deseja ativá-lo. Na verdade, isso significa quais sites poderão usar o Reporting Services. Quando terminar, você deverá ver os seguintes resultados **
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_3.png)
+![Configuration-step3](reporting-services-and-sharepoint-configuration_3.png)
 
-**Image3:**- Integração bem-sucedida do Reporting Services com o ambiente SharePoint
+**Imagem3:**- Integração bem-sucedida do Reporting Services com o ambiente SharePoint
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Voltando ao URL do ReportServer, devemos ver algo semelhante ao seguinte
+Voltando ao URL ReportServer, devemos ver algo semelhante ao seguinte
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_4.png)
+![Configuration-step4](reporting-services-and-sharepoint-configuration_4.png)
 
-**Image4:**- Reporting Services está conectado com sucesso ao ambiente SharePoint
+**Imagem4:**- Reporting Services foi conectado com sucesso ao ambiente SharePoint
 
-**NOTE:** ***Se o seu site SharePoint estiver configurado para SSL, ele não aparecerá nesta lista. É um problema conhecido e não significa que haja um problema. Seus relatórios ainda devem funcionar.***
+**NOTA:** ***Se o seu site SharePoint estiver configurado para SSL, ele não aparecerá nesta lista. É um problema conhecido e não significa que haja um problema. Seus relatórios ainda devem funcionar.***
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Agora que integrámos com sucesso ambos os produtos, estamos prontos para usar o Reporting Services no SharePoint 2010. Assim como na versão anterior, temos um recurso (ativado quando configuramos a Integração do Reporting Services) na "Site Collection Feature". Também a instalação adicionou 3 tipos de conteúdo ao nosso site. Na Imagem 7 podemos ver 2 desses tipos de conteúdo adicionados a uma biblioteca de documentos para criar um relatório personalizado usando o, como podemos ver na Image5 abaixo.
+Agora que integramos ambos os produtos com sucesso, estamos prontos para usar o Reporting Services no SharePoint 2010. Assim como na versão anterior, temos um recurso (ativado quando configuramos a Integração do Reporting Services) no “Site Collection Feature”. Além disso, a instalação adicionou 3 tipos de conteúdo para adicionar ao nosso site. Na Imagem 7 podemos ver 2 deles tipos de conteúdo adicionados em uma biblioteca de documentos para criar um relatório personalizado usando o, como podemos ver na Imagem 5 abaixo.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_5.png)
+![Configuration-step5](reporting-services-and-sharepoint-configuration_5.png)
 
-**Image5:**- Report Builder
+**Imagem5:**- Construtor de Relatórios
 
-O “Reporter Builder” é um controle ActiveX, portanto precisamos baixá-lo no servidor, como podemos ver na Imagem 6 abaixo.
+O “Reporter Builder” é um controle ActiveX então precisamos baixá-lo através do servidor, como podemos ver na Imagem 6 abaixo.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_6.png)
+![Configuration-step6](reporting-services-and-sharepoint-configuration_6.png)
 
-**Image6:**- Baixe e instale o Report Builder
+**Imagem6:**- Baixe e instale o Report Builder
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Depois que o processo de download for concluído, carregue o controle “Report Builder”. Agora estamos prontos para projetar nosso primeiro relatório, como mostrado na Image7 abaixo.
+Assim que o processo de download for concluído, carregue o controle “Report Builder”. Agora estamos prontos para desenhar nosso primeiro relatório, conforme mostrado na Imagem7 abaixo.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_7.png)
+![Configuration-step7](reporting-services-and-sharepoint-configuration_7.png)
 
-**Image7:**- Report Builder – Assistente de geração de novo relatório
+**Imagem7:**- Report Builder – Novo assistente de geração de relatórios
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-Depois de criar nosso relatório, podemos salvá‑lo na biblioteca de documentos criada para armazenar os relatórios no nosso SharePoint 2010. O outro tipo de conteúdo deve ser usado para criar conexões compartilhadas como fonte de dados e salvá‑las em uma biblioteca de documentos no SharePoint. Podemos criar uma biblioteca de documentos, adicionar esse tipo de conteúdo e, depois, ter nossas conexões disponíveis para alterar a fonte de dados dos relatórios.
+Após criar nosso relatório poderíamos salvá-lo na biblioteca de documentos criada para colocar os relatórios em nosso SharePoint 2010. O outro tipo de conteúdo deve ser usado para criar conexão compartilhada como fonte de dados e salvá-los em uma biblioteca de documentos no SharePoint. Podemos criar uma biblioteca de documentos, adicionar este tipo de conteúdo e depois termos nossas conexões disponíveis para alterar a fonte de dados dos relatórios.
 
-![todo:image_alt_text](reporting-services-and-sharepoint-configuration_8.png)
+![Configuration-step8](reporting-services-and-sharepoint-configuration_8.png)
 
-**Image8:**- Integração bem-sucedida do Aspose.PDF para Reporting Services com o MS SharePoint
+**Image8:**- Integração bem-sucedida de Aspose.PDF para Reporting Services com MS SharePoint
 {{% /alert %}}
-
 

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-reporting-services/_index.md
@@ -1,101 +1,100 @@
 ---
 title: Configurando o Reporting Services
-linktitle: Configurando o Reporting Services
+linktitle: Setting up Reporting Services
 type: docs
 weight: 20
-url: /pt/reportingservices/setting-up-reporting-services/
-lastmod: "2026-06-19"
+url: /reportingservices/setting-up-reporting-services/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Nossa primeira parada no Servidor Reporting Services é o Gerenciador de Configuração do Reporting Services.
+Nossa primeira parada no Reporting Services Server é o Reporting Services Configuration Manager.
 
 {{% /alert %}}
 
-## Conta de Serviço:
+## Conta de serviço:
 
-**Certifique‑se de entender qual conta de serviço você está usando para o Reporting Services. Se encontrarmos problemas, eles podem estar relacionados à conta de serviço que você está usando. O padrão é Network Service. Quando implantamos novas versões, sempre usamos Contas de Domínio, pois é onde provavelmente encontraremos problemas. Para esta instância do servidor, usamos uma Conta de Domínio chamada RSService.**
+**Certifique-se de entender qual conta de serviço você está usando para o Reporting Services. Se tivermos problemas, isso pode estar relacionado à conta de serviço que você está usando. O padrão é Serviço de Rede. Quando vamos implantar novas compilações, sempre usamos contas de domínio, porque é aí que provavelmente encontraremos problemas. Para esta instância de servidor, usamos uma conta de domínio chamada RSService.**
 
-![todo:image_alt_text](setting-up-reporting-services_1.png)
+![Set Up](setting-up-reporting-services_1.png)
 
-**Image1:- Configurando a conta de serviço**
+**Imagem1: – Configurando conta de serviço**
 
-## URL do Serviço Web:
+## URL do serviço web:
 
 {{% alert color="primary" %}}
 
-**Precisaremos configurar a URL do Serviço Web. Este é o diretório virtual (vdir) do ReportServer que hospeda os Serviços Web usados pelo Reporting Services, e com o qual o SharePoint se comunicará. A menos que você queira personalizar as propriedades do vdir (ou seja, SSL, portas, cabeçalhos de host, etc… ), você deve simplesmente clicar em Aplicar aqui e estará pronto para usar.**
-![todo:image_alt_text](setting-up-reporting-services_2.png)
+**Precisaremos configurar a URL do serviço Web. Este é o diretório virtual ReportServer (vdir) que hospeda os serviços Web Reporting Services usados ​​e com o qual o SharePoint se comunicará. A menos que você queira personalizar as propriedades do vdir (ou seja, SSL, portas, cabeçalhos de host, etc.), basta clicar em Aplicar aqui e pronto.**
+![Web Service URL](setting-up-reporting-services_2.png)
 
-**Image2:- Configurando a URL do Serviço Web Uma vez que a URL do Serviço Web tenha sido configurada, você deve ser capaz de ver os seguintes resultados**
+**Imagem2: - Configurando o URL do serviço da Web Depois que o URL do serviço da Web for configurado, você poderá ver os seguintes resultados **
 
-![todo:image_alt_text](setting-up-reporting-services_3.png)
+![Web Service URL Results](setting-up-reporting-services_3.png)
 
-**Image3:- Configuração bem-sucedida da URL do Serviço Web**
+**Imagem3: - Configuração bem-sucedida do URL do serviço Web**
 {{% /alert %}}
 
 ## Banco de dados:
 
-**Precisamos criar o Banco de Dados do Catálogo do Reporting Services. Isso pode ser colocado em qualquer mecanismo de banco de dados SQL 2008 ou SQL 2008 R2. O SQL11 também funcionaria bem, mas ainda está em BETA. Esta ação criará dois bancos de dados, ReportServer e ReportServerTempDB, por padrão.**
+**Precisamos criar o banco de dados do catálogo do Reporting Services. Isso pode ser colocado em qualquer Mecanismo de Banco de Dados SQL 2008 ou SQL 2008 R2. SQL11 também funcionaria bem, mas ainda está em BETA. Esta ação criará dois bancos de dados, ReportServer e ReportServerTempDB, por padrão.**
 
 {{% alert color="primary" %}}
-**A outra etapa importante nisso é garantir que você escolha SharePoint Integrated para o tipo de banco de dados. Uma vez feita essa escolha, ela não pode ser alterada.**
+**A outra etapa importante é certificar-se de escolher SharePoint Integrado para o tipo de banco de dados. Uma vez feita esta escolha, ela não poderá ser alterada.**
 
-![todo:image_alt_text](setting-up-reporting-services_4.png)
+![Creating Report Server Database](setting-up-reporting-services_4.png)
 
-**Image4:- Criando o banco de dados do servidor de relatórios**
+**Imagem4:- Criando banco de dados do servidor de relatório**
 
-![todo:image_alt_text](setting-up-reporting-services_5.png)
+![Setting up Database Server and Authentication Type](setting-up-reporting-services_5.png)
 
-**Image5:- Configurando o servidor de banco de dados e o tipo de autenticação**
+**Imagem5:- Configurando servidor de banco de dados e tipo de autenticação**
 
-![todo:image_alt_text](setting-up-reporting-services_6.png)
+![Setting up Database Name and Mode](setting-up-reporting-services_6.png)
 
-**Image6:- Configurando o nome do banco de dados e o Modo**
+**Imagem6: - Configurando nome e modo do banco de dados**
 {{% /alert %}}
 
-**Para as credenciais, é assim que o Report Server se comunicará com o SQL Server. Qualquer conta que você selecionar receberá certos direitos dentro do banco de dados Catalog, bem como alguns dos bancos de dados do sistema via RSExecRole. MSDB é um desses bancos de dados para uso de assinaturas, pois utilizamos o SQL Agent.**
+**Para as credenciais, é assim que o Report Server se comunicará com o SQL Server. Qualquer conta que você selecionar receberá determinados direitos no banco de dados do Catálogo, bem como em alguns bancos de dados do sistema por meio do RSExecRole. MSDB é um desses bancos de dados para uso de assinatura, pois usamos o SQL Agent.**
 
-![todo:image_alt_text](setting-up-reporting-services_7.png)
+![Setting up Report Server database credentials](setting-up-reporting-services_7.png)
 
-**Image7:- Configurando as credenciais do banco de dados do Report Server**
+**Imagem7: - Configurando credenciais do banco de dados do Report Server**
 
 {{% alert color="primary" %}}
 
-**Depois que as credenciais do banco de dados forem especificadas, deveríamos ser capazes de obter os resultados conforme especificado abaixo.**
+**Depois que as credenciais do banco de dados forem especificadas, poderemos obter os resultados conforme especificado abaixo.**
 
-![todo:image_alt_text](setting-up-reporting-services_8.png)
+![Report Server database creation progress](setting-up-reporting-services_8.png)
 
-**Image8:- Progresso da criação do banco de dados do Report Server**
+**Imagem8: - Progresso da criação do banco de dados do Servidor de Relatórios**
 
-![todo:image_alt_text](setting-up-reporting-services_9.png)
+![Report Server database completion summary](setting-up-reporting-services_9.png)
 
-**Image9:- Resumo da conclusão do banco de dados do Report Server**
+**Imagem9: - Resumo de conclusão do banco de dados do Report Server**
 {{% /alert %}}
 
-## URL do Report Manager:
+## URL do gerenciador de relatórios:
 
-**Podemos ignorar a URL do Report Manager, pois não é usada quando estamos no modo Integrado ao SharePoint. O SharePoint é nossa interface. O Report Manager não funciona.**
+**Podemos ignorar o URL do Report Manager, pois ele não é usado quando estamos no modo integrado do SharePoint. SharePoint é nosso front-end. O Gerenciador de relatórios não funciona.**
 
-## Chaves de Criptografia:
+## Chaves de criptografia:
 
 {{% alert color="primary" %}}
-**Faça backup das suas Chaves de Criptografia e certifique-se de saber onde as guarda. Se você se deparar com uma situação em que precise migrar o Banco de Dados ou restaurá‑lo, você precisará delas.**
+**Faça backup de suas chaves de criptografia e certifique-se de saber onde as guarda. Se você se encontrar em uma situação em que precise migrar o banco de dados ou restaurá-lo, você precisará deles.**
 
-![todo:image_alt_text](setting-up-reporting-services_10.png)
+![Report Server Encryption key backup](setting-up-reporting-services_10.png)
 
-**Image10:- backup da chave de criptografia do Report Server**
+**Imagem10: - Backup da chave de criptografia do servidor de relatório**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
-**Parabéns! Configuramos com sucesso o Reporting Services usando o Configuration Manager. Se você acessar a URL na aba Web Service URL, ela deve mostrar algo semelhante ao seguinte.**
+**Parabéns! Configuramos o Reporting Services com êxito usando o Configuration Manager. Se você navegar até o URL na guia URL do serviço Web, ele deverá mostrar algo semelhante ao seguinte.**
 
-![todo:image_alt_text](setting-up-reporting-services_11.png)
+![Report Server access after installation](setting-up-reporting-services_11.png)
 
-**Image11:- Acesso ao Report Server após a instalação**
+**Imagem11:- Reportar acesso ao servidor após instalação**
 
-**Motivo do erro: O SharePoint está instalado em nosso WFE e concluímos a configuração do Reporting Services. Neste exemplo, Reporting Services e SharePoint estão em máquinas diferentes. Se estivessem na mesma máquina, você não teria visto esse erro. Precisamos tecnicamente instalar o SharePoint na caixa RS. Isso significa que o IIS também será habilitado.**
+**Motivo do erro: o SharePoint está instalado em nosso WFE e concluímos a configuração do Reporting Services. Neste exemplo, o Reporting Services e o SharePoint estão em máquinas diferentes. Se eles estivessem na mesma máquina, você não teria visto esse erro. Tecnicamente, precisamos instalar o SharePoint no RS Box. Isso significa que o IIS também estará habilitado.**
 {{% /alert %}}
-
 

--- a/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
+++ b/pt/reportingservices/technical-articles/sql-reporting-services-integration-with-ms-sharepoint/setting-up-sharepoint-on-reporting-services-server/_index.md
@@ -1,50 +1,49 @@
 ---
-title: Configurando o SharePoint no servidor Reporting Services
-linktitle: Configurando o SharePoint no servidor Reporting Services
+title: Configurando o SharePoint no Reporting Services Server
+linktitle: Setting up SharePoint on Reporting Services Server
 type: docs
 weight: 30
-url: /pt/reportingservices/setting-up-sharepoint-on-reporting-services-server/
-lastmod: "2026-06-19"
+url: /reportingservices/setting-up-sharepoint-on-reporting-services-server/
+lastmod: "2021-06-05"
 ---
 
 {{% alert color="primary" %}}
 
-Agora precisamos executar etapas semelhantes às que fizemos para o SharePoint WFE. A primeira coisa é passar pela instalação dos pré-requisitos do uisites e, quando isso terminar, iniciar a configuração do SharePoint.
+Agora precisamos executar etapas semelhantes às que fizemos para o WFE do SharePoint. A primeira coisa é passar pela instalação dos pré-requisitos e, quando terminar, iniciar a configuração do SharePoint.
 
 {{% /alert %}}
 
-Para a configuração, escolho Farm de Servidores e uma instalação completa para corresponder à minha SharePoint Box, pois não quero uma instalação standalone para o SharePoint.
+Para a configuração, escolho Server Farm e uma instalação completa para corresponder ao meu SharePoint Box, pois não quero uma instalação autônoma para o SharePoint.
 
 ## Configuração do SharePoint
 
 {{% alert color="primary" %}}
 
-**No Assistente de Configuração do SharePoint, queremos conectar a uma farm existente.**
+**No Assistente de Configuração do SharePoint, queremos nos conectar a um farm existente.**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_1.png)
+![Assistente de configuração do SharePoint](setting-up-sharepoint-on-reporting-services-server_1.png)
 
-**Image1:- Assistente de configuração do SharePoint**
+**Imagem1:- Assistente de configuração do SharePoint**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**Em seguida, apontaremos para o banco de dados SharePoint_Config que nossa fazenda está usando. Se você não souber onde ele está, pode descobrir através do Central Admin em Configurações do Sistema -> Gerenciar Servidores nesta fazenda.**
+**Em seguida, apontaremos para o banco de dados SharePoint_Config que nosso farm está usando. Se você não sabe onde fica, você pode descobrir através do Central Admin em Configurações do Sistema -> Servidores Gerenciadores neste farm.**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_2.png)
+![Banco de dados de configuração do SharePoint](setting-up-sharepoint-on-reporting-services-server_2.png)
 
-**Image2:- Especificar configurações de banco de dados**
+**Imagem2:- Especifique as configurações do banco de dados**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_3.png)
+![Assistente de configuração do SharePoint](setting-up-sharepoint-on-reporting-services-server_3.png)
 
-**Image3:- Assistente de configuração do SharePoint**
+**Imagem3:- Assistente de configuração do SharePoint**
 {{% /alert %}}
 
 {{% alert color="primary" %}}
 
-**Uma vez que o assistente terminou, isso é tudo que precisamos fazer na caixa do Report Server por enquanto. Voltando para a URL do ReportServer, veremos outro erro, mas isso ocorre porque ainda não o configuramos através do Central Administrator.**
+**Depois que o assistente estiver concluído, isso é tudo que precisamos fazer na Caixa do Servidor de Relatórios por enquanto. Voltando à URL do ReportServer, veremos outro erro, mas é porque não o configuramos através do Administrador Central.**
 
-![todo:image_alt_text](setting-up-sharepoint-on-reporting-services-server_4.png)
+![Erro de configuração do SharePoint](setting-up-sharepoint-on-reporting-services-server_4.png)
 
-**Image4:- Erro do servidor de relatório**
+**Imagem4:- Reportar erro do servidor**
 {{% /alert %}}
-


### PR DESCRIPTION
Automated retranslation of `en/reportingservices` to Portuguese using the `translate-hugo-docs` workflow, with deterministic fallback for files the CLI could not restore.